### PR TITLE
Fix Overview synchronization with cached advisor reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Overview now discovers cached advisor reports from panel and agent scans.** Initial and return navigation read
+  supported, enabled advisors without starting scans or external queries. Incomplete findings remain visible without
+  invented scores, explicit `NOT_SCANNED` responses clear old scan display after a restart, and dismissal/restore
+  refreshes retain the existing in-flight scan protections ([#986](https://github.com/jdubois/boot-ui/issues/986)).
+
 - **Advisor browser coverage now distinguishes incomplete reports from numeric scores.** Live Spring and Quarkus
   scenarios retain findings and dismissal/restore assertions without requiring a score for `PARTIAL` results.
   Shared complete-report scenarios continue to verify exact dismissal and restore score changes across runtimes

--- a/bootui-quarkus-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/overview.spec.js
@@ -1,10 +1,15 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
-import {registerAdvisorScoringTests} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
+import {
+  registerAdvisorScoringTests,
+  stubUnscannedAdvisorReports
+} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
 
 registerAdvisorScoringTests(test, expect)
 
 test.describe('Overview view (Quarkus)', () => {
+  test.beforeEach(async ({page}) => stubUnscannedAdvisorReports(page))
+
   test('renders the panel header and the scanner dashboard', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 
@@ -40,7 +45,7 @@ test.describe('Overview view (Quarkus)', () => {
   test('does not run scanners until requested, then scores on demand', async ({openView, page}) => {
     await openView('overview', 'Overview')
 
-    // Nothing is scored on load.
+    // The cached reports are explicitly unscanned, independently of earlier tests' scans.
     await expect(page.locator('.overall-card').first()).toContainText('0 of')
 
     const architectureCard = page.locator('.scanner-card', {hasText: 'Architecture'})

--- a/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
+++ b/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
@@ -39,6 +39,40 @@ function architectureReport(status, dismissed = false) {
   }
 }
 
+function unscannedReport() {
+  return {
+    ...architectureReport('NOT_SCANNED'),
+    scan: {status: 'NOT_SCANNED', scannedAt: null},
+    severityCounts: [],
+    results: [],
+    violationsFound: 0,
+    rulesEvaluated: 0
+  }
+}
+
+/** @param {import('@playwright/test').Page} page */
+export async function stubUnscannedAdvisorReports(page, apiPath = '/bootui/api') {
+  for (const id of scannerIds.filter((id) => id !== 'github')) {
+    await page.route(`**${apiPath}/${id}`, (route) => route.fulfill({json: unscannedReport()}))
+  }
+}
+
+function hibernateReport() {
+  return {
+    ...architectureReport('PARTIAL'),
+    entityPackages: ['example.app'],
+    entitiesAnalyzed: 12,
+    rulesEvaluated: 70,
+    results: [
+      {
+        ...architectureReport('PARTIAL').results[0],
+        id: 'HIB-TEST-1',
+        name: 'Retained Hibernate finding'
+      }
+    ]
+  }
+}
+
 function vulnerabilityReport(dismissed, coverageStatus = 'COMPLETE') {
   return {
     total: 1,
@@ -100,6 +134,17 @@ function vulnerabilityReport(dismissed, coverageStatus = 'COMPLETE') {
 export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', apiPath = '/bootui/api'} = {}) {
   test.describe('Shared advisor scoring eligibility', () => {
     test.beforeEach(async ({page}) => {
+      await page.route(`**${apiPath}/architecture`, (route) => route.fulfill({json: unscannedReport()}))
+      await page.route(`**${apiPath}/vulnerabilities`, (route) =>
+        route.fulfill({
+          json: {
+            ...vulnerabilityReport(false),
+            scan: {status: 'NOT_SCANNED'},
+            severityCounts: [],
+            dependencies: []
+          }
+        })
+      )
       await page.route(`**${apiPath}/panels`, async (route) => {
         const response = await route.fetch()
         const body = await response.json()
@@ -112,12 +157,142 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       })
     })
 
-    test('retains incomplete findings and removes only their score from the aggregate', async ({page}) => {
-      let status = 'SCANNED'
+    for (const initialOverview of [false, true]) {
+      test(`discovers a Hibernate panel scan on ${initialOverview ? 'return' : 'first'} Overview navigation`, async ({
+        page
+      }) => {
+        let scanned = false
+        let reads = 0
+        const writes = []
+        page.on('request', (request) => {
+          if (request.method() === 'POST') writes.push(new URL(request.url()).pathname)
+        })
+        await page.route(`**${apiPath}/panels`, async (route) => {
+          const response = await route.fetch()
+          const body = await response.json()
+          body.panels = body.panels.map((panel) =>
+            scannerIds.includes(panel.id) ? {...panel, available: panel.id === 'hibernate', enabled: true} : panel
+          )
+          await route.fulfill({response, json: body})
+        })
+        await page.route(`**${apiPath}/hibernate{,/scan}`, async (route) => {
+          if (route.request().method() === 'POST') scanned = true
+          else reads++
+          await route.fulfill({json: scanned ? hibernateReport() : unscannedReport()})
+        })
+        const card = page.locator('.scanner-card').filter({hasText: 'Hibernate'})
+        if (initialOverview) {
+          await page.goto(`${uiPath}/#/overview`)
+          await expect(card).toContainText('Not scanned')
+          await expect(card.getByRole('button', {name: 'Run scan', exact: true})).toBeVisible()
+          expect(reads).toBe(1)
+          expect(writes).toEqual([])
+          await card.getByRole('link', {name: 'Open panel'}).click()
+        } else {
+          await page.goto(`${uiPath}/#/hibernate`)
+        }
+        await page.getByRole('button', {name: 'Run Hibernate checks', exact: true}).click()
+        await expect(page.getByText('Retained Hibernate finding', {exact: true})).toBeVisible()
+        await expect(page.locator('.advisor-score-card')).toContainText('Incomplete')
+        const readsBeforeReturn = reads
+        await page.locator('a[href$="#/overview"]').first().click()
+        await expect(card).toContainText('Incomplete')
+        await expect(card).toContainText('1 high')
+        await expect(card.locator('.scanner-score')).toHaveCount(0)
+        expect(reads).toBe(readsBeforeReturn + 1)
+        expect(writes).toEqual([`${apiPath}/hibernate/scan`])
+        // A restarted server explicitly reports no scan; old findings must disappear.
+        scanned = false
+        await card.getByRole('link', {name: 'Open panel'}).click()
+        await expect(page.locator('.advisor-score-card')).toContainText('Not scanned')
+        await page.locator('a[href$="#/overview"]').first().click()
+        await expect(card).toContainText('Not scanned')
+        await expect(card).not.toContainText('1 high')
+        await expect(card.getByRole('button', {name: 'Run scan', exact: true})).toBeVisible()
+        expect(writes).toEqual([`${apiPath}/hibernate/scan`])
+      })
+    }
+
+    test('waits for availability and reads only enabled advisors on a direct Overview load', async ({page}) => {
+      let releaseManifest
+      const manifestGate = new Promise((resolve) => {
+        releaseManifest = resolve
+      })
+      const advisorRequests = []
+      let manifests = 0
+      await page.route(`**${apiPath}/panels`, async (route) => {
+        manifests++
+        const response = await route.fetch()
+        const body = await response.json()
+        await manifestGate
+        body.panels = body.panels.map((panel) =>
+          scannerIds.includes(panel.id)
+            ? {...panel, available: ['architecture', 'hibernate'].includes(panel.id), enabled: panel.id !== 'hibernate'}
+            : panel
+        )
+        await route.fulfill({response, json: body})
+      })
+      page.on('request', (request) => {
+        const path = new URL(request.url()).pathname
+        if (scannerIds.some((id) => path === `${apiPath}/${id}` || path.startsWith(`${apiPath}/${id}/`)))
+          advisorRequests.push({path, method: request.method()})
+      })
+      await page.route(`**${apiPath}/architecture`, (route) => route.fulfill({json: architectureReport('SCANNED')}))
+      await page.goto(`${uiPath}/#/overview`)
+      await expect(page.locator('.panel-header')).toContainText('Run the advisors')
+      expect(advisorRequests).toEqual([])
+      releaseManifest()
+      const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
+      await expect(card.locator('.scanner-score')).toHaveText('90')
+      await expect(page.locator('.scanner-card')).toHaveCount(1)
+      expect(manifests).toBe(1)
+      expect(advisorRequests).toEqual([{path: `${apiPath}/architecture`, method: 'GET'}])
+    })
+
+    test('defers the return refresh until an in-flight first scan completes', async ({page}) => {
+      let releaseScan
+      const scanGate = new Promise((resolve) => {
+        releaseScan = resolve
+      })
+      let cached = unscannedReport()
+      let reads = 0
       let scans = 0
       await page.route(`**${apiPath}/architecture{,/scan}`, async (route) => {
-        if (route.request().method() === 'POST') scans++
-        await route.fulfill({json: architectureReport(status)})
+        if (route.request().method() === 'POST') {
+          scans++
+          await scanGate
+          cached = architectureReport('PARTIAL')
+        } else reads++
+        await route.fulfill({json: cached})
+      })
+      await page.goto(`${uiPath}/#/overview`)
+      const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
+      await expect(card).toContainText('Not scanned')
+      await card.getByRole('button', {name: 'Run scan', exact: true}).click()
+      await expect(card).toContainText('Scanning')
+      await card.getByRole('link', {name: 'Open panel'}).click()
+      await expect(page.locator('.advisor-score-card')).toContainText('Not scanned')
+      expect(reads).toBe(2)
+      await page.locator('a[href$="#/overview"]').first().click()
+      await expect(card).toContainText('Scanning')
+      expect(reads).toBe(2)
+      releaseScan()
+      await expect(card).toContainText('Incomplete')
+      await expect(card).toContainText('1 high')
+      await expect(card.locator('.scanner-score')).toHaveCount(0)
+      await expect.poll(() => reads).toBe(3)
+      expect(scans).toBe(1)
+    })
+
+    test('retains incomplete findings and removes only their score from the aggregate', async ({page}) => {
+      let status = 'NOT_SCANNED'
+      let scans = 0
+      await page.route(`**${apiPath}/architecture{,/scan}`, async (route) => {
+        if (route.request().method() === 'POST') {
+          scans++
+          if (scans === 1) status = 'SCANNED'
+        }
+        await route.fulfill({json: scans === 0 ? unscannedReport() : architectureReport(status)})
       })
       await page.goto(`${uiPath}/#/overview`)
       const overall = page.locator('.overall-card')
@@ -156,16 +331,25 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       })
       await page.goto(`${uiPath}/#/architecture`)
       await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+      const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
+      await page.locator('a[href$="#/overview"]').first().click()
+      await expect(card.locator('.scanner-score')).toHaveText('90')
+      await card.getByRole('link', {name: 'Open panel'}).click()
       await page.getByRole('button', {name: /Dismiss$/}).click()
       await expect(page.locator('.list-group-item.opacity-50')).toContainText('ARCH-TEST-1')
       await expect(page.locator('.advisor-summary__dismissed')).toContainText(
         '1 dismissed rule(s) excluded from this score'
       )
       await expect(page.locator('.advisor-summary__value')).toHaveText('100')
+      await page.locator('a[href$="#/overview"]').first().click()
+      await expect(card.locator('.scanner-score')).toHaveText('100')
+      await card.getByRole('link', {name: 'Open panel'}).click()
       await page.getByRole('button', {name: /Restore$/}).click()
       await expect(page.locator('.list-group-item.opacity-50')).toHaveCount(0)
       await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
       await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+      await page.locator('a[href$="#/overview"]').first().click()
+      await expect(card.locator('.scanner-score')).toHaveText('90')
       expect(scans).toBe(0)
     })
 
@@ -185,7 +369,6 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       const card = page.locator('.scanner-card').filter({hasText: 'Vulnerabilities'})
       await expect(card).toBeVisible()
       expect(scans).toBe(0)
-      await card.getByRole('button', {name: 'Run scan', exact: true}).click()
       await expect(card).toContainText('Active findings have unknown severity')
       await expect(card).toContainText('1 unknown')
       await card.getByRole('link', {name: 'Open panel'}).click()
@@ -211,7 +394,7 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
         await page.locator('a[href$="#/overview"]').first().click()
         await expect(card.locator('.scanner-score')).toHaveCount(0)
       }
-      expect(scans).toBe(1)
+      expect(scans).toBe(0)
     })
 
     for (const [theme, width] of [
@@ -228,6 +411,12 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
         await expect(summary).toContainText('no score is calculated')
         await expect(summary.locator('[role="img"]')).toHaveCount(0)
         await expect(page.getByText('Retained architecture finding', {exact: true})).toBeVisible()
+        if (Number(width) < 992) await page.getByRole('button', {name: 'Open navigation menu'}).click()
+        await page.locator('a[href$="#/overview"]').first().click()
+        const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
+        await expect(card).toContainText('Incomplete')
+        await expect(card).toContainText('1 high')
+        await expect(card.locator('.scanner-score')).toHaveCount(0)
         expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
       })
     }

--- a/bootui-spring-sample-app/e2e/tests/overview.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/overview.spec.js
@@ -1,10 +1,12 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
-import {registerAdvisorScoringTests} from '../scenarios/advisor-scoring.js'
+import {registerAdvisorScoringTests, stubUnscannedAdvisorReports} from '../scenarios/advisor-scoring.js'
 
 registerAdvisorScoringTests(test, expect)
 
 test.describe('Overview view', () => {
+  test.beforeEach(async ({page}) => stubUnscannedAdvisorReports(page))
+
   test('renders the panel header and the scanner dashboard', async ({openView}) => {
     const page = await openView('overview', 'Overview')
 
@@ -29,7 +31,7 @@ test.describe('Overview view', () => {
   test('does not run scanners until requested, then scores on demand', async ({openView, page}) => {
     await openView('overview', 'Overview')
 
-    // Nothing is scored on load.
+    // The cached reports are explicitly unscanned, independently of earlier tests' scans.
     await expect(page.locator('.overall-card').first()).toContainText('0 of')
 
     const architectureCard = page.locator('.scanner-card', {hasText: 'Architecture'})

--- a/bootui-ui/src/main/frontend/src/views/Overview.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Overview.test.js
@@ -32,7 +32,7 @@ function stubFetch(handlers) {
     vi.fn((input) => {
       const url = typeof input === 'string' ? input : input.url
       const match = Object.keys(handlers).find((key) => url.includes(key))
-      const body = match ? handlers[match] : {}
+      const body = match ? handlers[match] : severityReport([], 'NOT_SCANNED')
       return Promise.resolve(new Response(JSON.stringify(body), {status: 200}))
     })
   )
@@ -175,10 +175,184 @@ describe('Overview', () => {
     stubFetch(fetchHandlers)
     const wrapper = mountOverview(allPanels)
     await flushPromises()
-    // No POST scan endpoint should have been hit on mount; only panels/overview reads.
+    // Cached report reads are safe; neither scans nor GitHub refreshes run on mount.
     const calls = fetch.mock.calls.map((call) => call[0])
     expect(calls.some((url) => String(url).includes('/scan'))).toBe(false)
+    expect(calls.some((url) => String(url).includes('api/github'))).toBe(false)
     expect(wrapper.text()).toContain('Run all scanners')
+  })
+
+  it('reads every supported cached advisor once on initial KeepAlive activation', async () => {
+    stubFetch(Object.fromEntries(onlyPanels().panels.map(({id}) => [`api/${id}`, severityReport([])])))
+    const {wrapper} = mountKeptAlive({
+      panels: onlyPanels().panels.map((panel) => ({...panel, available: true, enabled: true}))
+    })
+    await flushPromises()
+    expect(fetch.mock.calls.map(([url]) => url).sort()).toEqual(
+      onlyPanels()
+        .panels.filter(({id}) => id !== 'github')
+        .map(({id}) => `api/${id}`)
+        .sort()
+    )
+    expect(fetch.mock.calls.every(([, init]) => !init?.method)).toBe(true)
+    expect(wrapper.text()).toContain('9 of 10 scanners scored')
+  })
+
+  it.each(['SCANNED', 'PARTIAL', 'ERROR', 'DISABLED', 'NOT_SCANNED'])(
+    'loads an existing %s report on a direct Overview mount without rescanning',
+    async (status) => {
+      stubFetch({'api/hibernate': severityReport([{severity: 'HIGH', count: 1}], status)})
+      const wrapper = mountOverview(onlyPanels('hibernate'))
+      await flushPromises()
+      const card = scannerCard(wrapper, 'Hibernate')
+      expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/hibernate'])
+      expect(card.text()).toContain('1 high')
+      expect(card.find('.scanner-score').exists()).toBe(status === 'SCANNED')
+      if (status === 'SCANNED') expect(card.find('.scanner-score').text()).toBe('90')
+      if (status === 'PARTIAL') expect(card.text()).toContain('Incomplete')
+      if (status === 'NOT_SCANNED') {
+        expect(card.props('state')).toBe('idle')
+        expect(card.find('button').text()).toBe('Run scan')
+      }
+    }
+  )
+
+  it('discovers a panel-originated report on return without a prior Overview scan', async () => {
+    const handlers = {'api/hibernate': severityReport([], 'NOT_SCANNED')}
+    stubFetch(handlers)
+    const {wrapper, show} = mountKeptAlive(onlyPanels('hibernate'))
+    await flushPromises()
+    expect(scannerCard(wrapper, 'Hibernate').props('state')).toBe('idle')
+    show.value = false
+    await flushPromises()
+    handlers['api/hibernate'] = severityReport([{severity: 'HIGH', count: 1}], 'PARTIAL')
+    show.value = true
+    await flushPromises()
+    const card = scannerCard(wrapper, 'Hibernate')
+    expect(card.text()).toContain('Incomplete')
+    expect(card.text()).toContain('1 high')
+    expect(card.find('.scanner-score').exists()).toBe(false)
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/hibernate', 'api/hibernate'])
+  })
+
+  it('waits for the shell manifest and skips disabled, unavailable, and unknown endpoints', async () => {
+    stubFetch({'api/hibernate': severityReport([])})
+    const panels = ref(null)
+    const {wrapper} = mountKeptAlive(panels)
+    await flushPromises()
+    expect(fetch).not.toHaveBeenCalled()
+    panels.value = {
+      panels: [
+        {id: 'hibernate', available: true, enabled: true},
+        {id: 'architecture', available: true, enabled: false},
+        {id: 'memory', available: false, enabled: true}
+      ]
+    }
+    await flushPromises()
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/hibernate'])
+    expect(scannerCard(wrapper, 'Architecture')).toBeUndefined()
+    expect(scannerCard(wrapper, 'Memory')).toBeUndefined()
+  })
+
+  it('defers discovery when the manifest arrives while Overview is inactive', async () => {
+    stubFetch({'api/hibernate': severityReport([])})
+    const panels = ref(null)
+    const {show} = mountKeptAlive(panels)
+    await flushPromises()
+    show.value = false
+    await flushPromises()
+    panels.value = onlyPanels('hibernate')
+    await flushPromises()
+    expect(fetch).not.toHaveBeenCalled()
+    show.value = true
+    await flushPromises()
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/hibernate'])
+  })
+
+  it('loads standalone availability before reading reports and surfaces manifest failures with retry', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve(new Response('{}', {status: 503})))
+    )
+    const wrapper = mount(Overview, {global: {stubs: {RouterLink: true}}})
+    await flushPromises()
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/panels'])
+    expect(wrapper.get('[role="alert"]').text()).toContain('Unable to load panel availability')
+    stubFetch({'api/panels': onlyPanels('hibernate'), 'api/hibernate': severityReport([])})
+    await wrapper.get('[role="alert"] button').trigger('click')
+    await flushPromises()
+    expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/panels', 'api/hibernate'])
+    expect(wrapper.find('[role="alert"]').exists()).toBe(false)
+    expect(scannerCard(wrapper, 'Hibernate').find('.scanner-score').text()).toBe('100')
+  })
+
+  it('surfaces an initial cached report failure without claiming to have a previous report', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.reject(new TypeError('offline')))
+    )
+    const wrapper = mountOverview(onlyPanels('hibernate'))
+    await flushPromises()
+    const card = scannerCard(wrapper, 'Hibernate')
+    expect(card.text()).toContain('Unable to refresh Hibernate')
+    expect(card.text()).not.toContain('last report')
+    expect(card.find('.scanner-score').exists()).toBe(false)
+  })
+
+  it.each(['response', 'failure'])('ignores a stale initial GET %s after a newer explicit scan', async (outcome) => {
+    document.cookie = 'XSRF-TOKEN=test-token; path=/'
+    let resolveRead
+    let rejectRead
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url, init) => {
+        if (init?.method === 'POST')
+          return Promise.resolve(new Response(JSON.stringify(severityReport([{severity: 'HIGH', count: 1}]))))
+        return new Promise((resolve, reject) => {
+          resolveRead = resolve
+          rejectRead = reject
+        })
+      })
+    )
+    const wrapper = mountOverview(onlyPanels('architecture'))
+    await flushPromises()
+    scannerCard(wrapper, 'Architecture').vm.$emit('run')
+    await flushPromises()
+    expect(architectureScore(wrapper)).toBe('90')
+    expect(fetch).toHaveBeenCalledTimes(2)
+    if (outcome === 'response') resolveRead(new Response(JSON.stringify(severityReport([], 'NOT_SCANNED'))))
+    else rejectRead(new TypeError('offline'))
+    await flushPromises()
+    expect(architectureScore(wrapper)).toBe('90')
+    expect(scannerCard(wrapper, 'Architecture').props('state')).toBe('done')
+    expect(wrapper.text()).not.toContain('Unable to refresh')
+  })
+
+  it('ignores a slower cached GET after returning to a newer panel report', async () => {
+    let finishRead
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              finishRead = resolve
+            })
+        )
+        .mockResolvedValueOnce(new Response(JSON.stringify(severityReport([{severity: 'HIGH', count: 1}], 'PARTIAL'))))
+    )
+    const {wrapper, show} = mountKeptAlive(onlyPanels('architecture'))
+    await flushPromises()
+    show.value = false
+    await flushPromises()
+    show.value = true
+    await flushPromises()
+    finishRead(new Response(JSON.stringify(severityReport([]))))
+    await flushPromises()
+    expect(scannerCard(wrapper, 'Architecture').text()).toContain('Incomplete')
+    expect(scannerCard(wrapper, 'Architecture').text()).toContain('1 high')
+    expect(wrapper.text()).toContain('0 of 1 scanners scored')
   })
 
   it('computes a score after running a scanner on demand', async () => {
@@ -295,7 +469,7 @@ describe('Overview', () => {
             new Response(JSON.stringify(busy), {status: 409, headers: {'Content-Type': 'application/json'}})
           )
         }
-        return Promise.resolve(new Response('{}', {status: 200}))
+        return Promise.resolve(new Response(JSON.stringify(severityReport([], 'NOT_SCANNED')), {status: 200}))
       })
     )
     const wrapper = mountOverview({
@@ -490,8 +664,7 @@ describe('Overview', () => {
     })
     await flushPromises()
 
-    const runButton = wrapper.findAll('button').find((button) => button.text().includes('Run scan'))
-    await runButton.trigger('click')
+    scannerCard(wrapper, 'Architecture').vm.$emit('run')
     await flushPromises()
     expect(architectureScore(wrapper)).toBe('90')
     expect(wrapper.text()).toContain('1 high')
@@ -562,9 +735,7 @@ describe('Overview', () => {
     vi.stubGlobal('fetch', fetchMock)
     const {wrapper, show} = mountKeptAlive(onlyPanels('vulnerabilities'))
     await flushPromises()
-    expect(fetchMock).not.toHaveBeenCalled()
-    scannerCard(wrapper, 'Vulnerabilities').vm.$emit('run')
-    await flushPromises()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(wrapper.text()).toContain('0 of 1 scanners scored')
     for (const [unknown, score] of [
       [0, '90'],
@@ -584,8 +755,8 @@ describe('Overview', () => {
       if (score) expect(card.find('.scanner-score').text()).toBe(score)
       expect(card.text()).toContain('1 high')
     }
-    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(1)
-    expect(fetchMock.mock.calls.filter(([url, init]) => url === 'api/vulnerabilities' && !init?.method)).toHaveLength(3)
+    expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(0)
+    expect(fetchMock.mock.calls.filter(([url, init]) => url === 'api/vulnerabilities' && !init?.method)).toHaveLength(4)
   })
 
   it('preserves a cached score on transport failure, then accepts an unscanned GET report', async () => {
@@ -616,6 +787,9 @@ describe('Overview', () => {
     show.value = true
     await flushPromises()
     expect(scannerCard(wrapper, 'Architecture').find('.scanner-score').exists()).toBe(false)
+    expect(scannerCard(wrapper, 'Architecture').props('state')).toBe('idle')
+    expect(scannerCard(wrapper, 'Architecture').text()).not.toContain('1 high')
+    expect(scannerCard(wrapper, 'Architecture').text()).not.toContain('Showing the last report')
     expect(wrapper.text()).toContain('0 of 1 scanners scored')
   })
 
@@ -644,14 +818,14 @@ describe('Overview', () => {
     await flushPromises()
     show.value = true
     await flushPromises()
-    expect(fetch.mock.calls.filter(([, init]) => !init?.method)).toHaveLength(0)
+    expect(fetch.mock.calls.filter(([, init]) => !init?.method)).toHaveLength(1)
     expect(wrapper.text()).toContain('Scanning')
     cachedStatus = 'PARTIAL'
     finishScan(new Response(JSON.stringify(severityReport([], cachedStatus))))
     await flushPromises()
     expect(wrapper.text()).toContain('Incomplete')
     expect(wrapper.text()).toContain('0 of 1 scanners scored')
-    expect(fetch.mock.calls.filter(([, init]) => !init?.method)).toHaveLength(1)
+    expect(fetch.mock.calls.filter(([, init]) => !init?.method)).toHaveLength(2)
   })
 
   it.each(['PARTIAL', 'ERROR', 'DISABLED'])(

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -1,7 +1,8 @@
 <script setup>
-import {actionBusyMessage, apiFetch, getJson, isActionBusyError} from '../api.js'
+import {actionBusyMessage, getJson, isActionBusyError} from '../api.js'
 import {getBootUiApplicationPath} from '../utils/bootUiPath.js'
-import {computed, inject, onActivated, onMounted, reactive, ref} from 'vue'
+import {computed, inject, onActivated, onDeactivated, onMounted, reactive, ref, watch} from 'vue'
+import {createPanelLookup} from '../utils/panelNavigation.js'
 import {describeLoadError} from '../utils/loadError.js'
 import {scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {
@@ -19,17 +20,15 @@ import SpinnerButton from './components/SpinnerButton.vue'
 const injectedPanels = inject('panels', null)
 const applicationPath = getBootUiApplicationPath()
 
-// Locally fetched panel availability when the shell has not provided it yet.
+// Standalone mounts fetch availability; the application shell owns its injected manifest.
 const localPanels = ref(null)
-const panelLookup = computed(() => {
-  const source = injectedPanels?.value?.panels ?? localPanels.value?.panels ?? []
-  return new Map(source.map((panel) => [panel.id, panel]))
-})
+const panelsError = ref(null)
+const panelLookup = computed(() => createPanelLookup(injectedPanels?.value ?? localPanels.value))
 
 function panelAvailable(id) {
   const panel = panelLookup.value.get(id)
   // Treat unknown panels as available so the dashboard degrades gracefully.
-  return !panel || panel.available !== false
+  return !panel || (panel.available !== false && panel.enabled !== false)
 }
 
 const platform = computed(() => injectedPanels?.value?.platform ?? localPanels.value?.platform ?? 'spring-boot')
@@ -170,7 +169,7 @@ function applyReport(def, state, report) {
   const status = report?.scan?.status
   state.statusLabel = scanStatusLabel(status)
   state.statusTone = scanStatusBadgeClass(status)
-  state.state = 'done'
+  state.state = status === 'NOT_SCANNED' ? 'idle' : 'done'
   state.error = null
   state.warning = validSummary ? null : 'The report has an invalid severity summary. Its counts cannot be displayed.'
 }
@@ -205,10 +204,11 @@ async function runScanner(def) {
 // The dashboard is kept alive (App.vue wraps it in <keep-alive include="Overview">), so its
 // scores survive navigation. Dismissing/restoring an advisor rule in a panel changes that
 // advisor's server-side score, which would otherwise leave the dashboard showing a stale value.
-// Refresh observed reports even when unscoreable: dismissing UNKNOWN can restore eligibility.
+// Discover panel/agent-originated reports too, even when unscoreable: dismissing UNKNOWN
+// can restore eligibility. Only read endpoints confirmed by the panel manifest.
 async function refreshScanner(def) {
   const state = scanners[def.id]
-  if (!def.reportEndpoint || !state.hasReport) return
+  if (!def.reportEndpoint || !panelLookup.value.has(def.id) || !panelAvailable(def.id)) return
   // A cached GET during a scan still contains the previous report, not a newer assessment.
   if (state.state === 'running') {
     pendingRefreshes.add(def.id)
@@ -222,7 +222,7 @@ async function refreshScanner(def) {
   } catch (e) {
     if (token !== requestTokens[def.id]) return
     state.state = 'error'
-    state.error = describeLoadError(e, `Unable to refresh ${displayTitle(def)}; showing the last report`).message
+    state.error = describeLoadError(e, `Unable to refresh ${displayTitle(def)}`).message
   }
 }
 
@@ -325,17 +325,30 @@ async function runAll() {
 }
 
 async function ensurePanels() {
-  if (injectedPanels?.value?.panels || localPanels.value) return
+  if (injectedPanels || localPanels.value) return
+  panelsError.value = null
   try {
-    const res = await apiFetch('api/panels')
-    if (res.ok) localPanels.value = await res.json()
-  } catch {
-    // Availability is best-effort; missing data simply shows every scanner card.
+    localPanels.value = await getJson('api/panels')
+  } catch (e) {
+    panelsError.value = describeLoadError(e, 'Unable to load panel availability').message
   }
 }
 
-onMounted(ensurePanels)
-onActivated(refreshScores)
+const active = ref(false)
+onMounted(() => {
+  active.value = true
+  ensurePanels()
+})
+onActivated(() => (active.value = true))
+onDeactivated(() => (active.value = false))
+// Mount and initial KeepAlive activation share one refresh, after availability is known.
+watch(
+  [active, panelLookup],
+  ([isActive]) => {
+    if (isActive) refreshScores()
+  },
+  {flush: 'post'}
+)
 </script>
 
 <template>
@@ -353,6 +366,11 @@ onActivated(refreshScores)
         </a>
       </template>
     </PanelHeader>
+
+    <div v-if="panelsError" class="alert alert-danger" role="alert">
+      {{ panelsError }}
+      <button type="button" class="btn btn-sm btn-outline-danger ms-2" @click="ensurePanels">Retry</button>
+    </div>
 
     <div class="row gx-3 gy-4 mb-4">
       <div class="col-12">

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -32,8 +32,8 @@ visible and shows the conflict as a warning. Different scanners remain independe
 Every advisor finding can be **dismissed** when it does not apply to your project. Each rule result carries a _Dismiss_
 button; dismissing moves the rule into a collapsed "Dismissed rules" list and excludes it from the panel's finding
 count, severity bars, advisor score, and the weighted Overview score. The panel's score recomputes immediately, and the
-Overview dashboard re-reads previously observed reports when you return to it, without rescanning, so a dismissal or
-restore updates both the score and eligibility in both places.
+Overview dashboard reads cached reports on initial navigation and when you return to it, without rescanning, so a
+panel-originated scan, dismissal, or restore updates both the score and eligibility in both places.
 Rules can be restored at any time from that list.
 
 ::: details Where dismissals are stored

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -5,7 +5,9 @@
 The Overview panel is BootUI's landing page: a guided "understand your app in minutes" dashboard rather than a static
 summary. It opens with the standard panel header and a link to the running application's homepage.
 
-Its centrepiece is an **on-demand security and health scoring dashboard**. Nothing is scanned on load. Before any scan
+Its centrepiece is an **on-demand security and health scoring dashboard**. Nothing is scanned on load. Overview reads
+the existing cached reports on initial navigation and when you return from another panel, including scans started in
+an advisor panel or by a local agent. These GET requests never start a scan, probe, or external query. Before any scan
 has run the overall-score card stays honest — it shows how many scanners have been scored and a prompt to run them,
 rather than an empty gauge.
 
@@ -27,10 +29,13 @@ alerts, but only when the credential is connected and authenticated.
 
 The overall score, scored count, and contribution breakdown include only scanners that actually scored. The available
 scanner total does not shrink when a report is incomplete: "2 of 4 scanners scored" means the mean covers two
-assessments, not that all four passed. Only scanners whose panels are available for this application are shown.
-Returning from a panel refreshes previously observed reports with GET requests, including Vulnerabilities after
+assessments, not that all four passed. Disabled and unavailable panels are excluded; automatic reads wait for the
+panel manifest and only use supported, enabled advisor endpoints.
+Returning from a panel refreshes cached reports with GET requests, including Vulnerabilities after
 dismissal or restoration. A busy or failed request retains the last accepted report with a warning or error; an
-authoritative new incomplete/failed report replaces its old score.
+authoritative new incomplete/failed report replaces its old score. A `NOT_SCANNED` response, such as after an application
+restart, replaces the old findings and returns the card to **Run scan**. An Overview scan already in progress finishes
+before the return-navigation refresh reads its updated report.
 
 The panel is fully available on every adapter. The scoring dashboard is rendered entirely in the browser: the shell
 aggregates each advisor's own scan endpoints and computes the same combined score, so no backend dashboard service is


### PR DESCRIPTION
## Executive summary

Overview now discovers reports already produced by advisor panels or local agents, on both initial navigation and return navigation. It waits for the panel manifest, reads only supported/enabled cached endpoints, and never starts scans or external queries on load. This PR preserves the current scoring eligibility; partial-scoring policy and stale frontend-asset recovery are separate changes.

## What does this PR do?

<!-- One-sentence summary of the change. -->
Synchronizes Overview with cached advisor reports, including Hibernate PARTIAL findings, without requiring an Overview-originated scan first.

- Coalesces initial mount/KeepAlive activation and waits for the shell-owned manifest instead of fetching it twice.
- Preserves per-scanner request tokens and deferred refreshes so old GETs cannot overwrite newer scans or return-navigation reports.
- Treats explicit `NOT_SCANNED` responses as idle, replacing old findings/scores after a restart; initial read errors remain visible without claiming a previous report exists.
- Adds shared browser regressions for all three stacks and both independent custom mounts, plus focused unit cases and coupled documentation/changelog updates.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->
A successful Hibernate panel scan could leave Overview saying it had never scanned: the refresh path required `hasReport`, which only an Overview-originated scan set. Existing PARTIAL evidence was therefore hidden even though the cached endpoint retained it.

Closes #986

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused validation used Java 17 and the worktree-isolated Maven repository for both installation and app runs:

| Validation | Result |
| --- | --- |
| `./mvnw -B -ntp -pl bootui-spring-sample-app,bootui-spring-webflux-sample-app,bootui-quarkus-sample-app -am -DskipTests install` | 14-module build passed |
| Frontend `npm test -- --run src/views/Overview.test.js src/views/components/ScannerScoreCard.test.js src/utils/scannerScore.test.js` | 82 passed |
| Frontend `npm run build` | Passed, including Vue/TypeScript checking |
| MVC `npm test -- tests/overview.spec.js` | 15 passed |
| WebFlux `npm run test:webflux -- tests-webflux/advisor-scoring.spec.js` | 9 passed |
| Custom mounts `npm run test:custom-path -- --grep 'Shared advisor scoring eligibility'` | 18 passed, MVC and WebFlux |
| Quarkus `npm test -- tests/overview.spec.js` | 15 passed, local OSV fixture |
| Reactor `spotless:apply spotless:check`; frontend and both E2E projects `format` / `format:check` | Passed |

The shared scenarios cover panel-originated Hibernate scans on first/return navigation, initial cached reports with delayed availability, no automatic POSTs, disabled/unavailable endpoints, one manifest request, explicit `NOT_SCANNED` restart clearing, an in-flight first scan, exact complete-score dismissal/restore (`90 → 100 → 90`), UNKNOWN eligibility, and light/dark/mobile layouts. The initial mobile regression test needed to open the real navigation menu before using its Overview link; all final matrix runs pass without retries, skips, or weakened assertions.

Full reactor Java tests/conformance and full browser suites were not rerun: no backend/JSON contract changed, and validation targeted the affected UI behavior on each runtime.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->
No visual redesign. The existing cards now show the retained report/status; shared browser assertions exercise the same presentation in light desktop and dark mobile layouts.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed