### PR TITLE
Add a focused BootUI Java development skill

### DIFF
--- a/.github/agents/bootui-vertical-pr.agent.md
+++ b/.github/agents/bootui-vertical-pr.agent.md
@@ -9,7 +9,11 @@ You are the BootUI vertical-PR owner. Deliver one coherent change from investiga
 
 1. Read the repository instructions and every path-specific instruction file relevant to the files the task may touch.
    Read authoritative product, specification, WebFlux/Quarkus support, and design documents when behavior touches them.
-2. Inspect the current implementation and tests before proposing changes. Reuse existing services, SPI ports, DTOs, policies, and adapter patterns.
+2. For substantive Java implementation, debugging, refactoring, testing, or Maven failure diagnosis, invoke the
+   `bootui-java-development` skill before investigating. If the host cannot invoke repository skills, read
+   `.github/skills/bootui-java-development/SKILL.md` directly and load its references only as needed. Give Java
+   subagents the same instruction. Inspect the current implementation and tests before proposing changes. Reuse
+   existing services, SPI ports, DTOs, policies, and adapter patterns.
 3. Define the acceptance boundary: requested behavior, affected modules, public contract, framework availability, safety implications, and validation.
 4. For a complex or explicitly plan-first task, produce a concrete plan and wait when coordinator approval is requested. Otherwise continue autonomously after resolving only genuinely blocking ambiguity.
 5. Implement one focused vertical slice. Push semantics into the framework-neutral engine, keep bindings thin, and

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -64,3 +64,8 @@ worktree isolation.
 Detailed rules are path-scoped under `.github/instructions/` and apply automatically by file path. Two custom agents
 under `.github/agents/` are available: `bootui-vertical-pr` for end-to-end feature delivery, and `bootui-release` for
 conducting a release or changing release machinery. They supplement rather than replace repository safety rules.
+
+For substantive Java development or Maven failure diagnosis, load the `bootui-java-development` repository skill at
+`.github/skills/bootui-java-development/SKILL.md`. It covers investigation, reliable LSP use, focused validation, and
+on-demand change recipes. If the host cannot invoke skills, read that file directly. This develops BootUI itself;
+`skills/bootui/SKILL.md` is the separate consumer skill for installing and using BootUI in another application.

--- a/.github/skills/bootui-java-development/SKILL.md
+++ b/.github/skills/bootui-java-development/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: bootui-java-development
+description: Use when implementing, debugging, refactoring, or testing existing BootUI Java code, including framework-neutral engine logic, Spring MVC and WebFlux adapters, Quarkus runtime and deployment integration, optional dependencies, DTO contracts, and Maven build failures. Not for frontend-only work, creating unrelated applications, or release operations.
+---
+
+# BootUI Java development
+
+Use this skill for substantive Java maintenance in this repository. It provides an investigation and implementation
+workflow, not a replacement for repository instructions or a requirement to delegate work.
+
+Follow [repository instructions](../../copilot-instructions.md) and the relevant
+[path-scoped instructions](../../instructions/). Consult [the module map](../../../docs/REPOSITORY.md) when locating
+ownership. Build and delivery requirements remain authoritative in [CONTRIBUTING.md](../../../CONTRIBUTING.md) and,
+when selected, the [vertical-PR agent](../../agents/bootui-vertical-pr.agent.md).
+
+This skill develops BootUI itself. The separate [consumer skill](../../../skills/bootui/SKILL.md) teaches agents to
+install and use BootUI in another application. Dr JSkill's application-creation workflow is not required here.
+
+## 1. Establish the change boundary
+
+Read the request, working-tree changes, relevant implementation, and nearby tests before editing. Identify:
+
+- The behavior to preserve or change and a concrete regression or acceptance case.
+- The owning layer: core DTO/helper, engine policy/service, adapter observation/wiring, or public transport.
+- The affected stacks and consumers, including MCP/CLI where applicable. Read the support and specification documents
+  required by repository instructions before changing behavior; do not infer parity from a similarly named class.
+- The smallest validation that could disprove the proposed fix.
+
+For a simple lookup or local edit, use direct tools. For a larger task, delegate only independent scopes with explicit
+file ownership and acceptance boundaries. Tell Java subagents to load this skill; avoid concurrent Maven builds in
+the same worktree. Loading it does not authorize committing, publishing, or spawning additional sessions.
+
+## 2. Investigate with evidence
+
+Find the file using a known path or a narrow glob. Read the implementation and its tests together, then trace the
+relevant call chain. Search for an existing helper or SPI before adding one.
+
+Use Java LSP when it answers a semantic question:
+
+| Question | Operation |
+| --- | --- |
+| What type or overload is this? | `hover`, `goToDefinition` |
+| Which code consumes this symbol? | `findReferences`, `incomingCalls` |
+| Which classes implement this port? | `goToImplementation` |
+| What is the structure of this large file? | `documentSymbol` |
+| Where is a named symbol? | `workspaceSymbol` |
+| Which usages must change with this name? | `rename`, followed by diff review |
+
+Use the actual symbol position in the current file, not a guessed or pre-edit line number. Before relying on
+cross-module results, compare them with one known declaration or caller. An empty workspace search or references
+limited to the declaration's file do not establish absence. If results are suspect, use a narrow glob/text search
+across the expected modules and inspect the matching code. Do not repeatedly retry the same query or install a new
+language server as part of an unrelated fix.
+
+LSP is an aid, not a gate: continue with targeted searches when it is unavailable. A successful tool call or symbol
+outline proves neither complete indexing nor compilation. Semantic renames also require checking string-based
+registrations, resources, configuration keys, and public contracts that LSP cannot safely rename.
+
+## 3. Implement the smallest complete change
+
+Load only the relevant section of [change recipes](references/change-recipes.md):
+
+- Extract shared behavior or add an SPI.
+- Change a DTO or a public response.
+- Fix an advisor's false positive or missing evidence.
+- Integrate an optional framework capability.
+
+Keep the regression case close to the behavior's owner. Prefer deterministic fixtures, fake providers, and controlled
+clocks to real network calls, host-dependent observations, sleeps, or an entire application context for pure logic.
+Exercise the failure and absence paths as well as the positive case. Wire every affected adapter; do not compensate
+for a missing binding with a silent fallback.
+
+## 4. Validate and debug deliberately
+
+Load [validation and debugging](references/validation.md) before choosing Maven commands. Start with the smallest
+relevant selection, then satisfy the required integration and delivery gates. Inspect reports to confirm that the
+intended tests and framework augmentation actually ran.
+
+When a run fails, classify the first actionable failure before editing: dependency resolution, compilation,
+framework bootstrap, assertion failure, or environment limitation. Preserve its diagnostic and reproduce it at the
+smallest useful scope. Do not respond to each failure with another full build or unrelated source changes.
+
+Review the final diff against the acceptance boundary and report any remaining blocker honestly. Do not claim
+compilation, cross-stack compatibility, or absence safety from an LSP response or a skipped test run.

--- a/.github/skills/bootui-java-development/references/change-recipes.md
+++ b/.github/skills/bootui-java-development/references/change-recipes.md
@@ -1,0 +1,82 @@
+# Change recipes
+
+Read only the recipe matching the task. Paths below are starting points, not a mandate to read entire modules or copy
+their implementation. Recheck the current code and tests before following an example.
+
+## Extract shared behavior or add an SPI
+
+First pin existing behavior with a regression case. Separate framework observation or execution from shared decisions,
+ordering, error handling, and DTO assembly. Define or reuse a neutral port and move policy into the engine without
+moving framework imports with it.
+
+The cache feature illustrates this boundary:
+
+- [CacheProvider](../../../../bootui-engine/src/main/java/io/github/jdubois/bootui/spi/CacheProvider.java) exposes native
+  topology and eviction primitives.
+- [CacheService](../../../../bootui-engine/src/main/java/io/github/jdubois/bootui/engine/cache/CacheService.java) owns
+  shared orchestration; [CacheServiceTests](../../../../bootui-engine/src/test/java/io/github/jdubois/bootui/engine/cache/CacheServiceTests.java)
+  use a fake provider to pin ordering, unavailable state, mutation races, and failures.
+- [SpringCacheProvider](../../../../bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/cache/SpringCacheProvider.java)
+  and [QuarkusCacheProvider](../../../../bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/cache/QuarkusCacheProvider.java)
+  keep native integration outside the engine.
+
+Find all constructor calls and registrations, including both Spring autoconfigurations and Quarkus producers and
+deployment registration. Test property-to-policy mapping and adapter discovery separately from pure engine behavior.
+Move behavioral tests with the implementation; retain native wiring tests. A cross-stack extraction also requires
+the conformance runs specified by repository instructions, even when the JSON is intended to stay unchanged.
+
+## Change a DTO or public response
+
+Trace record construction, serialization, all transport consumers, and availability/error responses before editing.
+Identify whether the change is internal or changes field names, null/empty behavior, ordering, types, or enum/status
+values on the wire. Do not add Jackson annotations to shared records to repair one adapter.
+
+Use [CoreDtoImmutabilityTests](../../../../bootui-core/src/test/java/io/github/jdubois/bootui/core/dto/CoreDtoImmutabilityTests.java)
+for defensive-copy behavior and
+[AbstractBootUiApiConformanceTest](../../../../bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java)
+for shared HTTP expectations. Extend the relevant contract assertions or fixture when existing coverage does not
+exercise the changed shape. Run that contract through all affected adapters; one serializer's unit test is not
+evidence of Jackson 2/3 parity.
+
+Check MCP descriptions/bindings, the generated CLI projection, UI consumption, and documentation when they expose the
+response. Follow their path-scoped instructions and the vertical-PR agent's integration checklist rather than
+maintaining another list of generation commands here.
+
+## Fix an advisor's false positive or missing evidence
+
+Write down the rule's claim and what observation would actually justify it. Distinguish a configured intent, a
+discovered declaration, and observed runtime behavior. Verify version-sensitive framework claims against the root
+POM's versions and primary documentation or source, not assumptions from another framework version.
+
+Create fixtures for a justified finding, a plausible counterexample, and unavailable or incomplete evidence. Unknown
+must not become healthy through zero clamping, an empty list, a broad catch, or default configuration inference.
+Preserve the advisor's established unavailable/partial/skipped semantics rather than inventing a new status.
+
+Inject controlled observations into the scanner or rule. For examples of deterministic scanner and collector
+fixtures, consult [MemoryScannerTests](../../../../bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java)
+and [MemoryCollectorTests](../../../../bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryCollectorTests.java).
+These are patterns, not a reason to change unrelated memory rules.
+
+When behavior changes, review rule identity, dismissal compatibility, severity, counts, assessment/scoring effects,
+and directly coupled advisor documentation. Test observation collection separately from rule evaluation so a perfect
+synthetic fixture cannot hide a broken adapter.
+
+## Integrate an optional framework capability
+
+Separate dependency absence from dependency present with no beans/resources, disabled policy, read-only policy, and
+genuine execution failure. State the expected result for each before implementing.
+
+For Spring, use the existing context-runner and classloader-filtering patterns, testing MVC and WebFlux wiring where
+supported. [HibernateAdvisorAbsenceTest](../../../../bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/hibernate/HibernateAdvisorAbsenceTest.java)
+is an entry point for optional-library absence. A missing-bean fixture alone does not prove classloading safety.
+
+For Quarkus, inspect capability-gated build steps and exclusion of classes importing optional APIs.
+[BootUiCacheProducer](../../../../bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/BootUiCacheProducer.java)
+illustrates isolated optional wiring. Use the
+[integration-test modules](../../../../bootui-quarkus-integration-tests/pom.xml): `base` omits optional extensions,
+while capability-specific modules exercise their presence. Use the production-mode fixture when production gating
+is affected; a dev/test application cannot prove that production stays dark.
+
+Verify both absent and present classpaths. Do not add the optional library to the shared engine or the absence fixture
+to make a failure disappear. Read the current adapter instructions for bean registration, capability gating, and
+availability requirements.

--- a/.github/skills/bootui-java-development/references/validation.md
+++ b/.github/skills/bootui-java-development/references/validation.md
@@ -1,0 +1,76 @@
+# Validation and debugging
+
+[CONTRIBUTING.md](../../../../CONTRIBUTING.md) owns build, formatting, conformance, and publishing commands.
+The [vertical-PR agent](../../../agents/bootui-vertical-pr.agent.md) defines its delivery gates. This guide helps choose
+the inner loop; it does not relax either source's requirements.
+
+## Establish the environment
+
+Run commands from the current worktree root using `./mvnw`. Check the JDK actually used by Maven with `./mvnw -version`
+before attributing toolchain failures to source changes. Read framework versions and active profile gates from the
+current POMs instead of pinning another copy in this skill.
+
+Use `-Dmaven.repo.local=.m2` consistently on Maven commands, including dependency installation and application runs.
+If the environment already configures an isolated repository, reuse it rather than overriding it. Do not edit global
+Maven settings or commit a repository override for worktree isolation. Keep builds sequential within a worktree;
+different worktrees must not overwrite one another's snapshot artifacts.
+
+Do not bootstrap dependencies speculatively. Resolve missing dependencies when a selected command reports them, and
+use the wrapper and repository's existing scripts rather than installing replacement tools.
+
+## Choose the test layer
+
+| Changed behavior | First useful scope | Additional evidence when affected |
+| --- | --- | --- |
+| Core helper or DTO | Relevant `bootui-core` tests | DTO collection invariants and serializer/HTTP contracts |
+| Engine service, rule, or SPI | Relevant `bootui-engine` tests with fake inputs/providers | Adapter mappings/wiring; cross-stack conformance for extraction or contract changes |
+| Spring observations or configuration | Relevant `bootui-spring-autoconfigure` tests | MVC and WebFlux context/absence tests and affected sample conformance runners |
+| Quarkus runtime/deployment integration | Relevant runtime/deployment unit tests | `base` and affected capability integration modules; production fixture for production gating |
+| Browser-facing API, MCP, or CLI | Owning Java tests and relevant transport conformance | Required browser suites, generated CLI contract, and coupled documentation |
+
+For an already installed current-worktree dependency graph, a concrete narrow example is:
+
+```bash
+./mvnw -B -ntp -Dmaven.repo.local=.m2 -pl bootui-engine test \
+  -Dtest=MemoryScannerTests,MemoryCollectorTests
+```
+
+Substitute existing test classes that cover the actual change. Combine related selectors using the same runner in
+one invocation. Do not run these memory tests for unrelated work.
+
+If upstream worktree modules are missing or changed, use the appropriate `-pl ... -am install` command from
+CONTRIBUTING, with the same isolated repository, before rerunning the owning module. Installing only an unchanged
+consumer against stale dependencies does not validate an engine or DTO edit.
+
+When intentionally combining a test selector with `-am`, Surefire may fail in upstream modules that contain none of
+the selected classes. Only for that case, `-Dsurefire.failIfNoSpecifiedTests=false` can allow upstream modules through.
+Confirm the selected classes actually ran in the target module; otherwise the result is not evidence. Never use this
+flag to conceal a misspelled selector or substitute `-DskipTests` for validation.
+
+## Confirm execution, not just exit status
+
+Inspect the reactor summary and the relevant module's `target/surefire-reports` (or Failsafe reports if its POM uses
+Failsafe). Confirm the reports belong to the current run, include the intended classes, and did not skip the behavior
+being claimed.
+
+Quarkus integration needs actual augmentation and application bootstrap, not only compilation of the extension.
+Consult the current JDK gates in the POMs and Quarkus instructions; a green run on a JDK that skips augmentation does
+not prove adapter behavior. Use a supported installed JDK, or report the missing evidence as a blocker rather than
+changing the gate.
+
+After the narrow regression passes, run the broader gates required by the affected contract and delivery workflow.
+Do not launch every sample, browser suite, or the coverage reactor for each intermediate edit.
+
+## Diagnose the first actionable failure
+
+| Failure | Next action |
+| --- | --- |
+| Artifact resolution | Check selected reactor, isolated repository, upstream installation, and the reported network error before changing Java |
+| `compile` or `testCompile` | Read the first compiler diagnostic and surrounding source; fix imports, signatures, syntax, or API-version mismatch in the owning layer |
+| Spring context or Quarkus augmentation | Inspect the first causal exception; check registration, optional class linkage, capability gating, and dependency versions |
+| Test assertion | Reproduce with the smallest selector; decide whether implementation or expectation violates the intended contract |
+| Timeout or environment problem | Identify the specific process/resource or missing prerequisite; preserve diagnostics and report limits without weakening assertions |
+
+Add or strengthen a regression test for a behavioral defect. After fixing a failure, rerun the failed selection and
+then its affected integration boundary. An LSP outline, stale report, skipped suite, or successful parent POM is not
+a substitute. Keep useful diagnostics in the session artifact directory; do not add scratch logs to the repository.


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Adds a repository-local `bootui-java-development` skill for maintaining BootUI's existing Java code, with on-demand change recipes and validation guidance.

The compact entry point covers evidence-driven investigation and reliable LSP use. Supporting references cover engine/SPI extraction, DTO contracts, advisor accuracy, optional dependencies, and targeted Maven debugging. Existing repository instructions remain authoritative rather than being duplicated.

Two existing instruction files explicitly activate the skill for substantive Java work: repository guidance and the `bootui-vertical-pr` agent, including its Java subagents. Hosts without skill invocation can read the entry point directly.

**Scope: five agent/skill Markdown files only. No application code, UI fixes, build configuration, or runtime behavior changes.** Dr JSkill and the existing BootUI consumer skill are unchanged.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

Recent BootUI work showed that a project-creation skill was not being invoked for existing-project Java maintenance, while LSP was underused and sometimes treated as stronger evidence than its results supported. This skill provides a repository-specific workflow and explicit activation without adding another agent or tool dependency.

N/A - no linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally - not run; agent-instruction-only change.
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests - N/A.
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082 - N/A.
- [ ] Ran the affected Playwright suite(s) for browser-facing changes - N/A.
- [x] Added or updated tests where applicable - no runtime tests needed; checked skill metadata, activation paths, whitespace, and all 22 local Markdown links.

Passed `./mvnw -B -ntp -Dmaven.repo.local=.m2 spotless:apply spotless:check` across the reactor and `git diff --check`. After synchronizing with `main`, the focused Overview and MCP Server frontend suites also passed (57 tests); those upstream UI changes are not part of this PR.

Skill discovery and activation in a fresh agent session have not been exercised yet.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

N/A - no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes - N/A; development guidance lives with the skill and no product behavior changes.
- [x] Public API kept backward compatible, or a migration note added to the PR description - unchanged.
- [x] No secrets, tokens, or local paths committed