### PR TITLE
fix(ui): recover panel navigation from stale lazy-loaded assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Panel navigation now recovers from stale UI assets after a backend rebuild.** Missing lazy-loaded JavaScript or
+  stylesheets show an explicit **Reload BootUI** action instead of silently leaving navigation stuck or blank.
+  Recovery preserves the intended route and custom mount, warns before discarding unsaved input, and never refreshes
+  automatically or masks ordinary API/application errors ([#985](https://github.com/jdubois/boot-ui/issues/985)).
+
 - **Advisor browser coverage now distinguishes incomplete reports from numeric scores.** Live Spring and Quarkus
   scenarios retain findings and dismissal/restore assertions without requiring a score for `PARTIAL` results.
   Shared complete-report scenarios continue to verify exact dismissal and restore score changes across runtimes

--- a/bootui-quarkus-sample-app/e2e/tests/stale-assets.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/stale-assets.spec.js
@@ -1,0 +1,4 @@
+import {expect, test} from '@playwright/test'
+import {registerStaleAssetTests} from '../../../bootui-spring-sample-app/e2e/scenarios/stale-assets.js'
+
+registerStaleAssetTests(test, expect)

--- a/bootui-spring-sample-app/e2e/scenarios/stale-assets.js
+++ b/bootui-spring-sample-app/e2e/scenarios/stale-assets.js
@@ -1,0 +1,177 @@
+// @ts-check
+
+export function registerStaleAssetTests(test, expect, {uiPath = '/bootui', apiPath = '/bootui/api'} = {}) {
+  const recoveryAlert = (page) => page.getByRole('alert').filter({hasText: 'BootUI could not load this panel'})
+  const heading = (page, name) => page.locator('main h2').filter({hasText: name}).first()
+
+  function recordRequests(page) {
+    const documents = []
+    const writes = []
+    page.on('request', (request) => {
+      if (request.isNavigationRequest() && request.frame() === page.mainFrame()) documents.push(request.url())
+      if (!['GET', 'HEAD'].includes(request.method())) writes.push(request.url())
+    })
+    return {documents, writes}
+  }
+
+  async function openHibernate(page) {
+    const link = page.locator('aside a[href="#/hibernate"]')
+    const group = page
+      .locator('aside .bootui-nav-section')
+      .filter({has: page.locator('a[href="#/hibernate"]')})
+      .getByRole('button')
+    if ((await group.getAttribute('aria-expanded')) !== 'true') await group.click()
+    await link.click()
+  }
+
+  test.describe('stale UI assets', () => {
+    for (const [theme, width] of [
+      ['light', 1600],
+      ['dark', 390]
+    ]) {
+      test(`offers visible keyboard recovery in ${theme} at ${width}px`, async ({page}) => {
+        await page.setViewportSize({width, height: 900})
+        await page.addInitScript((value) => localStorage.setItem('bootui.theme', value), theme)
+        await page.route(
+          (url) => url.pathname.startsWith(`${uiPath}/assets/Hibernate-`) && url.pathname.endsWith('.js'),
+          (route) => route.fulfill({status: 404, body: ''})
+        )
+        await page.goto(`${uiPath}/#/hibernate`)
+        const alert = recoveryAlert(page)
+        await expect(alert).toHaveCount(1)
+        const reload = alert.getByRole('button', {name: 'Reload BootUI', exact: true})
+        await expect(reload).toBeVisible()
+        await reload.focus()
+        await expect(reload).toBeFocused()
+        const bounds = await alert.boundingBox()
+        expect(bounds.x).toBeGreaterThanOrEqual(0)
+        expect(bounds.x + bounds.width).toBeLessThanOrEqual(width)
+        expect(bounds.y + bounds.height).toBeLessThanOrEqual(900)
+      })
+    }
+
+    test('keeps unsaved input until consent, then reloads the current UI into the intended panel', async ({page}) => {
+      const {documents, writes} = recordRequests(page)
+      const missingAssets = []
+      const staleChunk = (url) => url.pathname.startsWith(`${uiPath}/assets/Hibernate-`) && url.pathname.endsWith('.js')
+      await page.route(staleChunk, async (route) => {
+        missingAssets.push(route.request().url())
+        await route.fulfill({status: 404, contentType: 'text/plain', body: 'Asset removed after rebuild'})
+      })
+      await page.goto(`${uiPath}/?mode=dev#/http-probe`)
+      await heading(page, /^HTTP Probe/).waitFor()
+      await page.getByLabel('Path', {exact: true}).fill('/keep-my-unsent-request')
+      await openHibernate(page)
+
+      const alert = recoveryAlert(page)
+      await expect(alert).toHaveCount(1)
+      await expect(alert).toContainText('Could not open Hibernate')
+      await expect(alert).toContainText('Reloading discards unsaved input')
+      await expect(heading(page, /^HTTP Probe/)).toBeVisible()
+      await expect(page.getByLabel('Path', {exact: true})).toHaveValue('/keep-my-unsent-request')
+      expect(missingAssets).toHaveLength(1)
+      expect(documents).toHaveLength(1)
+      expect(writes).toEqual([])
+
+      await page.unroute(staleChunk)
+      const reload = alert.getByRole('button', {name: 'Reload BootUI', exact: true})
+      await reload.focus()
+      await expect(reload).toBeFocused()
+      await page.keyboard.press('Enter')
+      await expect(heading(page, /^Hibernate$/)).toBeVisible()
+      await expect(page).toHaveURL(new RegExp(`${uiPath}/\\?mode=dev#/hibernate$`))
+      await expect(alert).toHaveCount(0)
+      expect(documents).toHaveLength(2)
+      expect(writes).toEqual([])
+    })
+
+    test('preserves a deep link and shows a persistent failure without a reload loop', async ({page}) => {
+      const {documents, writes} = recordRequests(page)
+      const staleChunk = (url) => url.pathname.startsWith(`${uiPath}/assets/Hibernate-`) && url.pathname.endsWith('.js')
+      await page.route(staleChunk, (route) =>
+        route.fulfill({status: 404, contentType: 'text/plain', body: 'Asset still missing'})
+      )
+      const destination = `${uiPath}/?mode=dev#/hibernate?tab=findings#details`
+      await page.goto(destination)
+      const alert = recoveryAlert(page)
+      await expect(alert).toBeVisible()
+      expect(documents).toHaveLength(1)
+      await alert.getByRole('button', {name: 'Reload BootUI', exact: true}).click()
+      await expect(alert).toBeVisible()
+      await expect(page).toHaveURL(new RegExp(`${uiPath}/\\?mode=dev#/hibernate\\?tab=findings#details$`))
+      expect(documents).toHaveLength(2)
+      // An unrelated, healthy navigation remains usable and clears the stale failure.
+      await page.getByRole('link', {name: 'Overview', exact: true}).click()
+      await expect(heading(page, /^Overview/)).toBeVisible()
+      await expect(alert).toHaveCount(0)
+      expect(documents).toHaveLength(2)
+      expect(writes).toEqual([])
+    })
+
+    test('recovers a missing lazy stylesheet', async ({page}) => {
+      const {documents} = recordRequests(page)
+      const stylesheet = (url) => url.pathname.startsWith(`${uiPath}/assets/Health-`) && url.pathname.endsWith('.css')
+      await page.route(stylesheet, (route) => route.fulfill({status: 404, body: ''}))
+      await page.goto(`${uiPath}/#/health`)
+      await expect(recoveryAlert(page)).toContainText('Could not open Health')
+      expect(documents).toHaveLength(1)
+      await page.unroute(stylesheet)
+      await recoveryAlert(page).getByRole('button', {name: 'Reload BootUI', exact: true}).click()
+      await expect(heading(page, /^Health/)).toBeVisible()
+      await expect(recoveryAlert(page)).toHaveCount(0)
+      expect(documents).toHaveLength(2)
+    })
+
+    test('does not reload or lose input when the application is offline', async ({page, context}) => {
+      const {documents, writes} = recordRequests(page)
+      await page.goto(`${uiPath}/#/http-probe`)
+      await heading(page, /^HTTP Probe/).waitFor()
+      await page.getByLabel('Path', {exact: true}).fill('/unsent')
+      await context.setOffline(true)
+      await openHibernate(page)
+      await expect(recoveryAlert(page)).toBeVisible()
+      await openHibernate(page)
+      await expect(page.getByLabel('Path', {exact: true})).toHaveValue('/unsent')
+      expect(documents).toHaveLength(1)
+      expect(writes).toEqual([])
+      await context.setOffline(false)
+    })
+
+    test('leaves API errors to the panel instead of offering a stale-asset reload', async ({page}) => {
+      const {documents, writes} = recordRequests(page)
+      await page.route(
+        (url) => url.pathname === `${apiPath}/health`,
+        (route) => route.fulfill({status: 500, contentType: 'application/json', body: '{"error":"Report failed"}'})
+      )
+      await page.goto(`${uiPath}/#/health`)
+      await expect(heading(page, /^Health$/)).toBeVisible()
+      await expect(page.locator('main')).toContainText('500')
+      await expect(recoveryAlert(page)).toHaveCount(0)
+      expect(documents).toHaveLength(1)
+      expect(writes).toEqual([])
+    })
+
+    test('does not treat module evaluation bugs as stale assets', async ({page}) => {
+      const errors = []
+      page.on('console', (message) => {
+        if (message.type() === 'error') errors.push(message.text())
+      })
+      const {documents} = recordRequests(page)
+      await page.route(
+        (url) => url.pathname.startsWith(`${uiPath}/assets/Hibernate-`) && url.pathname.endsWith('.js'),
+        (route) =>
+          route.fulfill({
+            contentType: 'application/javascript',
+            body: 'throw new Error("Panel module evaluation failed"); export default {}'
+          })
+      )
+      await page.goto(`${uiPath}/#/http-probe`)
+      await heading(page, /^HTTP Probe/).waitFor()
+      await openHibernate(page)
+      await expect.poll(() => errors.some((message) => message.includes('Panel module evaluation failed'))).toBe(true)
+      await expect(recoveryAlert(page)).toHaveCount(0)
+      await expect(heading(page, /^HTTP Probe/)).toBeVisible()
+      expect(documents).toHaveLength(1)
+    })
+  })
+}

--- a/bootui-spring-sample-app/e2e/tests-custom-path/stale-assets.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-custom-path/stale-assets.spec.js
@@ -1,0 +1,4 @@
+import {expect, test} from '@playwright/test'
+import {registerStaleAssetTests} from '../scenarios/stale-assets.js'
+
+registerStaleAssetTests(test, expect, {uiPath: '/host/dev-console', apiPath: '/host/internal/bootui-api'})

--- a/bootui-spring-sample-app/e2e/tests-webflux/stale-assets.spec.js
+++ b/bootui-spring-sample-app/e2e/tests-webflux/stale-assets.spec.js
@@ -1,0 +1,4 @@
+import {expect, test} from '@playwright/test'
+import {registerStaleAssetTests} from '../scenarios/stale-assets.js'
+
+registerStaleAssetTests(test, expect)

--- a/bootui-spring-sample-app/e2e/tests/stale-assets.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/stale-assets.spec.js
@@ -1,0 +1,4 @@
+import {expect, test} from '@playwright/test'
+import {registerStaleAssetTests} from '../scenarios/stale-assets.js'
+
+registerStaleAssetTests(test, expect)

--- a/bootui-ui/src/main/frontend/src/App.test.js
+++ b/bootui-ui/src/main/frontend/src/App.test.js
@@ -118,10 +118,16 @@ async function mountApp(initialPath = '/overview', options = {}) {
   if (typeof window.matchMedia !== 'function') stubMatchMedia()
   vi.resetModules()
   const {default: App} = await import('./App.vue')
+  const {createRouteAssetRecovery, routeAssetRecoveryKey} = await import('./utils/routeAssetRecovery.js')
   const router = createRouter({
     history: createMemoryHistory(),
     routes: shellRoutes()
   })
+  const browser = {
+    location: {href: 'http://localhost/bootui/#/overview', reload: vi.fn()},
+    history: {state: null, replaceState: vi.fn()}
+  }
+  const recovery = createRouteAssetRecovery(router, browser)
 
   await router.push(initialPath)
   await router.isReady()
@@ -130,6 +136,7 @@ async function mountApp(initialPath = '/overview', options = {}) {
     attachTo: document.body,
     global: {
       plugins: [router],
+      provide: {[routeAssetRecoveryKey]: recovery},
       stubs: {
         CommandPalette: options.stubCommandPalette === false ? false : true,
         RouterView: options.stubRouterView === false ? false : {template: '<div />'}
@@ -138,7 +145,7 @@ async function mountApp(initialPath = '/overview', options = {}) {
   })
   await flushPromises()
 
-  return {router, wrapper}
+  return {router, wrapper, browser}
 }
 
 function groupToggle(wrapper, title) {
@@ -159,6 +166,36 @@ describe('App sidebar navigation', () => {
     vi.unstubAllGlobals()
     restoreLocalStorage()
     document.body.innerHTML = ''
+  })
+
+  it('shows one actionable asset failure without replacing the current panel', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const {router, wrapper, browser} = await mountApp('/overview', {stubRouterView: false})
+    router.addRoute({
+      path: '/hibernate',
+      name: 'hibernate',
+      meta: {title: 'Hibernate', group: 'advisors'},
+      component: () => Promise.reject(new TypeError('Failed to fetch dynamically imported module: old.js'))
+    })
+    await expect(router.push('/hibernate')).rejects.toThrow()
+    await flushPromises()
+
+    const alerts = wrapper.findAll('[role="alert"]')
+    expect(alerts).toHaveLength(1)
+    expect(alerts[0].text()).toContain('Could not open Hibernate')
+    expect(alerts[0].text()).toContain('Reloading discards unsaved input')
+    expect(wrapper.find('main section').exists()).toBe(true)
+    expect(browser.location.reload).not.toHaveBeenCalled()
+    const reload = alerts[0].find('button')
+    expect(reload.text()).toBe('Reload BootUI')
+    expect(reload.attributes('type')).toBe('button')
+    await reload.trigger('click')
+    expect(browser.location.reload).toHaveBeenCalledTimes(1)
+
+    await router.push('/health')
+    await flushPromises()
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+    wrapper.unmount()
   })
 
   it('moves the active group away from Security after navigating to another group', async () => {

--- a/bootui-ui/src/main/frontend/src/App.vue
+++ b/bootui-ui/src/main/frontend/src/App.vue
@@ -1,6 +1,17 @@
 <script setup>
 import {apiFetch} from './api.js'
-import {computed, defineAsyncComponent, nextTick, onBeforeUnmount, onMounted, provide, reactive, ref, watch} from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  inject,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  reactive,
+  ref,
+  watch
+} from 'vue'
 import {useRoute, useRouter} from 'vue-router'
 import {
   applyTheme,
@@ -24,11 +35,16 @@ import {
 } from './utils/panelNavigation.js'
 import {recordRecentPanel} from './utils/recentPanels.js'
 import {safeLocalStorage} from './utils/safeStorage.js'
+import {routeAssetRecoveryKey} from './utils/routeAssetRecovery.js'
 import CommandPalette from './views/components/CommandPalette.vue'
 const ConfirmDialog = defineAsyncComponent(() => import('./views/components/ConfirmDialog.vue'))
 
 const router = useRouter()
 const route = useRoute()
+const routeAssetRecovery = inject(routeAssetRecoveryKey, null)
+const failedPanelTitle = computed(() =>
+  routeAssetRecovery?.failure.value ? resolveRouteTitle(routeAssetRecovery.failure.value, panels.value?.platform) : null
+)
 const overview = ref(null)
 const panels = ref(null)
 const shellError = ref(null)
@@ -954,6 +970,17 @@ function onGlobalKeydown(e) {
         </header>
 
         <main ref="mainContentRef" class="content-stage" tabindex="-1">
+          <div v-if="failedPanelTitle" class="alert alert-warning shell-error shadow-sm" role="alert">
+            <div class="shell-error__title">
+              <i class="bi bi-exclamation-triangle" aria-hidden="true"></i>
+              <strong>Could not open {{ failedPanelTitle }}</strong>
+            </div>
+            <p>
+              BootUI could not load this panel's files. The application may have been rebuilt or stopped. Once it is
+              running, reload to get the current UI. Reloading discards unsaved input in this tab.
+            </p>
+            <button class="btn btn-primary" type="button" @click="routeAssetRecovery.reload">Reload BootUI</button>
+          </div>
           <div
             v-if="shellErrorMessage"
             :class="['alert', shellServerUnreachable ? 'alert-warning' : 'alert-danger']"

--- a/bootui-ui/src/main/frontend/src/main.js
+++ b/bootui-ui/src/main/frontend/src/main.js
@@ -9,10 +9,13 @@ import './assets/theme-minimal.css'
 import './assets/theme-win95.css'
 import App from './App.vue'
 import {routes} from './routes.js'
+import {createRouteAssetRecovery, routeAssetRecoveryKey} from './utils/routeAssetRecovery.js'
 
 const router = createRouter({
   history: createWebHashHistory(),
   routes
 })
 
-createApp(App).use(router).mount('#app')
+const routeAssetRecovery = createRouteAssetRecovery(router)
+
+createApp(App).provide(routeAssetRecoveryKey, routeAssetRecovery).use(router).mount('#app')

--- a/bootui-ui/src/main/frontend/src/utils/routeAssetRecovery.js
+++ b/bootui-ui/src/main/frontend/src/utils/routeAssetRecovery.js
@@ -1,0 +1,38 @@
+import {readonly, shallowRef} from 'vue'
+
+export const routeAssetRecoveryKey = Symbol('routeAssetRecovery')
+
+export function isRouteAssetError(error) {
+  if (!(error instanceof Error)) return false
+  return (
+    (error instanceof TypeError &&
+      /^(Failed to fetch dynamically imported module(?::|$)|error loading dynamically imported module(?::|$)|Importing a module script failed\.?$)/i.test(
+        error.message
+      )) ||
+    /^Unable to preload CSS for /.test(error.message)
+  )
+}
+
+export function createRouteAssetRecovery(router, browser = window) {
+  const failure = shallowRef(null)
+
+  router.onError((error, to) => {
+    // Keep genuine router/application errors observable; only asset failures get a reload action.
+    console.error(error)
+    if (isRouteAssetError(error)) failure.value = to
+  })
+  router.afterEach((_to, _from, navigationFailure) => {
+    if (!navigationFailure) failure.value = null
+  })
+
+  function reload() {
+    if (!failure.value) return
+    const url = new URL(browser.location.href)
+    url.hash = failure.value.fullPath
+    // A hash-only navigation does not fetch a fresh entry module. Reload explicitly, only on consent.
+    browser.history.replaceState(browser.history.state, '', url)
+    browser.location.reload()
+  }
+
+  return {failure: readonly(failure), reload}
+}

--- a/bootui-ui/src/main/frontend/src/utils/routeAssetRecovery.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/routeAssetRecovery.test.js
@@ -1,0 +1,105 @@
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {createMemoryHistory, createRouter} from 'vue-router'
+import {createRouteAssetRecovery, isRouteAssetError} from './routeAssetRecovery.js'
+
+const assetError = () => new TypeError('Failed to fetch dynamically imported module: http://localhost/assets/old.js')
+
+function setup(href = 'http://localhost/bootui/#/overview') {
+  const loadPanel = vi.fn(() => Promise.reject(assetError()))
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      {path: '/overview', component: {template: '<div />'}},
+      {path: '/hibernate', meta: {title: 'Hibernate'}, component: loadPanel},
+      {path: '/health', component: {template: '<div />'}}
+    ]
+  })
+  const browser = {
+    location: {href, reload: vi.fn()},
+    history: {state: {position: 1}, replaceState: vi.fn()}
+  }
+  const recovery = createRouteAssetRecovery(router, browser)
+  return {router, loadPanel, browser, recovery}
+}
+
+describe('route asset recovery', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => {}))
+
+  it.each([
+    assetError(),
+    new TypeError('error loading dynamically imported module: http://localhost/assets/old.js'),
+    new TypeError('Importing a module script failed.'),
+    new Error('Unable to preload CSS for http://localhost/assets/old.css')
+  ])('recognizes a browser import or Vite CSS failure: %s', (error) => {
+    expect(isRouteAssetError(error)).toBe(true)
+  })
+
+  it.each([
+    new TypeError('Failed to fetch'),
+    new Error('HTTP 500'),
+    new Error('Network Error'),
+    new SyntaxError("Unexpected token '<'"),
+    new ReferenceError('missing is not defined'),
+    new DOMException('Aborted', 'AbortError'),
+    'Failed to fetch dynamically imported module',
+    null
+  ])('does not classify an application or API error as a stale asset: %s', (error) => {
+    expect(isRouteAssetError(error)).toBe(false)
+  })
+
+  it('retains the current route and requires consent for each failed navigation', async () => {
+    const {router, loadPanel, browser, recovery} = setup()
+    await router.push('/overview')
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await expect(router.push('/hibernate?tab=findings#details')).rejects.toThrow('dynamically imported')
+      expect(recovery.failure.value.fullPath).toBe('/hibernate?tab=findings#details')
+      expect(router.currentRoute.value.path).toBe('/overview')
+      expect(browser.location.reload).not.toHaveBeenCalled()
+    }
+    expect(loadPanel).toHaveBeenCalledTimes(3)
+    expect(console.error).toHaveBeenCalledTimes(3)
+  })
+
+  it('handles initial navigation failures before the shell mounts', async () => {
+    const {router, recovery, browser} = setup()
+    await expect(router.push('/hibernate')).rejects.toThrow()
+    expect(recovery.failure.value.meta.title).toBe('Hibernate')
+    expect(browser.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('preserves the custom mount, document query, destination query and nested hash on explicit reload', async () => {
+    const {router, recovery, browser} = setup('http://localhost:8083/host/dev-console/?mode=dev#/overview')
+    await expect(router.push('/hibernate?tab=findings#details')).rejects.toThrow()
+    recovery.reload()
+    expect(browser.history.replaceState).toHaveBeenCalledWith(
+      browser.history.state,
+      '',
+      new URL('http://localhost:8083/host/dev-console/?mode=dev#/hibernate?tab=findings#details')
+    )
+    expect(browser.location.reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears recovery after successful navigation, but not an aborted navigation', async () => {
+    const {router, recovery, browser} = setup()
+    await router.push('/overview')
+    await expect(router.push('/hibernate')).rejects.toThrow()
+    const removeGuard = router.beforeEach(() => false)
+    await router.push('/health')
+    expect(recovery.failure.value).not.toBeNull()
+    removeGuard()
+    await router.push('/health')
+    expect(recovery.failure.value).toBeNull()
+    recovery.reload()
+    expect(browser.location.reload).not.toHaveBeenCalled()
+  })
+
+  it('keeps genuine module evaluation failures observable without offering a reload', async () => {
+    const {router, loadPanel, recovery, browser} = setup()
+    const error = new Error('Panel setup failed')
+    loadPanel.mockRejectedValue(error)
+    await expect(router.push('/hibernate')).rejects.toBe(error)
+    expect(console.error).toHaveBeenCalledWith(error)
+    expect(recovery.failure.value).toBeNull()
+    expect(browser.location.reload).not.toHaveBeenCalled()
+  })
+})

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -17,6 +17,13 @@ the search box to jump straight to a panel by name.
 
 ## Rules that apply to every panel
 
+**An old tab can recover after a UI rebuild.** If opening a panel fails because its JavaScript or stylesheet is no
+longer available, BootUI keeps the current panel and shows **Reload BootUI**. Once the application is running, use that
+action to fetch the current UI and open the intended panel, including its route query and hash. Custom console mounts
+are preserved. Reloading discards unsaved input in the tab, so BootUI never does it automatically. If loading still
+fails, the alert remains available; there is no automatic retry, reload loop, or background connection probe.
+Ordinary panel/API errors keep their existing error handling.
+
 **Unavailable panels are visible, not hidden.** When a panel's backing infrastructure is missing, the sidebar moves it
 into a collapsed *Disabled / unavailable* group, and opening it shows the reason at the top of the page.
 


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

**Executive summary:** recover failed panel navigation after a backend/UI rebuild with an explicit **Reload BootUI** action, rather than leaving the browser stuck or blank.

The shared shell recognizes browser dynamic-import and Vite stylesheet-load failures through Vue Router. It retains the current view and unsaved input until the user explicitly reloads, then preserves the intended panel, document query, route query/hash, and custom UI mount. Initial/deep-link failures also show recovery. No automatic refresh, retries, connection probes, scans, or mutations are added; ordinary API/application errors keep their existing handling and remain observable.

Scope is restart/stale-route-asset recovery only. No Overview cached-report synchronization, backend/availability changes, dependency changes, or advisor scoring changes.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Closes #985

Reproduced against the pre-fix packaged MVC UI from main `9a009454a`: a controlled 404 for a not-yet-loaded `Hibernate-*.js` asset produces Chromium's `TypeError: Failed to fetch dynamically imported module`. Clicking Hibernate leaves HTTP Probe visible with no explanation or recovery. The regression failed against that baseline and passes with this change. This reproduces removed-build-asset behavior without touching the user's running application.

Reload is explicitly user-triggered because silently refreshing would discard unsaved input and can strand a tab while the server is stopped. If the current shell loads but the requested asset is still missing, recovery remains visible without a reload loop.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Targeted validation used JDK 17 and an isolated absolute Maven repository for builds and all app runs; MVC and Quarkus ran separately. No full reactor test rerun or conformance rerun: Java, HTTP contracts, and availability policy are unchanged.

| Command / scope | Result |
| --- | --- |
| `./mvnw -B -ntp -pl bootui-spring-sample-app,bootui-spring-webflux-sample-app,bootui-quarkus-sample-app -am install -DskipTests` | All 14 selected reactor modules built/installed successfully; includes UI production build and Quarkus augmentation |
| Frontend `npm test -- src/App.test.js src/utils/routeAssetRecovery.test.js src/utils/loadError.test.js src/accessibility.test.js src/designSystem.test.js` | 68 passed |
| Frontend `npm run build` | Passed, including Vue type checking |
| MVC `npm test -- stale-assets.spec.js app-shell.spec.js` | 21 passed; after adding responsive cases, final `npm test -- stale-assets.spec.js` passed 8/8 |
| Spring `npm run test:webflux` | 26 passed, including existing advisor scoring cases |
| Spring `npm run test:custom-path` | 39 passed; 1 existing MVC-only OTLP case intentionally skips on WebFlux; all 16 new recovery cases passed |
| Quarkus `npm test -- stale-assets.spec.js app-shell.spec.js` | 15 passed |
| `spotless:apply`, `spotless:check`; frontend and both E2E `format` / `format:check` | Passed |
| `npm run docs:build` | Blocked locally: missing VuePress; dependency restore failed on pinned `fast-uri@3.1.7` (configured feed 404, public-registry retry ENOTCONN). No manifests or registry configuration changed; hosted CI can validate the unchanged dependency setup. |

Eight shared browser scenarios exercise missing JS and CSS, explicit keyboard reload, retained unsent input, offline behavior, persistent failure, custom/deep-link preservation, and exclusion of API errors and module-evaluation bugs. The same scenarios run on MVC, WebFlux, Quarkus and both custom Spring mounts. Tests honor real WebFlux capability differences rather than mocking Hibernate as available. All owned sample processes have been stopped.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

Reuses the existing shell warning treatment and primary button; no new CSS or design assets. Browser cases assert one visible recovery alert and keyboard-reachable action in light at 1600px and dark at 390px, including viewport bounds.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed