### PR TITLE
Teach the vertical-PR agent the seams and gates it was missing

### DIFF
--- a/.github/agents/bootui-vertical-pr.agent.md
+++ b/.github/agents/bootui-vertical-pr.agent.md
@@ -1,6 +1,6 @@
 ---
 name: bootui-vertical-pr
-description: Plans, implements, validates, and prepares one focused merge-ready BootUI pull request across the shared engine, Spring MVC, Spring WebFlux, Quarkus, UI, tests, and docs
+description: Plans, implements, validates, and prepares one focused merge-ready BootUI pull request across the shared engine, Spring MVC, Spring WebFlux, Quarkus, the MCP and CLI surfaces, UI, tests, and docs
 ---
 
 You are the BootUI vertical-PR owner. Deliver one coherent change from investigation through a merge-ready pull request.
@@ -14,25 +14,62 @@ You are the BootUI vertical-PR owner. Deliver one coherent change from investiga
 4. For a complex or explicitly plan-first task, produce a concrete plan and wait when coordinator approval is requested. Otherwise continue autonomously after resolving only genuinely blocking ambiguity.
 5. Implement one focused vertical slice. Push semantics into the framework-neutral engine, keep bindings thin, and
    preserve Spring MVC, Spring WebFlux, and Quarkus parity where the capability exists.
-6. Update all directly coupled surfaces: DTOs, engine, adapters, availability, UI, tests, conformance, docs, and advisor check documentation as applicable.
-7. Run the smallest targeted tests first, then required three-stack conformance, frontend, browser, formatting, or
-   release checks for the changed surface. For UI/E2E work, validate frontend formatting plus both Spring and Quarkus E2E
-   formatting; bootstrap Playwright with the repository's existing npm commands. Fix failures rather than weakening
-   assertions.
+6. Update all directly coupled surfaces: DTOs, engine, adapters, availability, UI, tests, conformance, docs, and advisor
+   check documentation as applicable. Watch for fan-out the edited file will not reveal:
+   - A panel or diagnostic that reaches agents also spans `McpToolCatalog` and its descriptions, every adapter's MCP
+     binding, the `CliCommandPaths` entry with a regenerated `bootui-cli/src/main/resources/bootui-tools.json`, and
+     `skills/bootui/SKILL.md`.
+   - A new Spring autoconfiguration belongs in `AutoConfiguration.imports`, and a new bootstrap
+     `EnvironmentPostProcessor` in `META-INF/spring.factories`. Neither is component-scanned.
+   - A panel support change updates `QuarkusPanelAvailability` and `docs/QUARKUS-SUPPORT.md`, distinguishing
+     unavailable, not-yet-supported, and not-applicable honestly.
+   - A renamed route path keeps a redirect from the previous path in `routes.js`.
+   - A new page under `docs/` needs a `docs/.vuepress/sidebar.js` entry, or it is unreachable on the published site.
+     Verify with `npm install && npm run docs:build`.
+   - Feature screenshots stay 1600x900 WebP at quality 80, captured after resetting both the window scroll and the
+     `.bootui-workspace` scroll.
+   - A workflow edit updates `.github/scripts/check-action-references.sh` or `check-release-integrity.sh` in the same
+     change; both gate every build.
+
+   Add a `CHANGELOG.md` entry under `[Unreleased]` for every user-visible change, in the existing Keep a Changelog style
+   with the issue link.
+7. Run the smallest targeted tests first, then reproduce the CI gates that the change actually touches:
+   - Formatting: `./mvnw -B -ntp spotless:check`, plus `npm run format:check` in `bootui-ui/src/main/frontend`,
+     `bootui-spring-sample-app/e2e`, and `bootui-quarkus-sample-app/e2e`.
+   - The full reactor as the Java 17 baseline job runs it: `./mvnw -B -ntp -Pcoverage clean install`. Coverage is not
+     optional there; its gates protect `SecretMasker`, `BootUiPathNormalizer`, the engine safety package, Spring and
+     Quarkus exposure/MCP policy, and the shared frontend path, state, and accessible-component primitives.
+   - The affected Spring MVC, Spring WebFlux, and Quarkus conformance runners after any cross-stack contract change.
+   - All four browser suites for UI, browser-facing API, or sample-app changes. Bootstrap each E2E directory with
+     `npm ci` and `npx playwright install --with-deps chromium`, then run `npm test`, `npm run test:webflux`, and
+     `npm run test:custom-path` in `bootui-spring-sample-app/e2e`, and `npm test` in `bootui-quarkus-sample-app/e2e`.
+
+   Fix failures rather than weakening assertions. Isolate Maven from other worktrees with `-Dmaven.repo.local=.m2`,
+   using the same repository for every invocation, and remember that a JDK outside 17, 21, and 25 silently skips Quarkus
+   augmentation, so a green local run there proves less than it appears to.
 8. Review the final diff for unrelated changes, framework leaks, unbounded work, optional-dependency classloading, secret exposure, safety-policy drift, and stale documentation.
 9. Unless the task is explicitly plan-only, finish by committing and opening or updating one non-draft pull request.
-   Follow repository formatting rules and the pull request template before publishing.
+   Follow repository formatting rules and the pull request template before publishing, and attach before/after
+   screenshots for changes that alter the Vue UI.
 10. After amending, rebasing, or force-pushing, verify the remote head SHA, commit count/trailers, PR diff, and required
     checks all belong to the replacement head. Never report completion from local state or an older CI run.
 
 ## Non-negotiable review checklist
 
-- Shared modules remain framework- and JSON-library-free.
+- Shared modules remain framework- and JSON-library-free, and core DTOs serialize byte-identically under Spring's
+  Jackson 3 and Quarkus' Jackson 2 on the Java 17 baseline compiled with `-parameters`.
 - Public JSON remains stable or changes deliberately with tests and documentation.
 - Property values are masked; network calls and mutations remain explicit and bounded.
 - Localhost, Host, CSRF, and panel read-only policy remain aligned across Spring MVC, Spring WebFlux, and Quarkus.
+- Production stays dark: Quarkus wires no data-bearing endpoint or CDI service in `LaunchMode.NORMAL`, the Spring shell
+  guard keeps `/bootui` a plain 404 while BootUI is off, and activation stays fail-closed through `bootui.enabled` and
+  the enabled/disabled profile lists.
 - Optional integrations are safe when dependencies are absent.
+- The CLI stays a mechanical projection of `McpToolCatalog`, with the manifest regenerated rather than hand-edited, and
+  `bootui-client` stays dependency-free. CLI and client command names, exit codes, and JSON output are public contract.
 - UI behavior is accessible in light and dark themes and does not surprise users.
+- Versions change only through `release.yml`; sample, integration-test, coverage, and conformance modules keep
+  `maven.deploy.skip=true` and stay outside the publication reactor.
 - Tests prove the requirement rather than merely exercising the changed lines.
 
 ## Handoff


### PR DESCRIPTION
## What does this PR do?

Audits `.github/agents/bootui-vertical-pr.agent.md` against the repository instructions, all eight path-scoped instruction files, `CONTRIBUTING.md`, and `build.yml`, and folds the gaps back into the agent.

## Why is this change needed?

The agent described a vertical slice as engine, adapters, UI, tests, and docs — the shape the repository had before the CLI, `bootui-client`, the MCP catalog, and the agent skill became part of every diagnostic. Path-scoped instructions only load once a file is already open, so the agent had no way to learn it must go there. It also stopped short of what CI runs, so a slice could look green locally and fail on the baseline job.

Nothing in the file was factually wrong; it was incomplete. Three groups of additions:

**Coupled surfaces the edited file never reveals**

- `McpToolCatalog` and its descriptions, every adapter's MCP binding, the `CliCommandPaths` entry with a regenerated `bootui-tools.json`, and `skills/bootui/SKILL.md`
- `AutoConfiguration.imports` and `META-INF/spring.factories` registration, neither of which is component-scanned
- `QuarkusPanelAvailability` with `docs/QUARKUS-SUPPORT.md`
- A redirect from the previous path when a route is renamed
- A `docs/.vuepress/sidebar.js` entry, without which a new page is unreachable on the published site
- The 1600x900 WebP feature-screenshot spec
- `check-action-references.sh` / `check-release-integrity.sh` in the same change as a workflow edit
- A `CHANGELOG.md` entry under `[Unreleased]` for user-visible changes

**Validation that mirrors `build.yml` instead of paraphrasing it**

- Coverage is part of the baseline reactor build (`-Pcoverage clean install`), not an optional profile
- All four Playwright suites are named, including the `test:custom-path` one that was absent everywhere
- Maven stays isolated per worktree with `-Dmaven.repo.local=.m2`, and a JDK outside 17, 21, and 25 silently skips Quarkus augmentation

**Invariants that had no line at all**

- Production stays dark: no Quarkus data endpoint or CDI service in `LaunchMode.NORMAL`, Spring's shell guard keeps `/bootui` a plain 404 while BootUI is off, activation stays fail-closed
- Core DTOs serialize byte-identically under Jackson 3 and Jackson 2 on the Java 17 `-parameters` baseline
- Versions move only through `release.yml`; sample, integration-test, coverage, and conformance modules stay outside the publication reactor

## How was it tested?

Documentation-only change to a single agent instruction file. No module, workflow, or product surface is touched, so the reactor build, conformance runners, and browser suites are unaffected.

- [x] Verified every claim added to the file against its source (`build.yml` job steps, `CONTRIBUTING.md` commands, the eight `.github/instructions/` files, the E2E `package.json` scripts, the PR template)
- [x] Confirmed no formatter covers `.github/**/*.md`: Spotless is Java/XML only and the root `package.json` has no prettier script, so there is no format check to run
- [x] Confirmed instruction-file-only commits do not carry a `CHANGELOG.md` entry, matching `ab0f4eda4`

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes — not applicable, no behaviour change
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed