### PR TITLE
Explain application assessment in the MCP Server panel

### DIFF
--- a/bootui-spring-sample-app/e2e/tests/mcp-server.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/mcp-server.spec.js
@@ -8,6 +8,26 @@ import {expect, test} from './fixtures.js'
  * alongside the suites that do.
  */
 test.describe('MCP Server client configuration', () => {
+  test('explains how to assess the application above client configuration', async ({openView}) => {
+    const page = await openView('mcp-server', 'MCP Server')
+
+    const assessment = page.getByRole('region', {name: 'Assess your application'})
+    await expect(assessment).toHaveCount(1)
+    await expect(assessment).toBeVisible()
+    await expect(assessment).toContainText('MCP prompt, not a tool')
+    await expect(assessment).toContainText('does not appear under Tools exposed')
+    await expect(assessment.getByRole('link', {name: 'BootUI agent skill'})).toHaveAttribute(
+      'href',
+      /AI-AGENTS\.html#install-the-bootui-agent-skill$/
+    )
+    await expect(assessment.locator('blockquote')).toContainText('ask before fresh scans')
+    await expect(assessment.locator('blockquote')).toContainText('until I approve specific actions')
+    await expect(assessment).toContainText('does not run scans or fixes')
+    expect(await assessment.evaluate((element) => element.nextElementSibling?.textContent)).toContain(
+      'Client configuration'
+    )
+  })
+
   test('offers one snippet per client and moves between them from the keyboard', async ({openView}) => {
     const page = await openView('mcp-server', 'MCP Server')
 

--- a/bootui-ui/src/main/frontend/src/views/McpServer.test.js
+++ b/bootui-ui/src/main/frontend/src/views/McpServer.test.js
@@ -88,6 +88,24 @@ describe('McpServer', () => {
     expect(wrapper.get('#mcp-enabled-toggle').element.checked).toBe(false)
   })
 
+  it('explains the assessment prompt above client configuration without invoking MCP', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(mcpStatus())))
+
+    wrapper = mount(McpServer)
+    await flushPromises()
+
+    const assessment = wrapper.get('section[aria-labelledby="mcp-assessment-heading"]')
+    expect(assessment.text()).toContain('MCP prompt, not a tool')
+    expect(assessment.text()).toContain('does not appear under Tools exposed')
+    expect(assessment.text()).toContain('Without prompt support')
+    expect(assessment.get('blockquote').text()).toContain('ask before fresh scans')
+    expect(assessment.get('blockquote').text()).toContain('until I approve specific actions')
+    expect(assessment.text()).toContain('does not run scans or fixes')
+    expect(assessment.element.nextElementSibling.textContent).toContain('Client configuration')
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith('api/mcp-server', {})
+  })
+
   it('posts the new state when the toggle is flipped', async () => {
     document.cookie = 'XSRF-TOKEN=test-token'
     const fetchMock = vi.fn().mockImplementation((url) => {

--- a/bootui-ui/src/main/frontend/src/views/McpServer.vue
+++ b/bootui-ui/src/main/frontend/src/views/McpServer.vue
@@ -265,6 +265,44 @@ const {autoRefresh, loading, load} = useAutoRefresh(fetchStatus, {enabled: manif
         </div>
       </div>
 
+      <section class="card mb-4" aria-labelledby="mcp-assessment-heading">
+        <div class="card-body p-4">
+          <h3 id="mcp-assessment-heading" class="h6 fw-bold mb-3">
+            <i class="bi bi-chat-left-text me-2" aria-hidden="true"></i>Assess your application
+          </h3>
+          <p class="small mb-2">
+            <code>assess_application</code> is an <strong>MCP prompt, not a tool</strong>, so it does not appear under
+            Tools exposed. It guides your coding agent to use the existing BootUI tools, gather runtime evidence, and
+            propose a prioritized action plan.
+          </p>
+          <p class="text-muted small mb-3">
+            Enable the server and connect your client using the configuration below. Then select
+            <code>assess_application</code> in a client that supports MCP prompts. Without prompt support, install the
+            <a
+              href="https://www.julien-dubois.com/boot-ui/AI-AGENTS.html#install-the-bootui-agent-skill"
+              target="_blank"
+              rel="noopener"
+              >BootUI agent skill</a
+            >
+            and send your agent this request:
+          </p>
+          <blockquote class="bg-light border rounded p-3 small mb-3">
+            Assess this application using BootUI. Start with existing evidence and ask before fresh scans. Give me a
+            prioritized, evidence-backed action plan, and do not modify anything until I approve specific actions.
+          </blockquote>
+          <p class="text-muted small mb-0">
+            Selecting the prompt only returns instructions; it does not run scans or fixes. Your external agent carries
+            out the workflow under its own permissions, not this panel.
+            <a
+              href="https://www.julien-dubois.com/boot-ui/AI-AGENTS.html#assess-an-application-and-approve-an-action-plan"
+              target="_blank"
+              rel="noopener"
+              >Assessment and approval guide</a
+            >.
+          </p>
+        </div>
+      </section>
+
       <!-- Client configuration -->
       <div class="card mb-4">
         <div class="card-body p-4">


### PR DESCRIPTION
## What does this PR do?

Adds an **Assess your application** section immediately above Client configuration in the MCP Server panel. It distinguishes the `assess_application` MCP prompt from tools, explains how to use it or the BootUI skill, provides a ready-to-use assessment request, and links to the assessment and approval guide.

## Why is this change needed?

Follow-up to #981. The assessment workflow is exposed as a prompt, not a tool, but the panel only lists tools. The missing explanation makes the workflow look unavailable. This documents the existing behavior without adding an assessment endpoint, triggering scans, or changing permissions.

## How was it tested?

- [ ] `./mvnw clean install` passes locally — not run; static shared-UI guidance only
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests — not applicable; no API changes
- [x] Started the Spring MVC sample app and loaded the updated Vue UI through Vite
- [x] Ran the affected Playwright suite: `tests/mcp-server.spec.js` (3 passing tests)
- [x] Added focused component and browser coverage for wording, placement, approval scope, and absence of MCP calls on render

The focused component, accessibility, design-system, and theme-contrast suites pass (76 tests). Repository Spotless apply/check and frontend/Spring E2E format/check pass. Desktop light/dark and mobile screenshots were inspected.

## Screenshots (UI changes)

![Assessment guidance above Client configuration in the MCP Server panel](https://github.com/user-attachments/assets/fec256cf-3a2e-42f5-8547-a157045a9ae1)

## Checklist

- [x] Existing documentation remains accurate; this surfaces its guidance in the panel without changing behavior
- [x] Public API kept backward compatible
- [x] No secrets, tokens, or local paths committed