### PR TITLE
Fix browser CI after advisor scoring integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Advisor browser coverage now distinguishes incomplete reports from numeric scores.** Live Spring and Quarkus
+  scenarios retain findings and dismissal/restore assertions without requiring a score for `PARTIAL` results.
+  Shared complete-report scenarios continue to verify exact dismissal and restore score changes across runtimes
+  and custom mounts. Metrics filter assertions also wait for the filtered response instead of iterating stale
+  row counts ([#983](https://github.com/jdubois/boot-ui/issues/983)).
+
 - **Architecture checks accept supported logger, scheduling and thread-factory patterns, and distinguish failed
   scans from successful analysis.** Private final instance loggers and Quarkus `@LoggerName` injection are recognized;
   scheduled signatures include repeatable/composed annotations and precise reactive types without flagging valid

--- a/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
@@ -30,7 +30,8 @@ test.describe('Hibernate advisor (Quarkus)', () => {
     }
     expect(report.results.some((result) => result.id.startsWith('HIB-QUERY-'))).toBe(false)
 
-    await expect(page.locator('.advisor-summary__value')).toBeVisible({timeout: 20_000})
+    await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
+    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
     await expect(page.locator('main')).toContainText('Entities analysed')
 
     // Effective batching makes the stronger IDENTITY finding apply, without duplicate generic advice.

--- a/bootui-quarkus-sample-app/e2e/tests/metrics.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/metrics.spec.js
@@ -84,21 +84,21 @@ test.describe('Metrics view', () => {
   test('filters meters by explanation source on the server', async ({openView, page}) => {
     await openView('metrics', 'Metrics')
 
-    const explanationRequest = page.waitForRequest((request) => {
-      const url = new URL(request.url())
+    const explanationResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url())
       return url.pathname.endsWith('/api/metrics') && url.searchParams.get('explanation') === 'CURATED'
     })
     await page.getByLabel('Filter meters by explanation source').selectOption('CURATED')
-    await explanationRequest
+    const response = await explanationResponse
+    expect(response.ok()).toBeTruthy()
+    const {meters} = await response.json()
+    expect(meters.every((meter) => meter.provenance?.explanationSource === 'CURATED')).toBeTruthy()
 
     // Which meters carry a registry description depends on third-party metadata, so assert the invariant instead
-    // of a specific meter: everything rendered under this filter is explained by the catalogue.
+    // of a specific meter. Wait for the filtered response's rows, not the previous list's size.
     const sources = page.locator('.meter-list .meter-source')
-    const rendered = await sources.count()
-    for (let index = 0; index < rendered; index += 1) {
-      await expect(sources.nth(index)).toContainText('BootUI catalogue')
-    }
-    if (rendered === 0) {
+    await expect(sources).toHaveText(meters.map(() => 'BootUI catalogue'))
+    if (meters.length === 0) {
       await expect(page.locator('.meter-list')).toContainText('No meters match')
     }
   })

--- a/bootui-quarkus-sample-app/e2e/tests/quarkus-advisor.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/quarkus-advisor.spec.js
@@ -18,12 +18,18 @@ test.describe('Quarkus advisor', () => {
   test('runs Quarkus checks and renders the advisor report', async ({openView, page}) => {
     await openView('spring', /^Quarkus/)
 
+    const scanResponse = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && /\/spring\/scan$/.test(new URL(response.url()).pathname)
+    )
     await page.getByRole('button', {name: /Run Quarkus checks/}).click()
+    const response = await scanResponse
+    expect(response.ok()).toBeTruthy()
+    const report = await response.json()
+    expect(report.scan.status).toBe('PARTIAL')
+    expect(report.scan.message).toBeTruthy()
 
-    // A successful scan renders the shared advisor summary score and the platform-aware "Idioms
-    // inspected" card. The state-changing POST also proves the Quarkus LocalhostOnlyFilter accepts a
-    // same-origin browser request without Spring Security's CSRF token.
-    await expect(page.locator('.advisor-summary__value')).toBeVisible({timeout: 20_000})
+    await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
+    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
     await expect(page.locator('main')).toContainText('Idioms inspected')
   })
 })

--- a/bootui-quarkus-sample-app/e2e/tests/security.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/security.spec.js
@@ -14,7 +14,8 @@ test.describe('Security advisor (Quarkus)', () => {
 
     await page.getByRole('button', {name: 'Run security checks'}).click()
 
-    await expect(page.locator('.advisor-summary__value')).toBeVisible({timeout: 20_000})
+    await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete', {timeout: 20_000})
+    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
     await expect(page.locator('main')).toContainText('Heuristic Quarkus rules')
     await expect(page.locator('main')).toContainText('Permission policies')
   })
@@ -22,8 +23,17 @@ test.describe('Security advisor (Quarkus)', () => {
   test('runs security checks and finds the sample app misconfigurations', async ({openView, page}) => {
     await openView('security', 'Security')
 
+    const scanResponse = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && /\/security\/scan$/.test(new URL(response.url()).pathname)
+    )
     await page.getByRole('button', {name: 'Run security checks'}).click()
-    await expect(page.locator('.advisor-summary__value')).toBeVisible({timeout: 20_000})
+    const response = await scanResponse
+    expect(response.ok()).toBeTruthy()
+    const report = await response.json()
+    expect(report.scan.status).toBe('PARTIAL')
+    expect(report.scan.message).toBeTruthy()
+    await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
+    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
 
     // quarkus.http.auth.basic=true with insecure-requests=enabled (the sample's default).
     const basicAuthRow = page.locator('.list-group-item', {hasText: 'QS-AUTH-002'})

--- a/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
+++ b/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
@@ -13,13 +13,13 @@ const scannerIds = [
   'github'
 ]
 
-function architectureReport(status) {
+function architectureReport(status, dismissed = false) {
   return {
     scan: {status, scannedAt: 1700000000000, message: 'Available evidence retained.'},
-    severityCounts: [{severity: 'HIGH', count: 1}],
+    severityCounts: [{severity: 'HIGH', count: dismissed ? 0 : 1}],
     basePackages: ['example.app'],
     rulesEvaluated: 1,
-    violationsFound: 1,
+    violationsFound: dismissed ? 0 : 1,
     classesAnalyzed: 2,
     disclaimer: 'Heuristic findings.',
     results: [
@@ -32,7 +32,7 @@ function architectureReport(status) {
         category: 'TEST',
         violationCount: 1,
         violations: [],
-        dismissed: false,
+        dismissed,
         recommendation: 'Review the finding.'
       }
     ]
@@ -140,6 +140,33 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       await expect(page.locator('.advisor-score-card')).toContainText('Incomplete')
       await expect(page.getByText('Retained architecture finding', {exact: true})).toBeVisible()
       await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    })
+
+    test('dismisses and restores a complete report finding with exact score changes', async ({page}) => {
+      let dismissed = false
+      let scans = 0
+      await page.route(`**${apiPath}/architecture{,/scan}`, async (route) => {
+        if (route.request().method() === 'POST') scans++
+        await route.fulfill({json: architectureReport('SCANNED', dismissed)})
+      })
+      await page.route(`**${apiPath}/dismissed-rules/ARCH-TEST-1`, async (route) => {
+        expect(['POST', 'DELETE']).toContain(route.request().method())
+        dismissed = route.request().method() === 'POST'
+        await route.fulfill({json: {dismissed: dismissed ? ['ARCH-TEST-1'] : []}})
+      })
+      await page.goto(`${uiPath}/#/architecture`)
+      await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+      await page.getByRole('button', {name: /Dismiss$/}).click()
+      await expect(page.locator('.list-group-item.opacity-50')).toContainText('ARCH-TEST-1')
+      await expect(page.locator('.advisor-summary__dismissed')).toContainText(
+        '1 dismissed rule(s) excluded from this score'
+      )
+      await expect(page.locator('.advisor-summary__value')).toHaveText('100')
+      await page.getByRole('button', {name: /Restore$/}).click()
+      await expect(page.locator('.list-group-item.opacity-50')).toHaveCount(0)
+      await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
+      await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+      expect(scans).toBe(0)
     })
 
     test('refreshes UNKNOWN dismissal and restore eligibility using only cached report GETs', async ({page}) => {

--- a/bootui-spring-sample-app/e2e/tests/advisor-dismiss.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/advisor-dismiss.spec.js
@@ -36,13 +36,11 @@ async function findingsCount(metric) {
 }
 
 /**
- * Reads the numeric advisor score rendered by the shared AdvisorSummary.
- *
  * @param {import('@playwright/test').Page} page
- * @returns {Promise<number>}
  */
-async function scoreValue(page) {
-  return Number.parseInt((await page.locator('.advisor-summary__value').innerText()).trim(), 10)
+async function expectIncompleteAssessment(page) {
+  await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
+  await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
 }
 
 test.describe('Advisor rule dismiss/restore', () => {
@@ -58,10 +56,19 @@ test.describe('Advisor rule dismiss/restore', () => {
     await clearDismissedRules(request)
   })
 
-  test('dismisses a finding server-side so it leaves the score, then restores it', async ({openView, page}) => {
+  test('dismisses and restores a real finding without scoring an incomplete report', async ({openView, page}) => {
     await openView('hibernate', 'Hibernate')
 
+    const scanResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && /\/hibernate\/scan$/.test(new URL(response.url()).pathname)
+    )
     await page.getByRole('button', {name: 'Run Hibernate checks'}).click()
+    const response = await scanResponse
+    expect(response.ok()).toBeTruthy()
+    const report = await response.json()
+    expect(report.scan.status).toBe('PARTIAL')
+    expect(report.scan.message).toBeTruthy()
 
     // Wait for the rule-results list to populate with at least one dismissible finding.
     const activeItems = page.locator('.list-group-item').filter({has: page.getByRole('button', {name: 'Dismiss'})})
@@ -73,9 +80,7 @@ test.describe('Advisor rule dismiss/restore', () => {
     // Nothing is dismissed yet, so the dismissed-note line is absent.
     await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
 
-    // The advisor score card renders once a scan has produced findings.
-    await expect(page.locator('.advisor-score-card')).toBeVisible()
-    const scoreBefore = await scoreValue(page)
+    await expectIncompleteAssessment(page)
 
     // Capture the rule id of the first active finding so we can target it precisely.
     const firstActive = activeItems.first()
@@ -90,34 +95,26 @@ test.describe('Advisor rule dismiss/restore', () => {
 
     await firstActive.getByRole('button', {name: 'Dismiss'}).click()
 
-    // The rule moves into the "Dismissed rules" list, the score subtracts it, and
-    // the dismissed subline appears. Because we cleared dismissals first, it reads "1 dismissed".
+    // Dismissal changes the active findings, not the incomplete assessment's eligibility.
     const dismissedItem = dismissedItemFor(ruleId)
     await expect(dismissedItem).toBeVisible()
     await expect(page.getByText('— not counted in score')).toBeVisible()
-    await expect(page.locator('.advisor-summary__dismissed')).toContainText('1 dismissed')
+    await expect(page.locator('.advisor-summary__dismissed')).toContainText(
+      '1 dismissed rule(s) excluded from active findings'
+    )
     await expect.poll(async () => findingsCount(findingsCard)).toBe(before - 1)
-
-    // Dismissing a finding removes its weighted penalty. The score therefore rises or
-    // holds: the sample app's Hibernate model has enough findings to clamp the raw score
-    // at 0, so dropping a single rule can leave the displayed score unchanged. The strict
-    // "dismiss raises the score" guarantee is unit-tested in Spring.test.js against a
-    // non-clamped report; here we assert it never *decreases* and that the score card
-    // notes the exclusion. The exact-restore check below is what pins the wiring down.
-    await expect(page.getByText('excluded from this score')).toBeVisible()
-    await expect.poll(async () => scoreValue(page)).toBeGreaterThanOrEqual(scoreBefore)
+    await expectIncompleteAssessment(page)
 
     // The rule is no longer offered as an active (dismissible) finding.
     await expect(activeItemFor(ruleId)).toHaveCount(0)
 
-    // Restoring returns the finding to the active list and the score to its original value.
+    // Restoring returns the finding to the active list without inventing a score.
     await dismissedItem.getByRole('button', {name: 'Restore'}).click()
 
     await expect(dismissedItemFor(ruleId)).toHaveCount(0)
     await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
-    await expect(page.getByText('excluded from this score')).toHaveCount(0)
     await expect.poll(async () => findingsCount(findingsCard)).toBe(before)
-    await expect.poll(async () => scoreValue(page)).toBe(scoreBefore)
+    await expectIncompleteAssessment(page)
     await expect(activeItemFor(ruleId)).toHaveCount(1)
   })
 })

--- a/bootui-spring-sample-app/e2e/tests/metrics.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/metrics.spec.js
@@ -78,21 +78,21 @@ test.describe('Metrics view', () => {
   test('filters meters by explanation source on the server', async ({openView, page}) => {
     await openView('metrics', 'Metrics')
 
-    const explanationRequest = page.waitForRequest((request) => {
-      const url = new URL(request.url())
+    const explanationResponse = page.waitForResponse((response) => {
+      const url = new URL(response.url())
       return url.pathname.endsWith('/api/metrics') && url.searchParams.get('explanation') === 'CURATED'
     })
     await page.getByLabel('Filter meters by explanation source').selectOption('CURATED')
-    await explanationRequest
+    const response = await explanationResponse
+    expect(response.ok()).toBeTruthy()
+    const {meters} = await response.json()
+    expect(meters.every((meter) => meter.provenance?.explanationSource === 'CURATED')).toBeTruthy()
 
     // Which meters carry a registry description depends on third-party metadata, so assert the invariant instead
-    // of a specific meter: everything rendered under this filter is explained by the catalogue.
+    // of a specific meter. Wait for the filtered response's rows, not the previous list's size.
     const sources = page.locator('.meter-list .meter-source')
-    const rendered = await sources.count()
-    for (let index = 0; index < rendered; index += 1) {
-      await expect(sources.nth(index)).toContainText('BootUI catalogue')
-    }
-    if (rendered === 0) {
+    await expect(sources).toHaveText(meters.map(() => 'BootUI catalogue'))
+    if (meters.length === 0) {
       await expect(page.locator('.meter-list')).toContainText('No meters match')
     }
   })


### PR DESCRIPTION
**Executive summary:** Restores the browser contract after the advisor audits: incomplete reports keep their findings but never acquire a numeric score. Complete reports retain explicit dismissal/restore scoring coverage. Also fixes the metrics-filter request/render race reproduced during full-suite validation. **No production code, workflows, retry settings, timeouts, or test skips change.**

## What does this PR do?

- Update live Quarkus application, Hibernate, and Security scenarios to assert `PARTIAL`/Incomplete and no gauge, retaining their real findings and platform-specific assertions.
- Keep the real Spring Hibernate dismissal/restore flow, including server persistence, active finding counts, and restoration, while asserting that the assessment remains unscored throughout.
- Add one shared complete-report scenario that asserts exact **90 → 100 → 90** score changes on dismissal/restore, without launching another scan. It runs on MVC, WebFlux, Quarkus, and both custom mounts.
- Fix both metrics explanation-source scenarios to await the filtered response, assert the returned provenance, and match the complete rendered list instead of iterating a stale pre-response row count.

## Why is this change needed?

Closes #983.

The final integrated main run [34153780091](https://github.com/jdubois/boot-ui/actions/runs/34153780091) passed its Java 17 build but failed five browser scenarios that still required `.advisor-summary__value` on intentionally incomplete reports. The Quarkus Hibernate case even asserted `PARTIAL` immediately before requiring a score.

Full local validation also reproduced the metrics race seen in earlier CI runs: observing a request does not mean the filtered DOM has rendered, so a captured row count could refer to the previous, larger list. The replacement checks the actual response and the whole current list; it does not relax the filtering invariant.

## How was it tested?

| Browser suite | Result |
| --- | --- |
| Full Spring MVC, run without the companion Quarkus server | 186 passed, 6 existing skips |
| Full Spring WebFlux | 18 passed |
| Full custom-path MVC/WebFlux | 23 passed, 1 existing skip |
| Full Quarkus with deterministic local OSV fixture | 122 passed, 1 existing skip |
| Updated metrics-source scenario, repeated on each adapter | 5/5 MVC and 5/5 Quarkus |

The Quarkus full suite preceded the final metrics assertion change; that changed scenario was then independently rerun five times. MVC's final full run includes that change. No new skips were added.

The first parallel full MVC run also exposed an environment interaction: its REST-client scenario intentionally expects the companion Quarkus endpoint to be unavailable. Starting that companion concurrently made the call succeed. No assertion was changed; the final MVC suite ran alone and passed.

- [ ] `./mvnw clean install` passes locally — not rerun in full for this test-only patch; the unchanged main base's Java 17 build passed in the linked workflow.
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests — no Java/API behavior changed; real browser/backend round trips were exercised instead.
- [x] Built and started the affected sample apps with JDK 17 and an isolated Maven repository; verified BootUI loads.
- [x] Ran the affected Playwright suites for browser-facing changes.
- [x] Added or updated tests where applicable.
- [x] Whole-reactor Spotless apply/check, frontend formatting, and both E2E formatting checks passed.

## Screenshots (UI changes)

N/A: no production UI changes.

## Checklist

- [x] Changelog updated; no product behavior or public contract change requiring documentation updates.
- [x] Public API kept backward compatible.
- [x] No secrets, tokens, or local paths committed.