### PR TITLE
Fix JVM Tuning budget validation and rendered memory quantities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **JVM Tuning no longer approves known-invalid tiny heap requests or wraps large memory observations to zero.**
+  The shared calculator checks both fixed and three-decimal percentage requests against HotSpot's generic 2 MiB
+  maximum-heap lower bound, without increasing an exhausted budget. Default footprint arithmetic and MiB formatting
+  avoid overflow, detected budgets round down to whole MiB consistently with generated Kubernetes limits, and limit
+  and usage reuse one cgroup sample. Sizing notes distinguish requested settings from effective heap alignment and
+  JVM-visible percentage denominators; model validity is not a startup or production-sizing guarantee. The full
+  source-backed audit records retained policies and deferred metaspace/probe work
+  ([#955](https://github.com/jdubois/boot-ui/issues/955)).
+
 - **`ARCH-SPRING-019` no longer reports every Spring Modulith event listener.** `@ApplicationModuleListener` composes
   `@Async`, `@Transactional(propagation = REQUIRES_NEW)` and `@TransactionalEventListener`, so a Modulith application
   collected one MEDIUM finding per cross-module listener — telling it that the caller's transaction does not propagate,

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryCalculator.java
@@ -86,6 +86,8 @@ final class MemoryCalculator {
     static final int MAX_HEAD_ROOM_PERCENT = 30;
     static final long MIN_TOTAL_MEMORY_BYTES = 128L * MEBIBYTE;
     static final long MAX_TOTAL_MEMORY_BYTES = 64L * 1024 * MEBIBYTE;
+    static final long MIN_REQUESTED_HEAP_BYTES = 2L * MEBIBYTE;
+    private static final long PERCENTAGE_THOUSANDTHS_PER_WHOLE = 100_000L;
 
     static int defaultThreadCount(int liveThreadCount) {
         return Math.max(liveThreadCount, DEFAULT_THREAD_COUNT_FLOOR);
@@ -117,7 +119,7 @@ final class MemoryCalculator {
      * @param headRoomPercent      percentage of total memory to leave unallocated
      * @param liveThreadCount      current live thread count (reported for UI context)
      * @param liveLoadedClassCount currently loaded classes (reported for UI context)
-     * @return calculation DTO; if inputs leave no room for any heap, the
+     * @return calculation DTO; if either generated heap request falls below HotSpot's generic lower bound, the
      * returned DTO has {@code valid = false} and a non-null
      * {@code error} — no exception is thrown so the panel can keep
      * polling without an HTTP error
@@ -200,13 +202,16 @@ final class MemoryCalculator {
         long stackBytesPerThread = STACK_BYTES_PER_THREAD;
         long stackBytesTotal = stackBytesPerThread * (long) clampedThreads;
         long fixedRegionsBytes = directMemoryBytes + metaspaceBytes + CODE_CACHE_BYTES + stackBytesTotal;
-        long headRoomBytes = (long) ((clampedHeadRoom / 100.0) * clampedTotal);
+        long headRoomBytes = clampedTotal * clampedHeadRoom / 100;
         long heapBytes = clampedTotal - headRoomBytes - fixedRegionsBytes;
 
-        if (heapBytes < MEBIBYTE) {
+        if (bytesToMiBFloor(heapBytes) * MEBIBYTE < MIN_REQUESTED_HEAP_BYTES
+                || heapPercentageThousandths(heapBytes, clampedTotal) * clampedTotal
+                        < MIN_REQUESTED_HEAP_BYTES * PERCENTAGE_THOUSANDTHS_PER_WHOLE) {
             String message = String.format(
-                    "No room for a renderable heap: fixed regions (%d MiB) + headroom (%d MiB) "
-                            + "leave less than 1 MiB from the %d MiB total. "
+                    "Insufficient heap budget: fixed regions (%d MiB) + headroom (%d MiB) "
+                            + "leave too little from the %d MiB total to request at least 2 MiB "
+                            + "in both fixed and three-decimal percentage options. "
                             + "Try a larger total memory, fewer threads, or lower headroom.",
                     bytesToMiBCeil(fixedRegionsBytes), bytesToMiBCeil(headRoomBytes), bytesToMiBCeil(clampedTotal));
             return new MemoryCalculationDto(
@@ -264,22 +269,25 @@ final class MemoryCalculator {
      */
     long defaultTotalMemoryBytes(
             long heapCommittedBytes, long nonHeapCommittedBytes, int threadCount, int loadedClasses) {
+        long min = 384L * MEBIBYTE;
+        long max = 2048L * MEBIBYTE;
         int safeThreads = Math.max(threadCount, DEFAULT_THREAD_COUNT_FLOOR);
         long fixed = DIRECT_MEMORY_BYTES
-                + computeMetaspaceBytes(loadedClasses)
+                + computeMetaspaceBytes(Math.max(loadedClasses, 0))
                 + CODE_CACHE_BYTES
                 + STACK_BYTES_PER_THREAD * (long) safeThreads;
         long floor = fixed + 128L * MEBIBYTE;
 
-        long useful = heapCommittedBytes + Math.max(0, nonHeapCommittedBytes);
+        long useful = clamp(heapCommittedBytes, 0, max) + clamp(nonHeapCommittedBytes, 0, max);
         useful = useful + (useful / 2); // ×1.5 footprint
 
-        long picked = Math.max(floor, useful);
-        picked = roundUpTo(picked, 64L * MEBIBYTE);
+        long picked = clamp(Math.max(floor, useful), min, max);
+        return roundUpTo(picked, 64L * MEBIBYTE);
+    }
 
-        long min = 384L * MEBIBYTE;
-        long max = 2048L * MEBIBYTE;
-        return clamp(picked, min, max);
+    static long heapPercentageThousandths(long heapBytes, long totalMemoryBytes) {
+        // Calculator budgets are capped at 64 GiB, so both this product and the reverse comparison fit in long.
+        return heapBytes * PERCENTAGE_THOUSANDTHS_PER_WHOLE / totalMemoryBytes;
     }
 
     private long computeMetaspaceBytes(int loadedClasses) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizer.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizer.java
@@ -3,7 +3,6 @@ package io.github.jdubois.bootui.engine.memory;
 import io.github.jdubois.bootui.core.dto.KubernetesMemoryRecommendationDto;
 import io.github.jdubois.bootui.core.dto.MemoryCalculationDto;
 import io.github.jdubois.bootui.spi.HealthProbeManifest;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -115,9 +114,8 @@ final class MemoryKubernetesSizer {
         if (!calculation.valid() || calculation.totalMemoryBytes() <= 0) {
             return 0;
         }
-        double calculated = calculation.heapBytes() * 100.0 / calculation.totalMemoryBytes();
-        double floored = Math.floor(calculated * 1000.0) / 1000.0;
-        return floored > 0 ? floored : calculated;
+        return MemoryCalculator.heapPercentageThousandths(calculation.heapBytes(), calculation.totalMemoryBytes())
+                / 1000.0;
     }
 
     private static long estimateCurrentSnapshotBytes(
@@ -178,7 +176,11 @@ final class MemoryKubernetesSizer {
                     "Health probes use the framework's default paths and the named container port \"http\"; verify both against custom application or management-server settings.");
         }
         warnings.add(
-                "JAVA_TOOL_OPTIONS uses MaxRAMPercentage, MinRAMPercentage, and InitialRAMPercentage so HotSpot follows the container limit across small and regular heaps. Metaspace, code cache, and thread-stack caps remain fixed.");
+                "JAVA_TOOL_OPTIONS uses MaxRAMPercentage, MinRAMPercentage, and InitialRAMPercentage against JVM-visible RAM, not the memory request. Verify container support and the generated limit; existing -Xmx, -Xms, or RAM-sizing overrides can change the result.");
+        warnings.add(
+                "Generated heap values are requests: collector and platform alignment can raise the effective heap. Model validity checks generic flag constraints, not JVM startup or workload sufficiency; verify effective settings on the target JVM.");
+        warnings.add(
+                "Fixed metaspace, code-cache, and stack settings do not cap total process memory. Unmodeled native allocations and container charges can exceed selected headroom; validate after warmup and under representative peak load.");
         warnings.add(
                 "Direct memory is modeled at "
                         + formatMi(calculation.directMemoryBytes())
@@ -186,9 +188,10 @@ final class MemoryKubernetesSizer {
         if (detectedContainerLimitBytes != null && detectedContainerLimitBytes.longValue() != limitBytes) {
             warnings.add("Detected cgroup memory limit is "
                     + formatMi(detectedContainerLimitBytes)
+                    + " (rounded up for display)"
                     + ", which differs from the calculator total "
                     + formatMi(limitBytes)
-                    + "; update the total memory input if you want the manifest to match the live container limit.");
+                    + "; review the selected whole-MiB limit before deployment.");
         }
         if (!nativeMemoryTrackingEnabled) {
             warnings.add("Native Memory Tracking is not enabled; this model cannot attribute all native JVM memory.");
@@ -305,11 +308,8 @@ final class MemoryKubernetesSizer {
     }
 
     static String formatMi(long bytes) {
-        long mebibytes = Math.max(0, (bytes + MB - 1) / MB);
+        long nonNegativeBytes = nonNegative(bytes);
+        long mebibytes = nonNegativeBytes / MB + (nonNegativeBytes % MB == 0 ? 0 : 1);
         return mebibytes + "Mi";
-    }
-
-    private static String formatPercentage(double percentage) {
-        return BigDecimal.valueOf(percentage).stripTrailingZeros().toPlainString();
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryReportProvider.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryReportProvider.java
@@ -74,8 +74,9 @@ public class MemoryReportProvider {
 
         int liveThreads = threadBean.getThreadCount();
         int liveClasses = classBean.getLoadedClassCount();
-        OptionalLong detectedContainerMemoryLimit = containerMemoryLimitDetector.detectLimit();
-        OptionalLong detectedContainerCurrentUsage = containerMemoryLimitDetector.detectCurrentUsage();
+        ContainerMemoryLimitDetector.CgroupMemorySample containerMemory = containerMemoryLimitDetector.detect();
+        OptionalLong detectedContainerMemoryLimit = containerMemory.limit();
+        OptionalLong detectedContainerCurrentUsage = containerMemory.current();
         long directBufferMemoryUsedBytes = directBufferMemoryUsedBytes();
         boolean resolvedVirtualThreadsEnabled = resolveVirtualThreadsEnabled();
         boolean resolvedKubernetesBurstableEnabled = kubernetesBurstableEnabled != null && kubernetesBurstableEnabled;
@@ -84,8 +85,10 @@ public class MemoryReportProvider {
 
         long resolvedTotalBytes = totalMemoryMb != null
                 ? totalMemoryBytes(totalMemoryMb)
-                : detectedContainerMemoryLimit.orElseGet(() -> calculator.defaultTotalMemoryBytes(
-                        heapUsage.getCommitted(), nonHeapUsage.getCommitted(), defaultThreadCount, liveClasses));
+                : detectedContainerMemoryLimit.isPresent()
+                        ? totalMemoryBytes(detectedContainerMemoryLimit.getAsLong() / MEBIBYTE)
+                        : calculator.defaultTotalMemoryBytes(
+                                heapUsage.getCommitted(), nonHeapUsage.getCommitted(), defaultThreadCount, liveClasses);
         int resolvedThreads = threadCount != null ? threadCount : defaultThreadCount;
         int resolvedHeadRoom =
                 headRoomPercent != null ? headRoomPercent : MemoryKubernetesSizer.DEFAULT_HEADROOM_PERCENT;

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCalculatorTests.java
@@ -101,7 +101,7 @@ class MemoryCalculatorTests {
             {1024 * MB, 250, 5_000, 0, 1, 5_000},
             {2048 * MB, 250, 5_000, 10, 40, 5_000},
             {64L * 1024 * MB, 10_000, 200_000, 30, 5_000, 200_000},
-            {518 * MB, 250, 0, 0, 10, 0}, // boundary: smallest total that still renders a 1 MiB heap
+            {520 * MB, 250, 0, 0, 10, 0},
         };
 
         for (long[] input : representativeInputs) {
@@ -196,20 +196,57 @@ class MemoryCalculatorTests {
     }
 
     @Test
-    void rejectsAPlanThatCannotRenderAtLeastOneMebibyteOfHeap() {
+    void rejectsKnownInvalidHeapRequestsIncludingPercentageTruncation() {
         MemoryCalculationDto invalid = calculator.calculate(517 * MB, 250, 0, 0, 10, 0);
-        MemoryCalculationDto boundary = calculator.calculate(518 * MB, 250, 0, 0, 10, 0);
+        MemoryCalculationDto oneMebibyte = calculator.calculate(518 * MB, 250, 0, 0, 10, 0);
+        MemoryCalculationDto truncatedPercentage = calculator.calculate(519 * MB, 250, 0, 0, 10, 0);
+        MemoryCalculationDto boundary = calculator.calculate(520 * MB, 250, 0, 0, 10, 0);
 
         assertThat(invalid.valid()).isFalse();
-        assertThat(invalid.error()).contains("less than 1 MiB");
+        assertThat(invalid.error()).contains("2 MiB", "percentage");
         assertThat(invalid.heapBytes()).isZero();
         assertThat(invalid.jvmOptions()).isEmpty();
+        assertThat(oneMebibyte.valid()).isFalse();
+        // A fixed 2 MiB request reaches HotSpot's generic bound, but 0.385% of 519 MiB does not.
+        assertThat(truncatedPercentage.valid()).isFalse();
+        assertThat(truncatedPercentage.jvmOptions()).isEmpty();
+        assertThat(calculator.buildKubernetesJvmOptions(truncatedPercentage, 0.385, 0.385))
+                .isEmpty();
 
         assertThat(boundary.valid()).isTrue();
-        assertThat(boundary.heapBytes()).isEqualTo(MB);
-        // Exact token equality (not mere substring containment) so a missing separator between
-        // "-Xms1m" and "-Xmx1m" (e.g. a concatenated "-Xms1m-Xmx1m") fails this assertion.
-        assertThat(List.of(boundary.jvmOptions().split(" "))).contains("-Xms1m", "-Xmx1m");
+        assertThat(boundary.heapBytes()).isEqualTo(3 * MB);
+        assertThat(List.of(boundary.jvmOptions().split(" "))).contains("-Xms3m", "-Xmx3m");
+    }
+
+    @Test
+    void acceptsExactGenericBoundWhenBothRepresentationsReachItWithoutInflation() {
+        MemoryCalculationDto result = calculator.calculate(400 * MB, 131, 0, 0, 10, 0);
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.heapBytes()).isEqualTo(2 * MB);
+        assertThat(List.of(result.jvmOptions().split(" "))).contains("-Xms2m", "-Xmx2m");
+        assertThat(MemoryKubernetesSizer.heapPercentage(result)).isEqualTo(0.5);
+    }
+
+    @Test
+    void extremeClassAndDirectObservationsLeaveAnInvalidRatherThanOverflowingBudget() {
+        MemoryCalculationDto result = calculator.calculate(
+                Long.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, 30, 10, 0, false, null, Long.MAX_VALUE);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.fixedRegionsBytes()).isPositive();
+        assertThat(result.heapBytes()).isZero();
+        assertThat(result.jvmOptions()).isEmpty();
+    }
+
+    @Test
+    void defaultTotalMemoryDoesNotWrapExtremeOrUnknownObservations() {
+        assertThat(calculator.defaultTotalMemoryBytes(Long.MAX_VALUE, Long.MAX_VALUE, 250, 0))
+                .isEqualTo(2048 * MB);
+        assertThat(calculator.defaultTotalMemoryBytes(Long.MIN_VALUE, Long.MIN_VALUE, 250, 0))
+                .isEqualTo(calculator.defaultTotalMemoryBytes(0, 0, 250, 0));
+        assertThat(calculator.defaultTotalMemoryBytes(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE))
+                .isEqualTo(2048 * MB);
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryKubernetesSizerTests.java
@@ -163,6 +163,7 @@ class MemoryKubernetesSizerTests {
                 HealthProbeManifest.SPRING_ACTUATOR);
 
         assertThat(recommendation.currentSnapshotBytes()).isEqualTo(Long.MAX_VALUE);
+        assertThat(recommendation.currentSnapshotMemory()).isEqualTo("8796093022208Mi");
         assertThat(recommendation.burstableRequestMemoryBytes()).isEqualTo(1024 * MB);
         assertThat(recommendation.requestMemoryBytes()).isEqualTo(1024 * MB);
         assertThat(recommendation.qosClass()).isEqualTo("Depends on CPU");
@@ -236,6 +237,35 @@ class MemoryKubernetesSizerTests {
     }
 
     @Test
+    void percentageBoundaryFailureCannotLeakDeploymentOptionsOrAnAvailableQos() {
+        MemoryCalculationDto calculation = calculator.calculate(519 * MB, 250, 0, 0, 10, 0);
+
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation,
+                64 * MB,
+                64 * MB,
+                0,
+                false,
+                519 * MB,
+                128 * MB,
+                true,
+                true,
+                HealthProbeManifest.QUARKUS_SMALLRYE);
+
+        assertThat(calculation.valid()).isFalse();
+        assertThat(recommendation.qosClass()).isEqualTo("Unavailable");
+        assertThat(recommendation.confidence()).isEqualTo("Low");
+        assertThat(recommendation.javaToolOptions()).isEmpty();
+        assertThat(recommendation.yaml()).isEmpty();
+        assertThat(recommendation.maxRamPercentage()).isZero();
+        assertThat(recommendation.initialRamPercentage()).isZero();
+        assertThat(recommendation.requestMemoryBytes()).isZero();
+        assertThat(recommendation.limitMemoryBytes()).isEqualTo(519 * MB);
+        assertThat(recommendation.currentSnapshotBytes()).isEqualTo(128 * MB);
+        assertThat(recommendation.warnings()).containsExactly(calculation.error());
+    }
+
+    @Test
     void modelConfidenceStaysLowWithoutMatchingCgroupObservations() {
         MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
 
@@ -266,6 +296,38 @@ class MemoryKubernetesSizerTests {
         assertThat(calculator.buildKubernetesJvmOptions(calculation, percentage, percentage))
                 .contains("-XX:MaxRAMPercentage=" + percentage)
                 .contains("-XX:MinRAMPercentage=" + percentage);
+    }
+
+    @Test
+    void percentageUsesAnExactDownwardFloorAtThreeDecimalPlaces() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_001, 7, 40, 5_001);
+        long expectedThousandths = calculation.heapBytes() * 100_000L / calculation.totalMemoryBytes();
+
+        assertThat(MemoryKubernetesSizer.heapPercentage(calculation)).isEqualTo(expectedThousandths / 1000.0);
+        assertThat(expectedThousandths * calculation.totalMemoryBytes())
+                .isLessThanOrEqualTo(calculation.heapBytes() * 100_000L);
+        assertThat(calculation.headRoomBytes()).isEqualTo(calculation.totalMemoryBytes() * 7 / 100);
+    }
+
+    @Test
+    void mebibyteFormattingPreservesBoundariesWithoutOverflow() {
+        assertThat(MemoryKubernetesSizer.formatMi(-1)).isEqualTo("0Mi");
+        assertThat(MemoryKubernetesSizer.formatMi(0)).isEqualTo("0Mi");
+        assertThat(MemoryKubernetesSizer.formatMi(MB)).isEqualTo("1Mi");
+        assertThat(MemoryKubernetesSizer.formatMi(MB + 1)).isEqualTo("2Mi");
+        assertThat(MemoryKubernetesSizer.formatMi(Long.MAX_VALUE)).isEqualTo("8796093022208Mi");
+    }
+
+    @Test
+    void notesDistinguishRequestedSettingsFromEffectiveHeapAndDeploymentLimits() {
+        MemoryCalculationDto calculation = calculator.calculate(1024 * MB, 250, 5_000, 10, 40, 5_000);
+        KubernetesMemoryRecommendationDto recommendation = recommend(
+                calculation, 64 * MB, 64 * MB, 0, false, null, null, false, false, HealthProbeManifest.SPRING_ACTUATOR);
+
+        assertThat(recommendation.warnings())
+                .anySatisfy(warning -> assertThat(warning).contains("alignment", "startup"))
+                .anySatisfy(warning -> assertThat(warning).contains("JVM-visible", "-Xmx", "-Xms"))
+                .anySatisfy(warning -> assertThat(warning).contains("total process"));
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryReportProviderTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryReportProviderTests.java
@@ -1,10 +1,15 @@
 package io.github.jdubois.bootui.engine.memory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import io.github.jdubois.bootui.core.dto.LiveMemoryReport;
 import io.github.jdubois.bootui.spi.HealthProbeManifest;
 import io.github.jdubois.bootui.spi.MemoryRuntimeConfig;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -175,5 +180,29 @@ class MemoryReportProviderTests {
 
         assertThat(oversized.calculation().totalMemoryBytes()).isEqualTo(MemoryCalculator.MAX_TOTAL_MEMORY_BYTES);
         assertThat(negative.calculation().totalMemoryBytes()).isEqualTo(MemoryCalculator.MIN_TOTAL_MEMORY_BYTES);
+    }
+
+    @Test
+    void detectedBudgetRoundsDownAndUsesOneCgroupSample() {
+        long mebibyte = 1024L * 1024L;
+        long detectedBytes = 1024L * mebibyte + mebibyte - 1;
+        ContainerMemoryLimitDetector detector = mock(ContainerMemoryLimitDetector.class);
+        when(detector.detect())
+                .thenReturn(new ContainerMemoryLimitDetector.CgroupMemorySample(
+                        OptionalLong.of(detectedBytes), OptionalLong.of(256L * mebibyte), OptionalLong.empty()));
+        MemoryReportProvider provider = new MemoryReportProvider(new MemoryCalculator(), detector);
+
+        LiveMemoryReport report = provider.buildReport(null, 50, 10, false, false);
+
+        assertThat(report.calculation().totalMemoryBytes()).isEqualTo(1024L * mebibyte);
+        assertThat(report.kubernetes().limitMemoryBytes())
+                .isEqualTo(report.calculation().totalMemoryBytes());
+        assertThat(report.kubernetes().limitMemory()).isEqualTo("1024Mi");
+        assertThat(report.kubernetes().yaml()).contains("memory: \"1024Mi\"");
+        assertThat(report.kubernetes().detectedContainerLimitBytes()).isEqualTo(detectedBytes);
+        assertThat(report.kubernetes().currentSnapshotBytes()).isEqualTo(256L * mebibyte);
+        assertThat(report.kubernetes().confidence()).isEqualTo("Low");
+        verify(detector).detect();
+        verifyNoMoreInteractions(detector);
     }
 }

--- a/docs/JVM-TUNING-CHECKS.md
+++ b/docs/JVM-TUNING-CHECKS.md
@@ -7,23 +7,34 @@ select a garbage collector, inspect application traffic, or claim that a snapsho
 This document records the evidence and decisions behind the shared engine used by Spring MVC, Spring WebFlux, and
 Quarkus. The compatibility baseline is Java 17 through Java 26, Spring Boot 4.1, and Quarkus 3.33 LTS.
 
+The full audit behind [#955](https://github.com/jdubois/boot-ui/issues/955) retains the existing partition and
+operator policies, corrects numerical/output boundaries, and separates generated requests from effective JVM memory.
+Observed-metaspace sizing and richer effective health-probe detection are explicitly deferred below rather than
+silently treated as complete. Sources were independently revalidated against JDK 17–26 GA source, Spring Boot 4.1.1,
+and Quarkus 3.33; this is not an execution matrix for every JVM vendor, update, collector, and architecture.
+
 ## Evidence ledger
 
 | Source | Evidence used |
 | ------ | ------------- |
 | [Spring Boot 4.1 system requirements](https://docs.spring.io/spring-boot/system-requirements.html) | Spring Boot 4.1 requires Java 17 and supports Java through 26, defining the generated-option compatibility range. |
 | [Oracle JDK 17 `java` launcher](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html) and [JDK 26 launcher](https://docs.oracle.com/en/java/javase/26/docs/specs/man/java.html) | Defines `-Xms`, `-Xmx`, `-Xss`, container support, RAM-percentage, metaspace, code-cache, GC, pre-touch, and OOM options across the supported range. `MinRAMPercentage` governs maximum-heap ergonomics for small heaps, so it must accompany `MaxRAMPercentage`. `UseContainerSupport` is Linux-only and already defaults to true where supported, so a portable snippet must not force it. |
-| [Paketo Java memory calculator reference](https://paketo.io/docs/reference/java-reference/#memory-calculator) and [`libjvm` calculator source](https://github.com/paketo-buildpacks/libjvm/blob/main/calc/calculator.go) | Supplies the partition formula and the 10 MiB direct-memory, 240 MiB code-cache, 1 MiB stack, and 250-thread modeling defaults. |
+| [HotSpot JDK 17 heap validation](https://github.com/openjdk/jdk/blob/jdk-17-ga/src/hotspot/share/gc/shared/gcArguments.cpp#L130-L150) and [JDK 26 heap validation](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/gc/shared/gcArguments.cpp#L113-L133) | Reject maximum heaps below 2 MiB before rounding up to collector-specific alignment. The launcher manuals say “greater than” 2 MB; the inclusive 2 MiB bound used here follows inspected HotSpot source and is not a startup guarantee. |
+| [JDK 26 G1 alignment](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/gc/g1/g1Arguments.cpp#L43-L61) and [card-table constraint](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/gc/shared/cardTable.cpp#L221-L224) | Effective heap can exceed a floored option literal. Alignment depends on collector, region size, OS/card/page settings; 8 MiB is not a universal alignment. |
+| [JDK 26 argument ergonomics](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/runtime/arguments.cpp) | Percentage sizing depends on JVM-visible RAM and existing flags. `MaxRAM` is deprecated in JDK 26 and is a sizing input, not a process-memory cap. JDK 26 changes the default `InitialRAMPercentage` to 0.0; this calculator supplies an explicit value. |
+| [Paketo Java memory calculator reference](https://paketo.io/docs/reference/java-reference/#memory-calculator), [pinned `libjvm` calculator](https://github.com/paketo-buildpacks/libjvm/blob/83e37180564a488c514ce039217dde75b8fcfa39/calc/calculator.go), and [launch helper](https://github.com/paketo-buildpacks/libjvm/blob/83e37180564a488c514ce039217dde75b8fcfa39/helper/memory_calculator.go) | Supplies the partition formula and the 10 MiB direct-memory, 240 MiB code-cache, 1 MiB stack, and 250-thread modeling defaults. Paketo's headroom default is 0%, not BootUI's 10%; upstream calculation does not establish portable minimum heaps or comprehensive overflow validation. |
 | [`ClassLoadingMXBean`](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/ClassLoadingMXBean.html) and [`BufferPoolMXBean`](https://docs.oracle.com/en/java/javase/17/docs/api/java.management/java/lang/management/BufferPoolMXBean.html) | Provide observable current loaded-class count and estimated direct-buffer memory usage. Both are snapshots, not peak forecasts. |
 | [JEP 444: Virtual Threads](https://openjdk.org/jeps/444) | Virtual threads are not tied one-to-one to OS threads and are mounted on carrier platform threads. Their presence does not provide an observable, deterministic replacement for a platform-thread native-stack budget. |
+| [JEP 491](https://openjdk.org/jeps/491) and [`ThreadMXBean`](https://docs.oracle.com/en/java/javase/26/docs/api/java.management/java/lang/management/ThreadMXBean.html) | ThreadMXBean observes platform threads, not virtual threads. Synchronized-related virtual-thread pinning changed in JDK 24; older pinning guidance is version-dependent. |
 | [Oracle GC ergonomics guidance](https://docs.oracle.com/en/java/javase/17/gctuning/ergonomics.html) | GC sizing and pause/throughput choices are competing workload goals; heap size alone is not sufficient evidence for changing collectors or enabling pre-touch. |
-| [JEP 439](https://openjdk.org/jeps/439) and [JEP 474](https://openjdk.org/jeps/474) | Generational ZGC availability and defaults changed after Java 17, so emitting `ZGenerational` cannot be portable across the supported range. |
-| [JEP 450: Compact Object Headers](https://openjdk.org/jeps/450) | Compact headers entered as a disabled experimental feature after Java 17 and require workload validation, so the advisor cannot enable them generically. |
+| [JEP 439](https://openjdk.org/jeps/439), [JEP 474](https://openjdk.org/jeps/474), and [JEP 490](https://openjdk.org/jeps/490) | Generational ZGC availability and defaults changed after Java 17; JDK 24 removed non-generational mode and obsoleted `ZGenerational`. Emitting that flag is not portable across the supported range. |
+| [JEP 450](https://openjdk.org/jeps/450) and [JEP 519](https://openjdk.org/jeps/519) | Compact headers progressed from an experimental to a product feature, not a universal default. That evolution does not establish workload suitability or availability across Java 17–26. |
+| [JDK 26 class metadata](https://docs.oracle.com/en/java/javase/26/gctuning/other-considerations.html) and [HotSpot memory pools](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/services/memoryPool.cpp) | `MaxMetaspaceSize` covers combined committed metadata; the Metaspace pool already includes compressed class metadata. Adding the Compressed Class Space pool again double-counts it, and its reserved address space is not committed RAM. |
 | [Kubernetes resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) and [Pod QoS classes](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/) | Memory limits are hard OOM boundaries; requests drive scheduling. Guaranteed QoS requires equal, non-zero CPU and memory requests and limits for every container, not memory equality alone. |
 | [Linux cgroup v2 memory controller](https://docs.kernel.org/admin-guide/cgroup-v2.html#memory-interface-files) | `memory.current` is the current total memory attributed to a cgroup and `memory.max` is its hard limit. |
 | [Oracle Native Memory Tracking](https://docs.oracle.com/en/java/javase/17/vm/native-memory-tracking.html) | NMT is off by default, requires `jcmd` output to use, and tracks JVM/HotSpot memory rather than all user-native allocations. Detecting its startup flag alone is not stronger sizing evidence. |
 | [Kubernetes probe configuration](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#use-a-named-port) | HTTP probes may refer to a named container port, avoiding a framework-specific hard-coded port number. |
-| [Spring Boot Kubernetes probes](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.kubernetes-probes) and [Quarkus 3.33 SmallRye Health](https://quarkus.io/version/3.33/guides/smallrye-health) | Supplies framework-default health capabilities and paths. Both frameworks allow configuration that can move those endpoints or their port. |
+| [Spring Boot 4.1.1 health documentation](https://github.com/spring-projects/spring-boot/blob/v4.1.1/documentation/spring-boot-docs/src/docs/antora/modules/reference/pages/actuator/endpoints.adoc), [probe autoconfiguration](https://github.com/spring-projects/spring-boot/blob/v4.1.1/module/spring-boot-health/src/main/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/AvailabilityProbesAutoConfiguration.java), and [Quarkus 3.33 SmallRye Health](https://quarkus.io/version/3.33/guides/smallrye-health) | Boot 4.1 defaults probe groups on when applicable; older Kubernetes-only enablement guidance is not the baseline. Dependency, exposure, group and routing configuration still matter. Quarkus management-interface exposure is build-time configurable. |
 
 ## Memory model
 
@@ -42,13 +53,18 @@ The current inputs and bounds are:
 
 | Input or region | Current behavior |
 | --------------- | ---------------- |
-| Total process budget | Operator input clamped to 128 MiB–64 GiB before byte conversion. The initial host default is an explicit BootUI heuristic, approximately 1.5 times committed heap plus non-heap, rounded to 64 MiB and clamped to 384 MiB–2 GiB. |
+| Total process budget | Operator input clamped to 128 MiB–64 GiB before byte conversion. A detected limit is rounded down to whole MiB before applying the same bounds; its original byte value remains in the report. The initial host default is an explicit BootUI heuristic, approximately 1.5 times committed heap plus non-heap, rounded to 64 MiB and clamped to 384 MiB–2 GiB. Footprint arithmetic is bounded before addition/rounding; negative/unknown counters contribute no observed bytes. |
 | Headroom | Operator-selected 0%–30%; default 10%. It covers unmodeled native/process overhead but is not a measured guarantee. |
 | Direct memory | Greater of Paketo's 10 MiB fallback and current `java.nio` direct-buffer memory, rounded up to MiB. It is modeled but not hard-capped. |
 | Metaspace | `(14,000,000 + 5,800 × current loaded classes) × 1.25`, rounded up to MiB. The constants follow Paketo; 1.25 is an explicit BootUI allowance for later class loading. |
 | Code cache | 240 MiB, following the comparable Paketo model. |
 | Platform-thread stacks | 1 MiB times the operator budget. The initial budget is `max(current live threads, 250)` for every runtime, including applications using virtual threads. |
-| Heap | Exact remaining bytes in the report; generated MiB options round down so rendering never exceeds the modeled budget. A plan with less than 1 MiB of renderable heap is invalid. |
+| Heap | Exact remaining modeled bytes in valid reports; fixed option literals round down to MiB. Both fixed and three-decimal percentage requests must reach HotSpot's generic 2 MiB maximum-heap lower bound. Otherwise the report is invalid with an explanation and no generated options/YAML. No upward heap adjustment rescues an exhausted budget. |
+
+The generic bound deliberately does not invent a workload-sized minimum. For example, 2 MiB is representable as
+`0.5%` of 400 MiB, but flooring its ratio against 519 MiB to `0.385%` requests less than 2 MiB; the latter plan is
+invalid even though its fixed option alone could request 2 MiB. Passing these arithmetic checks does not guarantee
+collector initialization, application startup, or workload sufficiency.
 
 ### Generated option inventory
 
@@ -73,8 +89,16 @@ For Kubernetes, fixed heap flags are replaced with:
 -Xss1024k
 ```
 
-The heap percentage is the modeled heap divided by the memory limit, floored to three decimal places. There is no
-universal 75% cap: fixed regions and selected headroom have already been subtracted.
+The heap percentage is the modeled heap divided by the selected whole-MiB memory limit, floored to three decimal
+places using bounded integer arithmetic. There is no universal 75% cap: fixed regions and selected headroom have
+already been subtracted.
+
+These are **requested settings**, not measured effective JVM settings. HotSpot can round heap sizes upward for
+collector/platform alignment even when the option literal rounds down. Percentage flags use JVM-visible RAM or an
+existing sizing override, which can differ from the chosen budget if container support or deployment settings differ.
+Explicit `-Xmx`/`-Xms` settings and other startup configuration can supersede generated environment options.
+`InitialRAMPercentage` also does not establish the same minimum-heap contract as `-Xms`. Check effective settings on
+the target JVM; neither these flags nor model validity enforce a total process-memory limit.
 
 ## Kubernetes behavior
 
@@ -86,32 +110,57 @@ universal 75% cap: fixed regions and selected headroom have already been subtrac
   QoS remains `Depends on CPU`. This is explicitly a starting heuristic.
 - `memory.current` (or the cgroup v1 current-usage file) is preferred for the snapshot. When unavailable, the fallback is
   committed heap + committed non-heap + observed direct buffers. Reserved stack address space is not added to resident
-  memory.
+  memory. Limit and usage come from one detector invocation, not separate re-selections; the underlying file reads are
+  still a non-atomic snapshot. Cgroup v1 usage is an approximate counter, not exact process RSS.
 - Confidence is `Medium` only when both cgroup limit and current usage are available and the detected limit matches the
   selected total. Every other valid model is `Low`; the advisor does not claim high confidence from NMT merely being
-  enabled.
+  enabled. This describes model-input confidence, not production safety. A minimum ancestor limit can cover siblings
+  whose consumption is absent from the process cgroup's usage; the model does not estimate that competing demand.
+- Diagnostic MiB strings round up for display without overflowing, including saturated `long` counters; raw byte
+  fields remain authoritative. Generated request/limit quantities are whole MiB and agree exactly with their byte
+  fields and the calculation denominator.
 - Generated health probes use framework-default paths and the named container port `http`. The fragment assumes the
   surrounding container declares that port name. Custom application paths, management interfaces, and ports must be
-  reconciled by the operator.
+  reconciled by the operator. Timings are example policy, not measured startup or latency requirements. Startup probes
+  suppress readiness/liveness until success; readiness failures do not restart the container, unlike startup/liveness
+  failure handling.
 
 ## Decision inventory
 
 | Decision | Result | Rationale |
 | -------- | ------ | --------- |
-| Paketo partition and fixed-region defaults | **KEEP** | Established, deterministic baseline with transparent arithmetic. |
-| Live class count with 1.25 allowance | **KEEP** | Observable input plus an explicit, testable heuristic. |
-| Metaspace and rendered-cap rounding | **MODIFY** | Caps round up; heap rounds down, preventing snippets from under-allocating caps or exceeding the plan. |
-| Direct-memory region | **MODIFY** | Raise the model to observed direct-buffer usage, but do not convert a transient observation into a hard cap. |
-| Virtual-thread stack discount | **REMOVE** | The previous 80-thread/512 KiB assumption was not derivable from `ThreadMXBean` or the virtual-thread scheduler. |
-| Automatic G1/ZGC selection and `ZGenerational` | **REMOVE** | Heap size alone does not establish pause/throughput goals, and flag behavior varies inside the supported JDK range. |
-| String deduplication, compact headers, and pre-touch | **REMOVE** | Workload- or JDK-specific choices cannot be inferred from this snapshot. |
-| Direct-memory cap and OOM exit/dump policy | **REMOVE** | Future native demand, restart policy, dump storage, and sensitive-data handling are deployment decisions. |
-| Kubernetes 75% heap ceiling | **REMOVE** | It double-counted native safety after fixed regions and headroom were already subtracted. |
-| `MinRAMPercentage` | **ADD** | Keeps the calculated maximum-heap percentage effective for HotSpot's small-heap path. |
-| Explicit `UseContainerSupport` | **REMOVE** | The option is Linux-only and already enabled by default where supported; omitting it keeps the fragment valid on other container platforms. |
-| cgroup current usage | **ADD** | More complete current container observation than summing selected JVM pools. |
-| Guaranteed QoS claim | **MODIFY** | Memory equality is necessary but not sufficient; CPU and all Pod containers also determine QoS. |
-| Hard-coded probe port 8080 | **MODIFY** | A named port is portable across framework defaults, with an explicit operator-verification warning. |
+| Paketo partition | **RETAIN** | Established deterministic policy, not exhaustive process-memory accounting. |
+| Total/thread/headroom input clamps | **RETAIN** | Existing bounded operator contract, not universal JVM limits. |
+| Host default and rounding | **UPDATE** | Preserve 1.5x/384 MiB–2 GiB/64 MiB policy; bound arithmetic before overflow. |
+| Detected total and YAML denominator | **UPDATE** | Round detected budget down to whole MiB, preserve raw evidence, and align emitted quantities with the model. |
+| Headroom default 10%, selectable 0%–30% | **RETAIN** | Explicit BootUI/operator heuristic; not Paketo's default or a safety guarantee. |
+| Live class count and 1.25 metaspace allowance | **RETAIN; ENHANCEMENT DEFERRED** | Observable class count with an explicit heuristic; it can underestimate current actual metadata. Observed-metaspace sizing requires separate policy and must not double-count compressed class space. |
+| Metaspace upward MiB rounding | **RETAIN** | Does not shrink the modeled requested cap; not evidence that the cap fits the workload. |
+| Direct fallback/observed usage without cap | **RETAIN** | Current buffers are not peak demand or all native allocations. Unavailable observations do not establish zero demand. |
+| Code cache 240 MiB | **RETAIN** | Paketo reserve, not every JVM mode's default or observed commitment. |
+| 1 MiB stacks; max(live platform threads,250) default | **RETAIN** | Explicit setting and reserve, not the platform's default stack size or future/native-thread count. |
+| Virtual-thread stack discount | **RETAIN REMOVAL** | Heap-backed virtual stacks do not remove native platform/carrier stacks. |
+| Minimum generated maximum heap | **UPDATE** | Reject fixed or serialized-percentage candidates below the generic 2 MiB source bound; no speculative 8 MiB floor. |
+| Fixed `-Xms`/`-Xmx` equality | **RETAIN** | Explicit fixed modeled heap policy, not an evidence-based production commitment recommendation. |
+| Literal flooring guarantees effective budget | **REMOVE CLAIM** | Target collector/platform alignment may enlarge effective heap; validity is arithmetic, not startup/load proof. |
+| Max/Min/Initial RAM percentages | **UPDATE** | Exact three-decimal flooring and emitted-bound validation; explain denominator, override and initial/minimum semantics. |
+| Universal 75% heap ceiling | **RETAIN REMOVAL** | Double-counts a reserve after fixed regions/headroom. |
+| Explicit `UseContainerSupport` | **RETAIN REMOVAL** | Linux-only and default-on where supported; verify deployment assumptions instead. |
+| `MaxRAM` as a budget fix | **REJECT ADDITION** | Not an enforced cap; deprecated in JDK 26. |
+| Automatic GC selection and `ZGenerational` | **RETAIN REMOVAL** | Workload- and version-dependent; omitting flags also does not copy the current collector to a new JVM. |
+| Deduplication, compact headers, pre-touch | **RETAIN REMOVAL** | No snapshot-based workload justification; compact-header productization does not make it universally available or appropriate. |
+| OOM exit/dump paths and policy | **RETAIN REMOVAL** | Restart/storage/sensitive-data policy belongs to the deployment. |
+| Equal requests/limits and `Depends on CPU` | **RETAIN** | Container memory alone cannot establish Guaranteed Pod QoS. Newer Pod-level resource policy is cluster-dependent and outside this fragment. |
+| Opt-in Burstable snapshot margin/floor/rounding | **RETAIN** | Explicit heuristic, capped at limit; no peak or production forecast. |
+| Cgroup current vs committed-pool fallback | **UPDATE READ COHERENCE** | Reuse one detector sample; charged memory and JVM commitment are not interchangeable physical-memory measures. |
+| Overflow/unknown observation handling | **UPDATE** | Preserve large quantities without wrapping to zero; retain low confidence without required observations. |
+| Medium model confidence | **RETAIN WITH LIMITATIONS** | Matching observed inputs only; no inference of sibling usage, future demand, or guaranteed free memory. |
+| NMT startup flag | **RETAIN** | No consumed NMT output or confidence boost; NMT excludes some process-native memory even when enabled. |
+| Named port, framework-default paths, explicit probe toggle | **RETAIN** | Review dependency, routing, management interface, declared port and custom paths. |
+| Probe timings | **RETAIN AS EXAMPLES** | User must establish startup/timeout/restart policy; not measured recommendations. |
+| Spring effective health capability | **UPDATE NEEDED; DEFERRED** | Boot 4.1 really defaults probes on, but configuration defaults alone do not prove Actuator presence, endpoint access/exposure, group state, or reachability. |
+| Quarkus health capability | **RETAIN LIMITED SIGNAL; ENHANCEMENT DEFERRED** | Extension presence is not full effective endpoint/management routing evidence. |
+| Native image/alternative JVMs | **RETAIN LIMITATIONS** | Native-image tuning is unavailable; HotSpot options require manual review on alternative JVM implementations. |
 
 Rejected new candidates include automatic CPU sizing, fixed GC pause targets, large pages, NUMA settings, Shenandoah or
 ZGC recommendations, automatic NMT enablement, and a universal native-overhead multiplier. They are unavailable on part
@@ -132,5 +181,10 @@ observations.
   Recommendations must be tested after warmup and under representative peak load.
 - **NMT:** BootUI detects the startup option but does not execute or parse `jcmd VM.native_memory`; no confidence claim
   depends on NMT output.
+- **Native memory:** GC/compiler structures, native libraries/agents, allocator effects, and container-charged
+  cache/kernel/tmpfs memory are not separately measured by the partition. Fixed JVM region settings do not cap these.
+- **Cgroup scope:** ancestor-limit and leaf-usage scope differences remain a limitation; finite cgroup-v2 zero limits
+  are currently treated as unavailable by the shared detector. This audit does not change that separately owned
+  observation layer.
 - **YAML scope:** the output is a container fragment, not a complete Deployment. It does not invent CPU resources,
   container names, images, security context, or a `ports` declaration.


### PR DESCRIPTION
## Executive summary

JVM Tuning now rejects known-invalid tiny maximum-heap requests, preserves large memory quantities without overflow, and keeps detected budgets consistent with generated Kubernetes limits. MVC, WebFlux, and Quarkus share the corrected engine and unchanged JSON contract. The complete audit records retained heuristics and explicit deferred findings.

**All CI gates pass on head `5038eb1c7ef09c2f9260f50b61287d74540baf19`**, including Java 17 coverage, Java 21/25 compatibility, all four browser suites, documentation, and CodeQL.

## What does this PR do?

<!-- One-sentence summary of the change. -->

Corrects numerical and generated-output boundaries in the shared JVM Tuning calculator without adding automatic tuning.

### Exact model and recommendation changes

- Validate fixed-MiB and serialized three-decimal percentage requests against HotSpot's generic 2 MiB maximum-heap lower bound. If percentage flooring puts a nominal 2 MiB heap below the bound, the plan is invalid. Never increase an exhausted budget to manufacture validity.
- Use bounded integer arithmetic for headroom and percentage flooring; bound default footprint arithmetic before addition/rounding; format saturated observations without overflowing to `0Mi`.
- Round detected budgets down to whole MiB before existing bounds, retain original detected bytes, and align calculator total, YAML limit, and percentage denominator. Reuse one existing cgroup sample without changing detector discovery/accounting.
- Explain effective heap alignment, JVM-visible denominators, startup-option overrides, native-memory exclusions, and validity limitations through existing warnings.

No DTO fields, HTTP parameters, availability/safety policies, probe templates, CLI commands, MCP schemas, or Vue components change. Live Memory shares the corrected provider; `get_jvm_tuning` and CLI `jvm tuning` still project the shared report on all three stacks.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #955

Previous tests approved `-Xms1m -Xmx1m`, rejected with `Too small maximum heap` on both tested HotSpot 17 and 26 runtimes. On the examined macOS/default-G1 setup, a 2 MiB request becomes 8 MiB after alignment. This disproves an exact-effective-budget guarantee, not evidence for a universal 8 MiB workload floor. An existing saturation test checked numeric `Long.MAX_VALUE` but missed its incorrectly rendered `0Mi` string.

### Primary sources

- [JDK 17 generic checks](https://github.com/openjdk/jdk/blob/jdk-17-ga/src/hotspot/share/gc/shared/gcArguments.cpp#L130-L150), [JDK 26 checks](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/gc/shared/gcArguments.cpp#L113-L133), [G1 alignment](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/gc/g1/g1Arguments.cpp#L43-L61), and [card-table constraint](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/gc/shared/cardTable.cpp#L221-L224). The inclusive bound follows source; manuals use stricter “greater than” wording.
- [JDK 17 launcher](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html), [JDK 26 launcher](https://docs.oracle.com/en/java/javase/26/docs/specs/man/java.html), and [JDK 26 ergonomics](https://github.com/openjdk/jdk/blob/jdk-26-ga/src/hotspot/share/runtime/arguments.cpp).
- [Pinned Paketo calculator](https://github.com/paketo-buildpacks/libjvm/blob/83e37180564a488c514ce039217dde75b8fcfa39/calc/calculator.go) and [helper](https://github.com/paketo-buildpacks/libjvm/blob/83e37180564a488c514ce039217dde75b8fcfa39/helper/memory_calculator.go).
- [Metadata accounting](https://docs.oracle.com/en/java/javase/26/gctuning/other-considerations.html), [NMT](https://docs.oracle.com/en/java/javase/26/vm/native-memory-tracking.html), [JEP 444](https://openjdk.org/jeps/444), [JEP 491](https://openjdk.org/jeps/491), [JEP 490](https://openjdk.org/jeps/490), [JEP 519](https://openjdk.org/jeps/519).
- [Linux cgroups](https://docs.kernel.org/admin-guide/cgroup-v2.html), [Kubernetes resources](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/), [QoS](https://kubernetes.io/docs/concepts/workloads/pods/pod-qos/), [probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
- [Spring Boot 4.1.1 probes](https://github.com/spring-projects/spring-boot/blob/v4.1.1/module/spring-boot-health/src/main/java/org/springframework/boot/health/autoconfigure/actuate/endpoint/AvailabilityProbesAutoConfiguration.java), [Quarkus 3.33 health](https://quarkus.io/version/3.33/guides/smallrye-health/).

### All-behavior audit disposition

The complete per-rule evidence ledger is committed in `docs/JVM-TUNING-CHECKS.md`.

| Behavior | Disposition |
| --- | --- |
| Paketo partition; total/thread/headroom bounds | Retain deterministic operator policy, not universal JVM or production limits. |
| Host 1.5x footprint, 384 MiB–2 GiB, 64 MiB steps | Retain heuristic; correct overflow before rounding. |
| Detected totals, quantities, percentage output | Update conservative normalization, exact flooring and emitted-bound validation. |
| Headroom default 10%, selectable 0–30% | Retain BootUI/operator policy; not Paketo's default or guaranteed native reserve. |
| Class formula, 1.25 metaspace allowance, upward cap rounding | Retain heuristic; observed-metaspace enhancement deferred. Never double-count compressed class space. |
| Direct fallback/current observation without cap | Retain lower-bound model; unknown is not measured zero, NIO is not all native memory. |
| Code cache 240 MiB, 1 MiB stacks, max(live platform threads,250) | Retain explicit reserves, not universal runtime defaults or forecast peaks. |
| Virtual-thread stack discount | Retain removal: carrier/platform stacks remain native; virtual stacks consume heap. |
| Minimum fixed/percentage requests | Update generic 2 MiB bound; no arbitrary 8 MiB or production workload floor. |
| Equal Xms/Xmx and fixed region flags | Retain requested fixed model; remove exact-effective-heap/startup implication. |
| Max/Min/Initial percentages | Retain flags; update precision and denominator/override/initial-vs-minimum explanation. |
| Universal 75% ceiling; explicit UseContainerSupport | Retain removal: no duplicate reserve or Linux-only flag in portable snippets. |
| MaxRAM as proposed budget fix | Reject addition: sizing input, not enforced cap; deprecated in JDK 26. |
| Automatic collector choice, ZGenerational, pre-touch, deduplication, compact headers | Retain removal; workload/version-specific. Refresh lifecycle evidence. |
| OOM exit/dump policy | Retain removal; deployment restart/storage/sensitive-data decisions. |
| Equal requests/limits; Depends on CPU QoS | Retain honest container-memory evidence; no Pod-wide guarantee. |
| Opt-in Burstable margin/floor/granularity/cap | Retain snapshot heuristic, not peak demand. |
| Cgroup current/pool fallback and saturation | Retain evidence semantics; coherent detector call and correct large-value rendering. |
| Confidence; NMT startup flag | Retain limited model confidence; no parsed NMT, future-demand or sibling-pressure inference. |
| Named port, framework-default paths, probe toggle/timings | Retain templates/example policy, not verified endpoints or measured startup/timeout requirements. |
| Spring effective health capability | Update needed, deferred: Boot 4.1 genuinely defaults probes on, but dependency/access/exposure/group/routing evidence is incomplete. |
| Quarkus effective health capability | Retain presence signal; richer effective routing/management detection deferred. |
| Automatic CPU sizing, pause targets, large pages, NUMA, NMT enablement | Reject additions: insufficient workload/platform evidence. |
| Native images and alternative JVMs | Retain honest applicability limits. |

### Limitations

Validity establishes arithmetic and supported generic flag constraints, not JVM startup, warmup, production sizing, or freedom from container OOM. Effective heap can align upward and native memory remains partially unmodeled. The unchanged shared detector can combine an ancestor ceiling with leaf usage and treats finite cgroup-v2 zero limits as unavailable. Existing input clamping remains deliberate.

The user selected this budget/output slice rather than observed-metaspace/effective-health changes. Those findings remain explicit deferrals, not claimed fixes.

## How was it tested?

- [ ] `./mvnw clean install` passes locally — full reactor ran in exact-head CI instead
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests (CI)
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082 (CI)
- [x] Ran the affected Playwright suite(s) for browser-facing changes (CI)
- [x] Added or updated tests where applicable

45 focused calculator/sizer/provider tests pass locally on Temurin 17.0.20.1+1; 44 passed on HotSpot 26.0.2.1 before the final invalid-output propagation case was added. New regressions first failed in six expected places before fixes. Local Java 17 whole-reactor Spotless and all three frontend/e2e formatting checks pass.

| Exact-head CI gate | Result |
| --- | --- |
| Java 17 full `-Pcoverage clean install` | Passed, including 1,055 frontend unit tests and coverage gates |
| Java 17 conformance | MVC 29 passed; WebFlux 29 passed; Quarkus 25 passed, 4 capability-dependent skips |
| Java 21 and 25 compatibility/conformance | Both passed |
| Spring browser suites | MVC 180 passed; WebFlux 12 passed; custom paths 13 passed |
| Quarkus browser suite | 117 passed |
| Documentation site | Passed |
| CodeQL | Both language analyses passed |

[Build/conformance/browser run](https://github.com/jdubois/boot-ui/actions/runs/34103580359), [compatibility run](https://github.com/jdubois/boot-ui/actions/runs/34103580385), [documentation run](https://github.com/jdubois/boot-ui/actions/runs/34103580384).

Heavyweight checks ran in CI instead of duplicating another coordinated local reactor. Local docs dependency restoration failed for locked `fast-uri@3.1.7` (mirror 404; upstream ENOTCONN); the successful exact-head documentation CI build provides independent validation. No dependency versions or registry configuration were changed.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

Not applicable: no Vue component or interaction changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed