### PR TITLE
docs: explain how to persist console state across container image rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **The documentation now says how to keep console state across container image rebuilds.** An application rebuilt from
+  source many times a day lost its dismissed advisor findings on every rebuild, because `.bootui/` lives in the image's
+  working directory. The answer already existed — `bootui.overrides-file` locates the runtime overrides file *and* the
+  dismissed-findings file BootUI resolves next to it, on all three stacks — but it was only findable as a one-line note
+  in a properties table, so it read as if it covered the Configuration panel alone. The Docker section of the
+  non-standard-runtimes page gains **Persisting console state across image rebuilds**: which two files exist and what
+  each holds, a compose snippet mounting them on a volume, the reason the key must come from the environment rather than
+  from `application.properties` (it is read before configuration files are loaded), and how to commit a baseline of
+  accepted findings into the image, including the read-only caveat and the `<vulnerability id>::<group:artifact>` key
+  shape. The advisors and activation pages link to it, and the property tables in `docs/PROPERTIES.md` and
+  `docs/SPECIFICATION.md` now state the key's dual role. The behavior is unchanged, and is now pinned by a test on each
+  adapter ([#930](https://github.com/jdubois/boot-ui/discussions/930)).
+
 - **`get_config` now tells an agent how its search actually matches, and what an empty result means.** Making the
   search relaxed-binding aware ([#939](https://github.com/jdubois/boot-ui/issues/939)) fixed the behavior but left the
   agent-facing description asserting it was "relaxed-binding aware" without saying what that does, and an agent reads

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducerDismissedRulesConfigTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/BootUiEngineProducerDismissedRulesConfigTest.java
@@ -1,0 +1,35 @@
+package io.github.jdubois.bootui.quarkus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Pins the {@code bootui.overrides-file} contract that {@link BootUiEngineProducer#dismissedRulesStore} shares with
+ * the Spring adapters: the advisor dismissed-findings file lives in the <em>same directory</em> as the configured
+ * overrides file, so relocating that key onto a mounted volume carries dismissals across container image rebuilds.
+ * Documented in {@code docs/setup/environments.md}; the Spring MVC and WebFlux halves are pinned by
+ * {@code BootUiAutoConfigurationTests} and {@code BootUiReactiveAutoConfigurationTests}.
+ */
+class BootUiEngineProducerDismissedRulesConfigTest {
+
+    private final BootUiEngineProducer producer = new BootUiEngineProducer();
+
+    @Test
+    void followsTheDirectoryOfTheConfiguredOverridesFile(@TempDir Path tempDir) {
+        Path stateDir = tempDir.resolve("var").resolve("bootui");
+        DismissedRulesStore store = producer.dismissedRulesStore(new StubConfig(Map.of(
+                "bootui.overrides-file",
+                stateDir.resolve("application-bootui.properties").toString())));
+
+        store.dismiss("RAPI-MAP-004");
+
+        assertThat(stateDir.resolve("boot-ui.yml")).exists();
+        assertThat(new DismissedRulesStore(stateDir.resolve("boot-ui.yml")).load())
+                .containsExactly("RAPI-MAP-004");
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiAutoConfigurationTests.java
@@ -28,6 +28,7 @@ import io.github.jdubois.bootui.autoconfigure.spring.SpringController;
 import io.github.jdubois.bootui.autoconfigure.sqltrace.SqlTraceController;
 import io.github.jdubois.bootui.autoconfigure.web.*;
 import io.github.jdubois.bootui.core.ValueExposure;
+import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
 import io.github.jdubois.bootui.engine.loggers.LoggersService;
 import io.github.jdubois.bootui.engine.restclienttrace.RestClientTraceRecorder;
 import io.github.jdubois.bootui.engine.telemetry.BootUiSpanExporter;
@@ -542,6 +543,23 @@ class BootUiAutoConfigurationTests {
                     context.getBean(ClaudeCodeController.class).dashboard();
                     assertThat(beanFactory.containsSingleton("bootUiClaudeCodeSessionStore"))
                             .isTrue();
+                });
+    }
+
+    @Test
+    void dismissedRulesStoreLivesNextToTheConfiguredOverridesFile(@TempDir Path tempDir) {
+        // Documented in docs/setup/environments.md: relocating bootui.overrides-file onto a mounted
+        // volume must move the advisor dismissals with it, or a container rebuild resets them.
+        Path stateDir = tempDir.resolve("var").resolve("bootui");
+        runner.withPropertyValues(
+                        "bootui.enabled=ON",
+                        "bootui.overrides-file=" + stateDir.resolve("application-bootui.properties"))
+                .run(context -> {
+                    context.getBean(DismissedRulesStore.class).dismiss("RAPI-MAP-004");
+
+                    assertThat(stateDir.resolve("boot-ui.yml")).exists();
+                    assertThat(new DismissedRulesStore(stateDir.resolve("boot-ui.yml")).load())
+                            .containsExactly("RAPI-MAP-004");
                 });
     }
 

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfigurationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiReactiveAutoConfigurationTests.java
@@ -37,6 +37,7 @@ import io.github.jdubois.bootui.autoconfigure.web.OverviewController;
 import io.github.jdubois.bootui.autoconfigure.web.PanelsController;
 import io.github.jdubois.bootui.autoconfigure.web.TracesController;
 import io.github.jdubois.bootui.core.dto.PanelsReport;
+import io.github.jdubois.bootui.engine.advisor.DismissedRulesStore;
 import io.github.jdubois.bootui.engine.exceptions.ExceptionStore;
 import io.github.jdubois.bootui.engine.jms.JmsActivityRecorder;
 import io.github.jdubois.bootui.engine.kafka.KafkaActivityRecorder;
@@ -45,6 +46,7 @@ import io.github.jdubois.bootui.engine.mcp.McpToolSchema;
 import io.github.jdubois.bootui.engine.panel.BootUiPanels;
 import io.github.jdubois.bootui.engine.restclienttrace.RestClientTraceRecorder;
 import io.github.jdubois.bootui.engine.sqltrace.SqlTraceRecorder;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +54,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.boot.actuate.web.exchanges.HttpExchangeRepository;
@@ -517,6 +520,23 @@ class BootUiReactiveAutoConfigurationTests {
                         .isArray()
                         .jsonPath("$.activeProfiles")
                         .isEmpty());
+    }
+
+    @Test
+    void dismissedRulesStoreLivesNextToTheConfiguredOverridesFile(@TempDir Path tempDir) {
+        // Same guarantee as the MVC adapter, documented in docs/setup/environments.md: relocating
+        // bootui.overrides-file onto a mounted volume must move the advisor dismissals with it.
+        Path stateDir = tempDir.resolve("var").resolve("bootui");
+        runner.withPropertyValues(
+                        "bootui.enabled=ON",
+                        "bootui.overrides-file=" + stateDir.resolve("application-bootui.properties"))
+                .run(context -> {
+                    context.getBean(DismissedRulesStore.class).dismiss("RAPI-MAP-004");
+
+                    assertThat(stateDir.resolve("boot-ui.yml")).exists();
+                    assertThat(new DismissedRulesStore(stateDir.resolve("boot-ui.yml")).load())
+                            .containsExactly("RAPI-MAP-004");
+                });
     }
 
     @Test

--- a/docs/PROPERTIES.md
+++ b/docs/PROPERTIES.md
@@ -100,7 +100,7 @@ settings" below.
 | `bootui.free-on-idle.enabled`    | `true`                                  | Release BootUI's live in-memory diagnostic buffers (captured SQL, ingested traces, and the request/security correlation windows) and pause recording into them after the console has been idle for `bootui.free-on-idle.timeout`, refilling them from live traffic once the console is used again. Dev-only (BootUI is inactive in production); the Exceptions and Log Tail buffers are always retained. Set to `false` to keep all buffers recording continuously. |
 | `bootui.free-on-idle.timeout`    | `5m`                                    | How long the console may go without any BootUI request (UI load, API poll, or stream open) before its live buffers are released. The timer resets on every BootUI request, so an open console never reclaims. Clamped to a minimum of one second. |
 | `bootui.read-only`               | `false`                                 | Disable every browser-triggered action while keeping read-only panel data visible.                                              |
-| `bootui.overrides-file`          | `.bootui/application-bootui.properties` | File used by the Configuration panel to persist local runtime overrides.                                                        |
+| `bootui.overrides-file`          | `.bootui/application-bootui.properties` | File used by the Configuration panel to persist local runtime overrides. BootUI resolves the advisor dismissed-findings file (`boot-ui.yml`) in the same directory. Set it from the environment, not from `application.properties`. |
 | `bootui.monitoring.exclude-self` | `true`                                  | Hide BootUI's own beans, mappings, loggers, metrics, traces, and related runtime data from monitoring panels.                   |
 
 ### Remote API authentication
@@ -253,7 +253,7 @@ Enforced identically on Spring and Quarkus (`PanelAccessFilter` / `QuarkusPanelA
 | -------------------------------- | --------------------------------------- | ---------------------------------------------------------------------- |
 | `bootui.panels.config.enabled`   | `true`                                  | Show the Configuration panel and allow its read APIs.                  |
 | `bootui.panels.config.read-only` | `false`                                 | Disable creating, updating, and deleting runtime property overrides.   |
-| `bootui.overrides-file`          | `.bootui/application-bootui.properties` | Local file where runtime overrides are persisted.                      |
+| `bootui.overrides-file`          | `.bootui/application-bootui.properties` | Local file where runtime overrides are persisted. Also locates `boot-ui.yml` (advisor dismissed findings), which BootUI resolves in the same directory. |
 | `bootui.expose-values`           | `MASKED`                                | Controls whether property values are masked, hidden, or fully exposed. |
 
 ### Loggers

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -2333,7 +2333,7 @@ Initial properties:
 | `bootui.startup.capacity`                    | `4096`                                  | Maximum startup steps retained by BootUI's auto-installed startup buffer.                         |
 | `bootui.enabled-profiles`                    | `dev,local`                             | Profiles that activate BootUI.                                                                    |
 | `bootui.disabled-profiles`                   | `prod,production`                       | Profiles that disable BootUI unless `bootui.enabled=ON`.                                          |
-| `bootui.overrides-file`                      | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides.                                       |
+| `bootui.overrides-file`                      | `.bootui/application-bootui.properties` | File used to persist local runtime configuration overrides; also locates `boot-ui.yml`.           |
 | `bootui.monitoring.exclude-self`             | `true`                                  | Hide BootUI's own runtime data from monitoring panels.                                            |
 | `bootui.cache.clear-enabled`                 | `true`                                  | Enable Cache clear actions after explicit browser confirmation.                            |
 | `bootui.http-sessions.max-sessions`          | `50`                                    | Maximum local embedded Tomcat HTTP sessions listed by the HTTP Sessions panel.                    |

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -26,6 +26,11 @@ Dismissals are applied server-side and persisted under the `dismissedRules` node
 (next to the runtime overrides file), so they survive restarts and stay consistent between each panel and the Overview
 dashboard. The file is developer-local and intended to be git-ignored. Rule identifiers are globally unique across
 advisors, so a dismissal always targets exactly one rule.
+
+`bootui.overrides-file` moves both files together: BootUI resolves `boot-ui.yml` in the same directory as the configured
+overrides file. That is what lets dismissals survive a container image rebuild — point the key at a mounted volume, or
+commit a baseline of accepted findings and copy it into the image. See
+[Persisting console state across image rebuilds](../setup/environments.md#persisting-console-state-across-image-rebuilds).
 :::
 
 ### Kotlin applications

--- a/docs/setup/activation.md
+++ b/docs/setup/activation.md
@@ -123,3 +123,9 @@ The Configuration panel can create, update, and delete local runtime overrides. 
 `.bootui/application-bootui.properties` by default, loaded at high precedence on the next startup, and never modify your
 application source configuration. Already-bound `@ConfigurationProperties` beans may keep their previous value until the
 app restarts; BootUI returns that warning with every override mutation.
+
+`bootui.overrides-file` changes where that file lives, and BootUI resolves the advisor dismissed-findings file
+(`boot-ui.yml`) in the same directory. Set it from the environment (`BOOTUI_OVERRIDES_FILE`) rather than from
+`application.properties`, which is loaded too late for the overrides file to be read at startup. Containers that rebuild
+their image from source can point it at a mounted volume so both files survive — see
+[Persisting console state across image rebuilds](environments.md#persisting-console-state-across-image-rebuilds).

--- a/docs/setup/environments.md
+++ b/docs/setup/environments.md
@@ -104,3 +104,69 @@ On Docker Desktop, use `-e BOOTUI_TRUSTED_PROXIES=192.168.65.0/24` instead.
 Scope `bootui.trusted-proxies` as narrowly as you can: for a user-defined Docker network, prefer that network's specific
 subnet over the broad `172.16.0.0/12`, and keep it limited to trusted local/dev networks. Reserve
 `bootui.allow-non-localhost=true` as a blunt last resort.
+
+### Persisting console state across image rebuilds
+
+BootUI keeps two developer-local files under `.bootui/` in the application's working directory:
+
+| File                            | Holds                                                                                    |
+| ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `application-bootui.properties` | Runtime overrides created from the Configuration panel, including the MCP Server toggle. |
+| `boot-ui.yml`                   | Advisor findings you dismissed, under a `dismissedRules:` node.                          |
+
+Inside a container that directory belongs to the image, so an image rebuilt from source starts from a clean slate:
+toggles are back to their configured value and dismissed findings reappear. `bootui.overrides-file` fixes both at once
+— BootUI resolves `boot-ui.yml` in the **same directory** as the configured overrides file, on Spring MVC, Spring
+WebFlux, and Quarkus alike. Point it at a mounted path:
+
+```yaml
+services:
+  app:
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      BOOTUI_TRUST_CONTAINER_GATEWAY: AUTO
+      BOOTUI_OVERRIDES_FILE: /var/bootui/application-bootui.properties
+    volumes:
+      - bootui-state:/var/bootui
+
+volumes:
+  bootui-state:
+```
+
+BootUI creates the directory if it does not exist. Both files now survive `docker compose up --build`.
+
+::: warning Set it from the environment, not from `application.properties`
+The overrides file is read by an `EnvironmentPostProcessor` that runs before your configuration files are loaded, so a
+`bootui.overrides-file` declared in `application.properties` would relocate the dismissed-findings file but not the
+overrides the console writes. Use the environment variable (or a `-D` system property) as shown above, so both files
+agree on one directory.
+:::
+
+Persisting state is not the only option, and for some settings it is not the best one. A value you want to hold across
+every environment belongs in configuration rather than in a file the console rewrites: `BOOTUI_MCP_ENABLED=ON` states
+the intent explicitly and cannot be toggled away by accident. The volume is the right tool for what a developer
+_discovers_ while using the console — dismissals above all.
+
+::: details Committing a baseline of accepted findings
+Because `boot-ui.yml` is a small, stable file, a team can commit it next to the application configuration and copy it
+into the image, so every rebuild starts from the same "these findings are known and accepted here" baseline:
+
+```yaml
+# .bootui/boot-ui.yml
+dismissedRules:
+  - RAPI-MAP-004
+  - HIB-FETCH-001
+```
+
+```dockerfile
+COPY .bootui/boot-ui.yml /var/bootui/boot-ui.yml
+```
+
+Two things to know. Dismissing from the console rewrites the whole file, so if you mount the baseline **read-only** the
+_Dismiss_ button fails; either keep the directory writable (a rebuild still restores the committed baseline) or set the
+advisor panels read-only with `bootui.panels.<id>.read-only=true`, which removes the dismiss and restore controls from
+the UI. And vulnerability dismissals are keyed `<vulnerability id>::<group:artifact>` rather than by a bare rule id —
+see [Dismissing a vulnerability](../features/advisors.md#dismissing-a-vulnerability).
+
+Any other top-level section in the file is preserved when BootUI rewrites it.
+:::


### PR DESCRIPTION
Answers [discussion #930](https://github.com/jdubois/boot-ui/discussions/930), where a team rebuilding its container image from source many times a day lost every dismissed advisor finding on each rebuild and could not find a way to keep them.

The capability already exists. `bootui.overrides-file` locates the Configuration panel's runtime overrides file **and** the advisor dismissed-findings file, which BootUI resolves in the same directory — identically on Spring MVC, Spring WebFlux, and Quarkus. Pointing that key at a mounted volume carries both files across rebuilds. It just wasn't findable: the only statement of the dual role was one line in a properties table, phrased as if the key served the Configuration panel alone, and the advisors page said dismissals live "next to the runtime overrides file" without saying that moving one moves the other.

### Documentation

`docs/setup/environments.md` gains **Persisting console state across image rebuilds** at the end of the Docker section, where the problem is actually met:

- the two files under `.bootui/` and what each holds
- a compose snippet mounting them on a named volume
- why the key must come from the environment rather than `application.properties` — the overrides file is read by an `EnvironmentPostProcessor` that runs before configuration files load, so an `application.properties` value would relocate the dismissals file but not the overrides one
- a note that config beats persistence for settings you want to hold everywhere (`BOOTUI_MCP_ENABLED=ON`), with the volume reserved for what a developer discovers in the console
- how to commit a baseline of accepted findings and copy it into the image, including the read-only-mount caveat and the `<vulnerability id>::<group:artifact>` key shape

The advisors and activation pages link to it, and `docs/PROPERTIES.md` and `docs/SPECIFICATION.md` state the key's dual role.

### Tests

No behavior changes. The directory-resolution guarantee the docs now promise was unpinned, so each adapter gets a test that relocates `bootui.overrides-file` into a temp directory, dismisses a rule, and asserts `boot-ui.yml` was written next to it:

- `BootUiAutoConfigurationTests` (Spring MVC)
- `BootUiReactiveAutoConfigurationTests` (Spring WebFlux)
- `BootUiEngineProducerDismissedRulesConfigTest` (Quarkus, new, via the existing `StubConfig`)

### Validation

- the three tests above, green
- `./mvnw spotless:apply` + `spotless:check` over the reactor, green

The VuePress site build could not run locally (`npm install` fails against the configured registry proxy with a 404 on an unrelated transitive package). The new markdown uses only container and fence syntax already present in `docs/`, and every link target and anchor was verified by hand.

Follow-up: I'll reply on the discussion once this lands. The third question there — a `bootui.advisors.dismissed` property — I'd rather not take: the dismissed set is a single read-write source, so a seeded id could never be restored from the console without introducing a seeded-vs-local distinction across the engine store, the JSON contract, and the UI on all three adapters, for an outcome the committed `boot-ui.yml` already delivers more reviewably.