### PR TITLE
feat(advisors): score usable partial assessments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- **Usable partial advisor assessments now retain their numeric scores.** This deliberately replaces complete-only
+  gating: confirmed findings and completed applicable checks still count when other evidence is missing. Shared
+  evidence facts distinguish actual assessments from attempted or skipped checks; vulnerability package evidence
+  separates query completion from successful advisory interpretation. Panels and Overview show **Partial assessment**,
+  qualify high scores as applying only to evaluated evidence, retain UNKNOWN findings and coverage explanations, and
+  mark the arithmetic-mean aggregate partial when such scores contribute. Weights, backend statuses, findings,
+  dismissal behavior and explicit-scan boundaries remain unchanged
+  ([#989](https://github.com/jdubois/boot-ui/issues/989)).
+
 - **Database advisor findings now distinguish incomplete evidence from absence.** Qualified JDBC metadata,
   index/constraint semantics, vendor generator bounds and database-side mapping comparisons are reviewed more
   conservatively. Four unsupported rules are retired without reusing their IDs, and SQL text variation is a

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/AbstractBootUiApiConformanceTest.java
@@ -861,6 +861,11 @@ public abstract class AbstractBootUiApiConformanceTest {
         assertThat(report.path("dependencies").isArray())
                 .as("$.dependencies must be an array")
                 .isTrue();
+        for (JsonNode dependency : report.path("dependencies")) {
+            assertThat(dependency.path("assessmentComplete").isBoolean())
+                    .as("$.dependencies[*].assessmentComplete must be a boolean")
+                    .isTrue();
+        }
         assertThat(report.path("total").isInt())
                 .as("$.total must be an integer")
                 .isTrue();

--- a/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiApiContractCatalog.java
+++ b/bootui-conformance/src/main/java/io/github/jdubois/bootui/conformance/BootUiApiContractCatalog.java
@@ -396,22 +396,34 @@ public final class BootUiApiContractCatalog {
     }
 
     private static ReadContract advisor(String panelId, String path, String resultField) {
-        return read(
-                panelId,
-                path,
-                fields(
-                        "localOnly",
-                        JsonType.BOOLEAN,
-                        "disclaimer",
-                        JsonType.STRING,
-                        "severityCounts",
-                        JsonType.ARRAY,
-                        "scan",
-                        JsonType.OBJECT,
-                        "scan.status",
-                        JsonType.STRING,
-                        resultField,
-                        JsonType.ARRAY));
+        Map<String, JsonType> shape = new LinkedHashMap<>(fields(
+                "localOnly",
+                JsonType.BOOLEAN,
+                "disclaimer",
+                JsonType.STRING,
+                "severityCounts",
+                JsonType.ARRAY,
+                "scan",
+                JsonType.OBJECT,
+                "scan.status",
+                JsonType.STRING,
+                resultField,
+                JsonType.ARRAY));
+        if (Set.of(
+                        "architecture",
+                        "memory",
+                        "rest-api",
+                        "spring",
+                        "database-advisor",
+                        "hibernate",
+                        "security",
+                        "pentesting")
+                .contains(panelId)) {
+            shape.put("assessmentEvidence", JsonType.OBJECT);
+            shape.put("assessmentEvidence.usable", JsonType.BOOLEAN);
+            shape.put("assessmentEvidence.incomplete", JsonType.BOOLEAN);
+        }
+        return read(panelId, path, shape);
     }
 
     private static ReadContract memory(String panelId, String path) {

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AdvisorAssessmentEvidenceDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/AdvisorAssessmentEvidenceDto.java
@@ -1,0 +1,16 @@
+package io.github.jdubois.bootui.core.dto;
+
+/**
+ * Evidence available to an advisor assessment, independently of findings and scan execution status.
+ *
+ * @param usable whether an applicable evaluation reached an evidence-backed outcome
+ * @param incomplete whether required evidence was unavailable, failed, or truncated; intentional
+ *     inapplicability alone does not make an assessment incomplete
+ */
+public record AdvisorAssessmentEvidenceDto(boolean usable, boolean incomplete) {
+
+    /** Legacy reports cannot establish successful evaluation from their attempted-rule counters. */
+    public static AdvisorAssessmentEvidenceDto unknown() {
+        return new AdvisorAssessmentEvidenceDto(false, true);
+    }
+}

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ArchitectureReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/ArchitectureReport.java
@@ -16,7 +16,33 @@ public record ArchitectureReport(
         List<ArchitectureSeverityCountDto> severityCounts,
         ArchitectureScanStatusDto scan,
         List<ArchitectureRuleResultDto> results,
-        List<ArchitectureRuleResultDto> analysisErrors) {
+        List<ArchitectureRuleResultDto> analysisErrors,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public ArchitectureReport(
+            boolean localOnly,
+            String disclaimer,
+            List<String> basePackages,
+            int classesAnalyzed,
+            int rulesEvaluated,
+            int violationsFound,
+            List<ArchitectureSeverityCountDto> severityCounts,
+            ArchitectureScanStatusDto scan,
+            List<ArchitectureRuleResultDto> results,
+            List<ArchitectureRuleResultDto> analysisErrors) {
+        this(
+                localOnly,
+                disclaimer,
+                basePackages,
+                classesAnalyzed,
+                rulesEvaluated,
+                violationsFound,
+                severityCounts,
+                scan,
+                results,
+                analysisErrors,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public ArchitectureReport {
         basePackages = DtoCollections.immutableCopy(basePackages);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DatabaseAdvisorReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DatabaseAdvisorReport.java
@@ -30,7 +30,41 @@ public record DatabaseAdvisorReport(
         List<DatabaseAdvisorSeverityCountDto> severityCounts,
         DatabaseAdvisorScanStatusDto scan,
         List<DatabaseAdvisorRuleResultDto> results,
-        List<DatabaseAdvisorDiagnosticDto> diagnostics) {
+        List<DatabaseAdvisorDiagnosticDto> diagnostics,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public DatabaseAdvisorReport(
+            boolean localOnly,
+            String disclaimer,
+            List<String> dataSourceNames,
+            List<DatabaseAdvisorDataSourceDto> dataSources,
+            int tablesAnalyzed,
+            int rulesEvaluated,
+            int violationsFound,
+            int rulesSkipped,
+            int rulesErrored,
+            boolean truncated,
+            List<DatabaseAdvisorSeverityCountDto> severityCounts,
+            DatabaseAdvisorScanStatusDto scan,
+            List<DatabaseAdvisorRuleResultDto> results,
+            List<DatabaseAdvisorDiagnosticDto> diagnostics) {
+        this(
+                localOnly,
+                disclaimer,
+                dataSourceNames,
+                dataSources,
+                tablesAnalyzed,
+                rulesEvaluated,
+                violationsFound,
+                rulesSkipped,
+                rulesErrored,
+                truncated,
+                severityCounts,
+                scan,
+                results,
+                diagnostics,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public DatabaseAdvisorReport {
         dataSourceNames = DtoCollections.immutableCopy(dataSourceNames);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyDto.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/DependencyDto.java
@@ -4,6 +4,9 @@ import java.util.List;
 
 /**
  * One Maven dependency discovered on the running application's classpath.
+ *
+ * @param assessmentComplete whether its OSV query pagination and every required advisory detail
+ *     and package association were resolved; this does not imply known severity or complete inventory
  */
 public record DependencyDto(
         String groupId,
@@ -13,7 +16,29 @@ public record DependencyDto(
         String source,
         int vulnerabilityCount,
         String highestSeverity,
-        List<DependencyVulnerabilityDto> vulnerabilities) {
+        List<DependencyVulnerabilityDto> vulnerabilities,
+        boolean assessmentComplete) {
+
+    public DependencyDto(
+            String groupId,
+            String artifactId,
+            String version,
+            String packageName,
+            String source,
+            int vulnerabilityCount,
+            String highestSeverity,
+            List<DependencyVulnerabilityDto> vulnerabilities) {
+        this(
+                groupId,
+                artifactId,
+                version,
+                packageName,
+                source,
+                vulnerabilityCount,
+                highestSeverity,
+                vulnerabilities,
+                false);
+    }
 
     public DependencyDto {
         vulnerabilities = DtoCollections.immutableCopy(vulnerabilities);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/HibernateReport.java
@@ -15,7 +15,31 @@ public record HibernateReport(
         int violationsFound,
         List<HibernateSeverityCountDto> severityCounts,
         HibernateScanStatusDto scan,
-        List<HibernateRuleResultDto> results) {
+        List<HibernateRuleResultDto> results,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public HibernateReport(
+            boolean localOnly,
+            String disclaimer,
+            List<String> entityPackages,
+            int entitiesAnalyzed,
+            int rulesEvaluated,
+            int violationsFound,
+            List<HibernateSeverityCountDto> severityCounts,
+            HibernateScanStatusDto scan,
+            List<HibernateRuleResultDto> results) {
+        this(
+                localOnly,
+                disclaimer,
+                entityPackages,
+                entitiesAnalyzed,
+                rulesEvaluated,
+                violationsFound,
+                severityCounts,
+                scan,
+                results,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public HibernateReport {
         entityPackages = DtoCollections.immutableCopy(entityPackages);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/MemoryReport.java
@@ -19,7 +19,31 @@ public record MemoryReport(
         List<MemorySeverityCountDto> severityCounts,
         MemoryScanStatusDto scan,
         List<MemoryRuleResultDto> results,
-        List<MemoryRuleResultDto> analysisErrors) {
+        List<MemoryRuleResultDto> analysisErrors,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public MemoryReport(
+            boolean localOnly,
+            String disclaimer,
+            int rulesEvaluated,
+            int violationsFound,
+            MemorySummaryDto summary,
+            List<MemorySeverityCountDto> severityCounts,
+            MemoryScanStatusDto scan,
+            List<MemoryRuleResultDto> results,
+            List<MemoryRuleResultDto> analysisErrors) {
+        this(
+                localOnly,
+                disclaimer,
+                rulesEvaluated,
+                violationsFound,
+                summary,
+                severityCounts,
+                scan,
+                results,
+                analysisErrors,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public MemoryReport {
         severityCounts = DtoCollections.immutableCopy(severityCounts);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/PentestingReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/PentestingReport.java
@@ -13,7 +13,29 @@ public record PentestingReport(
         List<PentestingSeverityCountDto> severityCounts,
         PentestingScanStatusDto scan,
         List<PentestingCoverageDto> coverage,
-        List<PentestingFindingDto> findings) {
+        List<PentestingFindingDto> findings,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public PentestingReport(
+            boolean localOnly,
+            String disclaimer,
+            int checksRun,
+            int findingsFound,
+            List<PentestingSeverityCountDto> severityCounts,
+            PentestingScanStatusDto scan,
+            List<PentestingCoverageDto> coverage,
+            List<PentestingFindingDto> findings) {
+        this(
+                localOnly,
+                disclaimer,
+                checksRun,
+                findingsFound,
+                severityCounts,
+                scan,
+                coverage,
+                findings,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public PentestingReport {
         severityCounts = DtoCollections.immutableCopy(severityCounts);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestApiReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/RestApiReport.java
@@ -16,7 +16,33 @@ public record RestApiReport(
         int violationsFound,
         List<RestApiSeverityCountDto> severityCounts,
         RestApiScanStatusDto scan,
-        List<RestApiRuleResultDto> results) {
+        List<RestApiRuleResultDto> results,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public RestApiReport(
+            boolean localOnly,
+            String disclaimer,
+            List<String> basePackages,
+            int controllersAnalyzed,
+            int handlersAnalyzed,
+            int rulesEvaluated,
+            int violationsFound,
+            List<RestApiSeverityCountDto> severityCounts,
+            RestApiScanStatusDto scan,
+            List<RestApiRuleResultDto> results) {
+        this(
+                localOnly,
+                disclaimer,
+                basePackages,
+                controllersAnalyzed,
+                handlersAnalyzed,
+                rulesEvaluated,
+                violationsFound,
+                severityCounts,
+                scan,
+                results,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public RestApiReport {
         basePackages = DtoCollections.immutableCopy(basePackages);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SecurityReport.java
@@ -16,7 +16,33 @@ public record SecurityReport(
         List<SecuritySeverityCountDto> severityCounts,
         SecurityScanStatusDto scan,
         List<SecurityRuleResultDto> results,
-        List<SecurityRuleResultDto> analysisErrors) {
+        List<SecurityRuleResultDto> analysisErrors,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public SecurityReport(
+            boolean localOnly,
+            String disclaimer,
+            List<String> filterChains,
+            int filterChainsAnalyzed,
+            int rulesEvaluated,
+            int violationsFound,
+            List<SecuritySeverityCountDto> severityCounts,
+            SecurityScanStatusDto scan,
+            List<SecurityRuleResultDto> results,
+            List<SecurityRuleResultDto> analysisErrors) {
+        this(
+                localOnly,
+                disclaimer,
+                filterChains,
+                filterChainsAnalyzed,
+                rulesEvaluated,
+                violationsFound,
+                severityCounts,
+                scan,
+                results,
+                analysisErrors,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public SecurityReport {
         filterChains = DtoCollections.immutableCopy(filterChains);

--- a/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringReport.java
+++ b/bootui-core/src/main/java/io/github/jdubois/bootui/core/dto/SpringReport.java
@@ -16,7 +16,33 @@ public record SpringReport(
         List<SpringSeverityCountDto> severityCounts,
         SpringScanStatusDto scan,
         List<SpringRuleResultDto> results,
-        List<SpringRuleResultDto> analysisErrors) {
+        List<SpringRuleResultDto> analysisErrors,
+        AdvisorAssessmentEvidenceDto assessmentEvidence) {
+
+    public SpringReport(
+            boolean localOnly,
+            String disclaimer,
+            List<String> inspected,
+            int componentsAnalyzed,
+            int rulesEvaluated,
+            int violationsFound,
+            List<SpringSeverityCountDto> severityCounts,
+            SpringScanStatusDto scan,
+            List<SpringRuleResultDto> results,
+            List<SpringRuleResultDto> analysisErrors) {
+        this(
+                localOnly,
+                disclaimer,
+                inspected,
+                componentsAnalyzed,
+                rulesEvaluated,
+                violationsFound,
+                severityCounts,
+                scan,
+                results,
+                analysisErrors,
+                AdvisorAssessmentEvidenceDto.unknown());
+    }
 
     public SpringReport {
         inspected = DtoCollections.immutableCopy(inspected);

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/advisor/AdvisorAssessmentEvidence.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/advisor/AdvisorAssessmentEvidence.java
@@ -1,0 +1,19 @@
+package io.github.jdubois.bootui.engine.advisor;
+
+import io.github.jdubois.bootui.core.dto.AdvisorAssessmentEvidenceDto;
+import java.util.Collection;
+import java.util.function.Function;
+
+/** Captures actual rule outcomes before report builders discard passing and skipped results. */
+public final class AdvisorAssessmentEvidence {
+
+    private AdvisorAssessmentEvidence() {}
+
+    public static <T> AdvisorAssessmentEvidenceDto fromResults(
+            Collection<T> results, Function<T, String> status, boolean incomplete) {
+        boolean usable =
+                results.stream().map(status).anyMatch(value -> "PASS".equals(value) || "VIOLATION".equals(value));
+        boolean failed = results.stream().map(status).anyMatch("ERROR"::equals);
+        return new AdvisorAssessmentEvidenceDto(usable, incomplete || failed);
+    }
+}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/advisor/AdvisorRuleAssessment.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/advisor/AdvisorRuleAssessment.java
@@ -1,0 +1,4 @@
+package io.github.jdubois.bootui.engine.advisor;
+
+/** Internal coverage accompanying a rule result without changing its public outcome. */
+public record AdvisorRuleAssessment<T>(T result, boolean incomplete) {}

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureScanner.java
@@ -7,6 +7,7 @@ import io.github.jdubois.bootui.core.dto.ArchitectureScanStatusDto;
 import io.github.jdubois.bootui.core.dto.ArchitectureSeverityCountDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
@@ -214,7 +215,9 @@ public final class ArchitectureScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                analysisErrors(results));
+                analysisErrors(results),
+                AdvisorAssessmentEvidence.fromResults(
+                        results, ArchitectureRuleResultDto::status, "PARTIAL".equals(status)));
     }
 
     public ArchitectureReport applyDismissals(ArchitectureReport report, Set<String> dismissedIds) {
@@ -246,7 +249,8 @@ public final class ArchitectureScanner {
                 severityCounts(active),
                 updatedScan,
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     static List<ArchitectureRuleResultDto> analysisErrors(List<ArchitectureRuleResultDto> results) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/databaseadvisor/DatabaseAdvisorScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/databaseadvisor/DatabaseAdvisorScanner.java
@@ -9,6 +9,7 @@ import io.github.jdubois.bootui.core.dto.DatabaseAdvisorSeverityCountDto;
 import io.github.jdubois.bootui.core.dto.SqlTraceEntryDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
 import io.github.jdubois.bootui.engine.hibernate.EntityDiscovery;
 import io.github.jdubois.bootui.engine.hibernate.HibernateSchemaBridge;
 import io.github.jdubois.bootui.engine.hibernate.HibernateSchemaBridge.MappedEntityFacts;
@@ -282,7 +283,8 @@ public final class DatabaseAdvisorScanner {
                 severityCounts(active),
                 updatedScan,
                 marked,
-                report.diagnostics());
+                report.diagnostics(),
+                report.assessmentEvidence());
     }
 
     private List<DatabaseAdvisorDiagnosticDto> schemaDiagnostics(List<SchemaSnapshot> schemas) {
@@ -549,7 +551,9 @@ public final class DatabaseAdvisorScanner {
                     severityCounts(violations),
                     scan,
                     violations,
-                    List.copyOf(diagnostics));
+                    List.copyOf(diagnostics),
+                    AdvisorAssessmentEvidence.fromResults(
+                            results, DatabaseAdvisorRuleResultDto::status, "PARTIAL".equals(status)));
         }
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateScanner.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.engine.hibernate;
 
+import io.github.jdubois.bootui.core.dto.AdvisorAssessmentEvidenceDto;
 import io.github.jdubois.bootui.core.dto.HibernateReport;
 import io.github.jdubois.bootui.core.dto.HibernateRuleResultDto;
 import io.github.jdubois.bootui.core.dto.HibernateScanStatusDto;
@@ -148,6 +149,7 @@ public final class HibernateScanner {
         Set<String> unknown = new LinkedHashSet<>();
         int skipped = 0;
         int attempts = 0;
+        boolean usable = false;
         HibernateApplicationFacts app = observation.application();
         Boolean logging = app.sqlLoggerEnabled();
         if (observation.units().stream()
@@ -197,6 +199,8 @@ public final class HibernateScanner {
                 if (HibernateRuleSupport.ERROR.equals(result.status())) failed.add(identity);
                 if (context.evidence().requiredUnknown) unknown.add(identity);
                 if (HibernateRuleSupport.SKIPPED.equals(result.status())) skipped++;
+                usable |= isViolation(result)
+                        || (HibernateRuleSupport.PASS.equals(result.status()) && !context.evidence().requiredUnknown);
                 if (isViolation(result)) mergeViolation(violations, result, label);
             }
         }
@@ -220,7 +224,8 @@ public final class HibernateScanner {
                 entityPackages(entities),
                 entities.size(),
                 rules.size(),
-                List.copyOf(violations.values()));
+                List.copyOf(violations.values()),
+                usable);
     }
 
     private static boolean applicationRule(String id) {
@@ -302,6 +307,26 @@ public final class HibernateScanner {
             int entitiesAnalyzed,
             int rulesEvaluated,
             List<HibernateRuleResultDto> results) {
+        return report(
+                status,
+                message,
+                scannedAt,
+                entityPackages,
+                entitiesAnalyzed,
+                rulesEvaluated,
+                results,
+                results.stream().anyMatch(HibernateScanner::isViolation));
+    }
+
+    private HibernateReport report(
+            String status,
+            String message,
+            Long scannedAt,
+            List<String> entityPackages,
+            int entitiesAnalyzed,
+            int rulesEvaluated,
+            List<HibernateRuleResultDto> results,
+            boolean usable) {
         List<HibernateRuleResultDto> violations = violationResults(results);
         int violationsFound = violations.size();
         HibernateScanStatusDto scan = new HibernateScanStatusDto(
@@ -315,7 +340,8 @@ public final class HibernateScanner {
                 violationsFound,
                 severityCounts(violations),
                 scan,
-                violations);
+                violations,
+                new AdvisorAssessmentEvidenceDto(usable, "PARTIAL".equals(status)));
     }
 
     public HibernateReport applyDismissals(HibernateReport report, Set<String> dismissedIds) {
@@ -346,7 +372,8 @@ public final class HibernateScanner {
                 violationsFound,
                 severityCounts(active),
                 updatedScan,
-                marked);
+                marked,
+                report.assessmentEvidence());
     }
 
     private EntityDiscovery safeEntityDiscovery() {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRule.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRule.java
@@ -1,10 +1,15 @@
 package io.github.jdubois.bootui.engine.memory;
 
 import io.github.jdubois.bootui.core.dto.MemoryRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 
 interface MemoryRule {
 
     MemoryRuleDefinition definition();
 
     MemoryRuleResultDto evaluate(MemoryContext context);
+
+    default AdvisorRuleAssessment<MemoryRuleResultDto> evaluateAssessment(MemoryContext context) {
+        return MemoryRuleSupport.assessment(evaluate(context));
+    }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRuleSupport.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.memory;
 
 import io.github.jdubois.bootui.core.dto.MemoryRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +12,7 @@ final class MemoryRuleSupport {
     static final String VIOLATION = "VIOLATION";
     static final String SKIPPED = "SKIPPED";
     static final String ERROR = "ERROR";
+    private static final String REQUIRED_EVIDENCE_UNAVAILABLE = "REQUIRED_EVIDENCE_UNAVAILABLE";
 
     static final String CRITICAL = "CRITICAL";
     static final String HIGH = "HIGH";
@@ -30,6 +32,30 @@ final class MemoryRuleSupport {
 
     static MemoryRuleResultDto skipped(MemoryRuleDefinition definition, String reason) {
         return result(definition, SKIPPED, 0, List.of(detail(reason)));
+    }
+
+    static MemoryRuleResultDto unknown(MemoryRuleDefinition definition, String reason) {
+        return result(definition, REQUIRED_EVIDENCE_UNAVAILABLE, 0, List.of(detail(reason)));
+    }
+
+    static AdvisorRuleAssessment<MemoryRuleResultDto> assessment(MemoryRuleResultDto result) {
+        if (!REQUIRED_EVIDENCE_UNAVAILABLE.equals(result.status())) {
+            return new AdvisorRuleAssessment<>(result, ERROR.equals(result.status()));
+        }
+        return new AdvisorRuleAssessment<>(
+                new MemoryRuleResultDto(
+                        result.id(),
+                        result.name(),
+                        result.category(),
+                        result.severity(),
+                        result.description(),
+                        SKIPPED,
+                        result.violationCount(),
+                        result.sampleViolations(),
+                        result.recommendation(),
+                        result.learnMoreUrl(),
+                        result.dismissed()),
+                true);
     }
 
     static MemoryRuleResultDto error(MemoryRuleDefinition definition, String reason) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryRules.java
@@ -1,7 +1,9 @@
 package io.github.jdubois.bootui.engine.memory;
 
 import io.github.jdubois.bootui.core.dto.HeapClassHistogramEntryDto;
+import io.github.jdubois.bootui.core.dto.MemoryRuleResultDto;
 import io.github.jdubois.bootui.core.dto.ThreadInfoDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.MemoryData;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.MemoryPoolSnapshot;
 import io.github.jdubois.bootui.engine.memory.MemoryContext.ThreadData;
@@ -31,6 +33,15 @@ abstract class AbstractMemoryRule implements MemoryRule {
 
     @Override
     public final io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluate(MemoryContext context) {
+        return evaluateAssessment(context).result();
+    }
+
+    @Override
+    public final AdvisorRuleAssessment<MemoryRuleResultDto> evaluateAssessment(MemoryContext context) {
+        return MemoryRuleSupport.assessment(evaluateSafely(context));
+    }
+
+    private MemoryRuleResultDto evaluateSafely(MemoryContext context) {
         try {
             if (definition.category() == MemoryCategory.THREADS
                     && context.threads().collectionError() != null) {
@@ -52,6 +63,10 @@ abstract class AbstractMemoryRule implements MemoryRule {
 
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto skipped(String reason) {
         return MemoryRuleSupport.skipped(definition, reason);
+    }
+
+    io.github.jdubois.bootui.core.dto.MemoryRuleResultDto unknown(String reason) {
+        return MemoryRuleSupport.unknown(definition, reason);
     }
 
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto violation(List<String> details) {
@@ -155,7 +170,7 @@ final class HighHeapUtilizationRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         MemoryData memory = context.memory();
         if (memory.heapMax() <= 0) {
-            return skipped("Maximum heap size is not reported by this JVM.");
+            return unknown("Maximum heap size is not reported by this JVM.");
         }
         MemoryContext.PostGcHeapData postGc = context.postGcHeap();
         if (postGc.heapAvailable() && postGc.heapUsed() >= 0) {
@@ -170,7 +185,7 @@ final class HighHeapUtilizationRule extends AbstractMemoryRule {
             return pass();
         }
         if (memory.heapUsed() < 0) {
-            return skipped("Heap usage is unavailable.");
+            return unknown("Heap usage is unavailable.");
         }
         int percent = MemoryFormat.percentOf(memory.heapUsed(), memory.heapMax());
         if (percent >= THRESHOLD_PERCENT) {
@@ -207,7 +222,7 @@ final class OldGenerationNearMaxRule extends AbstractMemoryRule {
         }
         MemoryPoolSnapshot pool = oldGen.get();
         if (pool.max() <= 0) {
-            return skipped("Old-generation pool '" + pool.name() + "' does not report a maximum size.");
+            return unknown("Old-generation pool '" + pool.name() + "' does not report a maximum size.");
         }
         MemoryContext.PostGcHeapData postGc = context.postGcHeap();
         if (postGc.oldGenAvailable() && postGc.oldGenUsed() >= 0) {
@@ -220,7 +235,7 @@ final class OldGenerationNearMaxRule extends AbstractMemoryRule {
             return pass();
         }
         if (pool.used() < 0) {
-            return skipped("Old-generation usage is unavailable.");
+            return unknown("Old-generation usage is unavailable.");
         }
         if (pool.usedPercent() >= THRESHOLD_PERCENT) {
             return violation("Old-generation pool '" + pool.name() + "' is " + pool.usedPercent() + "% full ("
@@ -253,7 +268,7 @@ final class SmallMaxHeapUnderPressureRule extends AbstractMemoryRule {
         if (memory.heapMax() <= 0) {
             // HotSpot effectively always reports a bounded max heap; skip rather than fire a
             // spurious violation when getMax() returns -1 on unusual JVMs or startup edge-cases.
-            return skipped("Maximum heap size is not reported by this JVM.");
+            return unknown("Maximum heap size is not reported by this JVM.");
         }
         Long containerLimit = memory.containerMemoryLimitBytes();
         if (containerLimit == null || containerLimit < MIN_CONTAINER_LIMIT) {
@@ -268,7 +283,7 @@ final class SmallMaxHeapUnderPressureRule extends AbstractMemoryRule {
         } else if (memory.heapUsed() >= 0) {
             usedPercent = context.heapUsedPercent();
         } else {
-            return skipped("Heap occupancy is unavailable.");
+            return unknown("Heap occupancy is unavailable.");
         }
         if (smallHeap && usedPercent >= PRESSURE_PERCENT) {
             int percent = MemoryFormat.percentOf(memory.heapMax(), containerLimit);
@@ -310,7 +325,7 @@ final class MetaspaceSaturationRule extends AbstractMemoryRule {
         }
         MemoryPoolSnapshot pool = metaspace.get();
         if (pool.used() < 0) {
-            return skipped("Metaspace usage is unavailable.");
+            return unknown("Metaspace usage is unavailable.");
         }
         if (pool.usedPercent() >= THRESHOLD_PERCENT) {
             return violation("Metaspace is " + pool.usedPercent() + "% full (" + MemoryFormat.bytes(pool.used())
@@ -343,7 +358,7 @@ final class CodeCacheSaturationRule extends AbstractMemoryRule {
             return skipped("No code-cache pool is exposed by this JVM.");
         }
         if (segments.stream().noneMatch(pool -> pool.max() > 0 && pool.used() >= 0)) {
-            return skipped("Code-cache usage or maxima are unavailable.");
+            return unknown("Code-cache usage or maxima are unavailable.");
         }
         List<String> details = new ArrayList<>();
         for (MemoryPoolSnapshot pool : segments) {
@@ -377,7 +392,7 @@ final class DirectBufferGrowthRule extends AbstractMemoryRule {
         long capacity = memory.directBufferCapacity();
         long max = memory.maxDirectMemoryBytes();
         if (capacity < 0 || max <= 0) {
-            return skipped(
+            return unknown(
                     "Direct-buffer capacity or its effective maximum is unavailable; a missing cap is not an unlimited cap.");
         }
         int percent = MemoryFormat.percentOf(capacity, max);
@@ -477,7 +492,7 @@ final class DeadlockDetectedRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         ThreadData threads = context.threads();
         if (threads.total() <= 0) {
-            return skipped("No thread snapshot is available to assess platform-thread deadlocks.");
+            return unknown("No thread snapshot is available to assess platform-thread deadlocks.");
         }
         if (!threads.deadlockDetected()) {
             return pass();
@@ -513,7 +528,7 @@ final class HighBlockedThreadRatioRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         ThreadData threads = context.threads();
         if (threads.total() <= 0) {
-            return skipped("No thread snapshot is available.");
+            return unknown("No thread snapshot is available.");
         }
         int blocked = context.blockedThreadCount();
         double ratio = (double) blocked / threads.total();
@@ -548,7 +563,7 @@ final class ThreadPoolExhaustionGapRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         ThreadData threads = context.threads();
         if (threads.total() <= 0) {
-            return skipped("No thread snapshot is available.");
+            return unknown("No thread snapshot is available.");
         }
         long gap = (long) threads.peak() - threads.total();
         if (threads.peak() >= 2L * threads.total() && gap >= MIN_GAP) {
@@ -583,15 +598,15 @@ final class RunawayCpuThreadRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         ThreadData threads = context.threads();
         if (!threads.cpuTimeSupported()) {
-            return skipped("Per-thread CPU timing is not supported or not enabled on this JVM.");
+            return unknown("Per-thread CPU timing is not supported or not enabled on this JVM.");
         }
         if (threads.detailsTruncated()) {
-            return skipped(
+            return unknown(
                     "Per-thread details are capped at 1,000 platform threads; CPU-hot-thread analysis is incomplete.");
         }
         long uptimeMillis = context.runtime().uptimeMillis();
         if (uptimeMillis <= 0) {
-            return skipped("JVM uptime is not available to normalize thread CPU time.");
+            return unknown("JVM uptime is not available to normalize thread CPU time.");
         }
         long minCpuMillis = Math.max(CPU_THRESHOLD_MILLIS, (long) (uptimeMillis * UPTIME_FRACTION));
         List<ThreadInfoDto> hot = new ArrayList<>();
@@ -641,7 +656,7 @@ final class BigObjectsRule extends AbstractMemoryRule {
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         if (!context.heapContent().available()) {
-            return skipped("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
+            return unknown("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
         }
         List<HeapClassHistogramEntryDto> candidates = new ArrayList<>();
         for (HeapClassHistogramEntryDto entry : context.heapContent().histogram()) {
@@ -708,7 +723,7 @@ final class CollectionBloatRule extends AbstractMemoryRule {
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         if (!context.heapContent().available()) {
-            return skipped("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
+            return unknown("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
         }
         long totalBytes = context.heapContent().totalBytes();
         List<HeapClassHistogramEntryDto> candidates = new ArrayList<>();
@@ -727,7 +742,7 @@ final class CollectionBloatRule extends AbstractMemoryRule {
             return pass();
         }
         if (candidateBytes < 0) {
-            return skipped("Collection histogram bytes exceed the numeric range.");
+            return unknown("Collection histogram bytes exceed the numeric range.");
         }
         candidates.sort((left, right) -> Long.compare(right.bytes(), left.bytes()));
         long largest = candidates.get(0).bytes();
@@ -777,11 +792,11 @@ final class DominantClassRule extends AbstractMemoryRule {
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         if (!context.heapContent().available()) {
-            return skipped("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
+            return unknown("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
         }
         long totalBytes = context.heapContent().totalBytes();
         if (totalBytes <= 0) {
-            return skipped("The sampled heap histogram is empty.");
+            return unknown("The sampled heap histogram is empty.");
         }
         return context.heapContent().histogram().stream()
                 .filter(entry -> !isArrayClass(entry.className()))
@@ -863,7 +878,7 @@ final class CommittedFootprintNearContainerLimitRule extends AbstractMemoryRule 
             return skipped("No container memory limit was detected.");
         }
         if (memory.heapMax() <= 0) {
-            return skipped("Maximum heap is unavailable; the configured envelope cannot be assessed.");
+            return unknown("Maximum heap is unavailable; the configured envelope cannot be assessed.");
         }
         if (memory.heapMax() >= limit) {
             return violation(
@@ -876,14 +891,14 @@ final class CommittedFootprintNearContainerLimitRule extends AbstractMemoryRule 
             return MemoryRuleSupport.error(definition(), context.threads().collectionError());
         }
         if (context.threads().total() <= 0 || context.runtime().threadStackBytes() <= 0) {
-            return skipped("Platform-thread stack estimate is unavailable.");
+            return unknown("Platform-thread stack estimate is unavailable.");
         }
         long stacks = MemoryFormat.product(
                 context.threads().total(), context.runtime().threadStackBytes());
         long configuredFootprint =
                 MemoryFormat.sum(memory.heapMax(), memory.nonHeapCommitted(), memory.directBufferCapacity(), stacks);
         if (configuredFootprint < 0) {
-            return skipped("Configured memory components are unavailable or exceed the numeric range.");
+            return unknown("Configured memory components are unavailable or exceed the numeric range.");
         }
         if (MemoryFormat.percentOf(configuredFootprint, limit) >= THRESHOLD_PERCENT) {
             int percent = MemoryFormat.percentOf(configuredFootprint, limit);
@@ -927,10 +942,10 @@ final class HighGcOverheadRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         MemoryContext.RuntimeData runtime = context.runtime();
         if (runtime.uptimeMillis() < MIN_UPTIME_MILLIS) {
-            return skipped("JVM uptime is too short to assess lifetime GC overhead.");
+            return unknown("JVM uptime is too short to assess lifetime GC overhead.");
         }
         if (runtime.gcCollectionTimeMillis() < 0) {
-            return skipped("Cumulative GC time is not reported by this JVM.");
+            return unknown("Cumulative GC time is not reported by this JVM.");
         }
         int percent = MemoryFormat.percentOf(runtime.gcCollectionTimeMillis(), runtime.uptimeMillis());
         if (percent >= THRESHOLD_PERCENT) {
@@ -970,7 +985,7 @@ final class UnequalInitialAndMaxHeapRule extends AbstractMemoryRule {
         }
         long initial = context.runtime().initialHeapBytes();
         if (initial <= 0 || memory.heapMax() <= 0) {
-            return skipped("Initial or maximum heap size is not available.");
+            return unknown("Initial or maximum heap size is not available.");
         }
         if (initial < memory.heapMax()) {
             String initialLabel = memory.hasJvmArgumentPrefix("-Xms") ? "-Xms" : "Initial heap";
@@ -1022,7 +1037,7 @@ final class CompressedOopsCliffRule extends AbstractMemoryRule {
         long boundary = MemoryFormat.product(alignment, COMPRESSED_OOPS_HEAP_PER_ALIGNMENT_BYTE);
         long upperBound = MemoryFormat.sum(boundary, boundary / 4);
         if (boundary <= 0 || upperBound < 0) {
-            return skipped("The compressed-oops alignment boundary exceeds the numeric range.");
+            return unknown("The compressed-oops alignment boundary exceeds the numeric range.");
         }
         if (useCompressedOops != null && !useCompressedOops && heapMax <= boundary) {
             return skipped("Compressed object pointers are disabled (UseCompressedOops=false).");
@@ -1188,12 +1203,12 @@ final class PlatformThreadStackReservationRule extends AbstractMemoryRule {
             return MemoryRuleSupport.error(definition(), context.threads().collectionError());
         }
         if (platformThreads <= 0) {
-            return skipped("No thread snapshot is available.");
+            return unknown("No thread snapshot is available.");
         }
         long stackBytes = context.runtime().threadStackBytes();
         long reserved = MemoryFormat.product(platformThreads, stackBytes);
         if (stackBytes <= 0 || reserved < 0) {
-            return skipped("Platform-thread stack reservation is unavailable or exceeds the numeric range.");
+            return unknown("Platform-thread stack reservation is unavailable or exceeds the numeric range.");
         }
         Long limit = context.memory().containerMemoryLimitBytes();
         boolean relativeBreach =
@@ -1239,11 +1254,11 @@ final class ArrayDominanceRule extends AbstractMemoryRule {
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         if (!context.heapContent().available()) {
-            return skipped("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
+            return unknown("No class histogram is available; run Heap Dump analysis or re-scan to collect one.");
         }
         long totalBytes = context.heapContent().totalBytes();
         if (totalBytes <= 0) {
-            return skipped("The sampled heap histogram is empty.");
+            return unknown("The sampled heap histogram is empty.");
         }
         List<HeapClassHistogramEntryDto> arrays = new ArrayList<>();
         long arrayBytes = 0;
@@ -1254,7 +1269,7 @@ final class ArrayDominanceRule extends AbstractMemoryRule {
             }
         }
         if (arrayBytes < 0) {
-            return skipped("Array histogram bytes exceed the numeric range.");
+            return unknown("Array histogram bytes exceed the numeric range.");
         }
         int sharePercent = MemoryFormat.percentOf(arrayBytes, totalBytes);
         if (arrays.isEmpty() || sharePercent < SHARE_PERCENT_THRESHOLD) {
@@ -1298,10 +1313,10 @@ final class RecentGcOverheadRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         MemoryContext.GcTrend trend = context.gcTrend();
         if (!trend.available() || trend.deltaGcTimeMillis() < 0) {
-            return skipped("No comparable GC baseline is available; re-run after a representative workload.");
+            return unknown("No comparable GC baseline is available; re-run after a representative workload.");
         }
         if (trend.deltaUptimeMillis() < MIN_WINDOW_MILLIS) {
-            return skipped("Too little time has passed since the last scan to measure recent GC overhead.");
+            return unknown("Too little time has passed since the last scan to measure recent GC overhead.");
         }
         int percent = MemoryFormat.percentOf(trend.deltaGcTimeMillis(), trend.deltaUptimeMillis());
         if (percent < THRESHOLD_PERCENT) {
@@ -1345,7 +1360,7 @@ final class CompressedClassSpaceRule extends AbstractMemoryRule {
         }
         MemoryContext.MemoryPoolSnapshot ccs = pool.get();
         if (ccs.max() <= 0 || ccs.used() < 0) {
-            return skipped("Compressed Class Space does not report a maximum size on this JVM.");
+            return unknown("Compressed Class Space does not report a maximum size on this JVM.");
         }
         if (ccs.usedPercent() >= THRESHOLD_PERCENT) {
             return violation("Compressed Class Space is " + ccs.usedPercent() + "% full ("
@@ -1384,11 +1399,11 @@ final class ContainerMemoryPressureRule extends AbstractMemoryRule {
         }
         Long current = memory.containerMemoryCurrentBytes();
         if (current == null || current < 0) {
-            return skipped("Current container memory usage is not available (no cgroup files readable).");
+            return unknown("Current container memory usage is not available (no cgroup files readable).");
         }
         Long workingSet = memory.containerMemoryWorkingSetBytes();
         if (workingSet != null && (workingSet < 0 || workingSet > current)) {
-            return skipped("Container working-set usage is inconsistent with current usage.");
+            return unknown("Container working-set usage is inconsistent with current usage.");
         }
         long measuredUsage = workingSet != null ? workingSet : current;
         int percent = MemoryFormat.percentOf(measuredUsage, limit);
@@ -1439,7 +1454,7 @@ final class SerialGcOnMultiCoreRule extends AbstractMemoryRule {
         }
         long effectiveMemoryBytes = effectiveMemoryBytes(memory, context.runtime());
         if (effectiveMemoryBytes < 0) {
-            return skipped("Available physical or container memory is unknown.");
+            return unknown("Available physical or container memory is unknown.");
         }
         if (effectiveMemoryBytes >= 0 && effectiveMemoryBytes < SERVER_CLASS_MEMORY_THRESHOLD_BYTES) {
             return skipped("Serial GC is expected below Oracle's historical 'server-class machine' ergonomics"
@@ -1485,10 +1500,10 @@ final class G1FullGcFrequencyRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         MemoryContext.GcTrend trend = context.gcTrend();
         if (!trend.available()) {
-            return skipped("No previous scan to compare; re-run the scan to measure G1 Full GC frequency.");
+            return unknown("No previous scan to compare; re-run the scan to measure G1 Full GC frequency.");
         }
         if (!trend.perCollectorDeltas().containsKey("G1 Old Generation")) {
-            return skipped("No comparable G1 Old Generation collection count is available.");
+            return unknown("No comparable G1 Old Generation collection count is available.");
         }
         long fullGcDelta = trend.perCollectorDeltas().getOrDefault("G1 Old Generation", 0L);
         if (fullGcDelta <= 0) {
@@ -1525,18 +1540,18 @@ final class OverProvisionedHeapRule extends AbstractMemoryRule {
     @Override
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         if (context.runtime().uptimeMillis() < MIN_UPTIME_MILLIS) {
-            return skipped("JVM uptime is too short to assess heap over-provisioning.");
+            return unknown("JVM uptime is too short to assess heap over-provisioning.");
         }
         MemoryContext.PostGcHeapData postGc = context.postGcHeap();
         boolean postAvailable = postGc.heapAvailable() && postGc.heapCommitted() >= 0 && postGc.heapUsed() >= 0;
         long committed =
                 postAvailable ? postGc.heapCommitted() : context.memory().heapCommitted();
         if (committed <= 0) {
-            return skipped("Committed heap size is not available.");
+            return unknown("Committed heap size is not available.");
         }
         long used = postAvailable ? postGc.heapUsed() : context.memory().heapUsed();
         if (used < 0 || used > committed) {
-            return skipped("Comparable heap usage and committed capacity are unavailable.");
+            return unknown("Comparable heap usage and committed capacity are unavailable.");
         }
         long slack = committed - used;
         if (used <= committed / COMMITTED_TO_USED_RATIO && slack >= MIN_SLACK_BYTES) {
@@ -1591,7 +1606,7 @@ final class InterpretedJitModeRule extends AbstractMemoryRule {
                             + " (below tier 4); assess whether this is intentional for startup or diagnostics.");
                 }
             } catch (NumberFormatException ex) {
-                return skipped("The compilation tier argument could not be interpreted.");
+                return unknown("The compilation tier argument could not be interpreted.");
             }
         }
         return pass();
@@ -1622,7 +1637,7 @@ final class HighSwapUtilizationRule extends AbstractMemoryRule {
         long totalSwap = context.runtime().totalSwapSpaceBytes();
         long freeSwap = context.runtime().freeSwapSpaceBytes();
         if (totalSwap < 0 || freeSwap < 0 || freeSwap > totalSwap) {
-            return skipped("Swap space statistics are not available on this platform.");
+            return unknown("Swap space statistics are not available on this platform.");
         }
         if (totalSwap == 0) {
             return skipped("No swap space is configured on this host.");
@@ -1670,7 +1685,7 @@ final class GcEventDurationOutlierRule extends AbstractMemoryRule {
         MemoryContext.GcEvent latestGcEvent = context.latestGcEvent();
         long durationMillis = latestGcEvent.durationMillis();
         if (durationMillis < 0) {
-            return skipped("No new application GC event is available (requires a HotSpot JVM and a collection since"
+            return unknown("No new application GC event is available (requires a HotSpot JVM and a collection since"
                     + " the previous scan).");
         }
         if (durationMillis < PAUSE_THRESHOLD_MILLIS) {
@@ -1718,7 +1733,7 @@ final class BufferPoolGrowthWithoutReleaseRule extends AbstractMemoryRule {
                 || direct.get().used() < 0
                 || !trend.available()
                 || !trend.consecutiveIncreaseStreaks().containsKey(direct.get().name())) {
-            return skipped("No comparable direct-buffer usage baseline is available.");
+            return unknown("No comparable direct-buffer usage baseline is available.");
         }
         List<MemoryContext.BufferPoolSnapshot> pools = context.memory().bufferPools();
         List<String> details = new ArrayList<>();
@@ -1774,7 +1789,7 @@ final class OldGenerationTrendingUpwardRule extends AbstractMemoryRule {
     io.github.jdubois.bootui.core.dto.MemoryRuleResultDto evaluateRule(MemoryContext context) {
         MemoryContext.OldGenTrend trend = context.oldGenTrend();
         if (!trend.available()) {
-            return skipped("No previous scan to compare; re-run the scan several times to measure the"
+            return unknown("No previous scan to compare; re-run the scan several times to measure the"
                     + " old-generation trend.");
         }
         if (trend.consecutiveIncreaseStreak() < GROWTH_STREAK_THRESHOLD) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/memory/MemoryScanner.java
@@ -7,6 +7,8 @@ import io.github.jdubois.bootui.core.dto.MemorySeverityCountDto;
 import io.github.jdubois.bootui.core.dto.MemorySummaryDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import io.github.jdubois.bootui.engine.threads.ThreadDumpService;
 import java.time.Clock;
@@ -146,16 +148,21 @@ public final class MemoryScanner {
                 .withBufferPoolTrend(bufferPoolTrend)
                 .withOldGenTrend(oldGenTrend);
 
-        List<MemoryRuleResultDto> results = MemoryRuleRegistry.activeRules().stream()
-                .map(rule -> rule.evaluate(evaluated))
+        List<AdvisorRuleAssessment<MemoryRuleResultDto>> assessments = MemoryRuleRegistry.activeRules().stream()
+                .map(rule -> rule.evaluateAssessment(evaluated))
                 .toList();
+        List<MemoryRuleResultDto> results =
+                assessments.stream().map(AdvisorRuleAssessment::result).toList();
+        boolean incomplete = assessments.stream().anyMatch(AdvisorRuleAssessment::incomplete);
         boolean hadErrors = results.stream().anyMatch(result -> MemoryRuleSupport.ERROR.equals(result.status()));
         String status = hadErrors ? "PARTIAL" : "SCANNED";
         String message = "Memory Advisor evaluated " + results.size() + " rules against the JVM runtime.";
         if (hadErrors) {
             message += " Some rules could not be evaluated.";
+        } else if (incomplete) {
+            message += " Some checks lack the observations needed for an assessment.";
         }
-        return report(status, message, clock.millis(), summary(evaluated), results.size(), results);
+        return report(status, message, clock.millis(), summary(evaluated), results.size(), results, incomplete);
     }
 
     /**
@@ -245,6 +252,17 @@ public final class MemoryScanner {
             MemorySummaryDto summary,
             int rulesEvaluated,
             List<MemoryRuleResultDto> results) {
+        return report(status, message, scannedAt, summary, rulesEvaluated, results, "PARTIAL".equals(status));
+    }
+
+    private MemoryReport report(
+            String status,
+            String message,
+            Long scannedAt,
+            MemorySummaryDto summary,
+            int rulesEvaluated,
+            List<MemoryRuleResultDto> results,
+            boolean incomplete) {
         List<MemoryRuleResultDto> violations = results.stream()
                 .filter(MemoryScanner::isViolation)
                 .sorted(IMPORTANCE_ORDER)
@@ -261,7 +279,8 @@ public final class MemoryScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                analysisErrors(results));
+                analysisErrors(results),
+                AdvisorAssessmentEvidence.fromResults(results, MemoryRuleResultDto::status, incomplete));
     }
 
     public MemoryReport applyDismissals(MemoryReport report, Set<String> dismissedIds) {
@@ -291,7 +310,8 @@ public final class MemoryScanner {
                 severityCounts(active),
                 updatedScan,
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     static List<MemoryRuleResultDto> analysisErrors(List<MemoryRuleResultDto> results) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingScanner.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.engine.pentesting;
 
+import io.github.jdubois.bootui.core.dto.AdvisorAssessmentEvidenceDto;
 import io.github.jdubois.bootui.core.dto.PentestingCoverageDto;
 import io.github.jdubois.bootui.core.dto.PentestingFindingDto;
 import io.github.jdubois.bootui.core.dto.PentestingReport;
@@ -270,7 +271,11 @@ public final class PentestingScanner {
                 severityCounts(sortedFindings),
                 scan,
                 coverage,
-                sortedFindings);
+                sortedFindings,
+                new AdvisorAssessmentEvidenceDto(
+                        coverage.stream()
+                                .anyMatch(item -> "INFO".equals(item.status()) || "REVIEW".equals(item.status())),
+                        "PARTIAL".equals(status)));
     }
 
     private List<PentestingSeverityCountDto> severityCounts(List<PentestingFindingDto> findings) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScanner.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.engine.quarkusapp;
 
+import io.github.jdubois.bootui.core.dto.AdvisorAssessmentEvidenceDto;
 import io.github.jdubois.bootui.core.dto.SpringReport;
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
 import io.github.jdubois.bootui.core.dto.SpringScanStatusDto;
@@ -133,7 +134,9 @@ public final class QuarkusAppScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                errors);
+                errors,
+                new AdvisorAssessmentEvidenceDto(
+                        rulesEvaluated > 0 || !violations.isEmpty(), "PARTIAL".equals(status) || !errors.isEmpty()));
     }
 
     public SpringReport applyDismissals(SpringReport report, Set<String> dismissedIds) {
@@ -164,7 +167,8 @@ public final class QuarkusAppScanner {
                 severityCounts(active),
                 scan,
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     private List<SpringSeverityCountDto> severityCounts(List<SpringRuleResultDto> results) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityChecks.java
@@ -7,13 +7,14 @@ import io.github.jdubois.bootui.spi.QuarkusSecurityPermission;
 import io.github.jdubois.bootui.spi.QuarkusSecuritySnapshot;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * The fixed Quarkus-native security ruleset (see {@code docs/QUARKUS-CHECKS.md}). Each rule inspects the
  * neutral {@link QuarkusSecuritySnapshot} and, when triggered, emits one {@link SecurityRuleResultDto}
- * with status {@code VIOLATION}. The full set evaluated is {@link #ruleCount()}; only violations are returned.
+ * with status {@code VIOLATION}. The registry size is {@link #ruleCount()}; only violations are returned.
  */
 final class QuarkusSecurityChecks {
 
@@ -30,14 +31,42 @@ final class QuarkusSecurityChecks {
     }
 
     static List<SecurityRuleResultDto> evaluate(QuarkusSecuritySnapshot s) {
+        return assess(s).findings();
+    }
+
+    record Assessment(List<SecurityRuleResultDto> findings, boolean usable) {}
+
+    private static final class Evidence {
+        private final Set<String> unknownRules;
+        private boolean usable;
+
+        private Evidence(Set<String> unknownRules) {
+            this.unknownRules = unknownRules;
+        }
+
+        private boolean observe(String id, boolean finding) {
+            return observe(id, true, finding);
+        }
+
+        private boolean observe(String id, boolean applicable, boolean finding) {
+            usable |= applicable && !unknownRules.contains(id);
+            return finding;
+        }
+    }
+
+    static Assessment assess(QuarkusSecuritySnapshot s) {
+        Evidence evidence = new Evidence(s.evidence().unknownRules());
         List<SecurityRuleResultDto> v = new ArrayList<>();
 
-        if (!s.anyAuthMechanism()
-                && !hasProtectivePolicy(s.permissions())
-                && s.protectiveAnnotationCount() == 0
-                && !s.defaultRolesAllowed()
-                && !s.denyUnannotatedEndpoints()
-                && s.endpointCount() > 0) {
+        if (evidence.observe(
+                "QS-AUTH-001",
+                s.endpointCount() > 0,
+                !s.anyAuthMechanism()
+                        && !hasProtectivePolicy(s.permissions())
+                        && s.protectiveAnnotationCount() == 0
+                        && !s.defaultRolesAllowed()
+                        && !s.denyUnannotatedEndpoints()
+                        && s.endpointCount() > 0)) {
             v.add(rule(
                     "QS-AUTH-001",
                     "No authentication mechanism configured",
@@ -50,7 +79,7 @@ final class QuarkusSecurityChecks {
                     "Add an authentication mechanism and protect endpoints with a permission policy or"
                             + " @RolesAllowed/@PermissionsAllowed."));
         }
-        if (s.basicAuth() && "enabled".equals(s.insecureRequests())) {
+        if (evidence.observe("QS-AUTH-002", s.basicAuth(), s.basicAuth() && "enabled".equals(s.insecureRequests()))) {
             v.add(rule(
                     "QS-AUTH-002",
                     "Basic authentication without TLS",
@@ -62,7 +91,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.auth.basic=true, quarkus.http.insecure-requests=enabled"),
                     "Set quarkus.http.insecure-requests=redirect and configure TLS."));
         }
-        if (s.formAuth() && !s.csrfPresent()) {
+        if (evidence.observe("QS-AUTH-003", s.formAuth(), s.formAuth() && !s.csrfPresent())) {
             v.add(rule(
                     "QS-AUTH-003",
                     "Review form authentication CSRF defenses",
@@ -74,7 +103,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.auth.form.enabled=true, quarkus-rest-csrf absent"),
                     "Add the io.quarkus:quarkus-rest-csrf extension and embed the CSRF token in forms."));
         }
-        if (s.formAuth() && "enabled".equals(s.insecureRequests())) {
+        if (evidence.observe("QS-AUTH-012", s.formAuth(), s.formAuth() && "enabled".equals(s.insecureRequests()))) {
             v.add(rule(
                     "QS-AUTH-012",
                     "Form authentication without TLS",
@@ -86,7 +115,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.auth.form.enabled=true, quarkus.http.insecure-requests=enabled"),
                     "Set quarkus.http.insecure-requests=redirect (or disabled) and configure TLS."));
         }
-        if (s.jwtConfigured() && !s.jwtIssuerConfigured()) {
+        if (evidence.observe("QS-AUTH-004", s.jwtConfigured(), s.jwtConfigured() && !s.jwtIssuerConfigured())) {
             v.add(rule(
                     "QS-AUTH-004",
                     "JWT verification without an expected issuer",
@@ -98,7 +127,7 @@ final class QuarkusSecurityChecks {
                     List.of("mp.jwt.verify.publickey* set, mp.jwt.verify.issuer absent"),
                     "Set mp.jwt.verify.issuer to the expected token issuer."));
         }
-        if (s.embeddedUsersEnabled()) {
+        if (evidence.observe("QS-AUTH-007", s.embeddedUsersEnabled())) {
             v.add(rule(
                     "QS-AUTH-007",
                     "Embedded identity store enabled in the current runtime",
@@ -110,7 +139,8 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.security.users.embedded.enabled=true"),
                     "Use quarkus-elytron-security-jdbc/oidc for real deployments; keep embedded users to %dev/%test."));
         }
-        if (s.embeddedUsersEnabled() && s.embeddedUsersPlainText()) {
+        if (evidence.observe(
+                "QS-AUTH-013", s.embeddedUsersEnabled(), s.embeddedUsersEnabled() && s.embeddedUsersPlainText())) {
             v.add(rule(
                     "QS-AUTH-013",
                     "Embedded users stored with plain-text passwords",
@@ -124,7 +154,7 @@ final class QuarkusSecurityChecks {
                     "Use an identity provider or a supported adaptive password-hashing store for production;"
                             + " the embedded store's legacy digest default is not modern password-storage advice."));
         }
-        if (s.jwtConfigured() && !s.jwtAudiencesConfigured()) {
+        if (evidence.observe("QS-AUTH-008", s.jwtConfigured(), s.jwtConfigured() && !s.jwtAudiencesConfigured())) {
             v.add(rule(
                     "QS-AUTH-008",
                     "JWT verification without audience validation",
@@ -136,7 +166,7 @@ final class QuarkusSecurityChecks {
                     List.of("mp.jwt.verify.publickey* set, mp.jwt.verify.audiences absent"),
                     "Set mp.jwt.verify.audiences to this service's expected audience(s)."));
         }
-        if (s.jwtConfigured() && s.jwtInlinePublicKey()) {
+        if (evidence.observe("QS-AUTH-009", s.jwtConfigured(), s.jwtConfigured() && s.jwtInlinePublicKey())) {
             v.add(rule(
                     "QS-AUTH-009",
                     "Review static JWT trust-anchor rotation",
@@ -148,7 +178,7 @@ final class QuarkusSecurityChecks {
                     List.of("mp.jwt.verify.publickey set"),
                     "Document and test trust-anchor rotation; remote JWKS is optional, not inherently safer."));
         }
-        if (s.jdbcClearPasswordMapperEnabled()) {
+        if (evidence.observe("QS-AUTH-010", s.jdbcClearPasswordMapperEnabled())) {
             v.add(rule(
                     "QS-AUTH-010",
                     "JDBC identity store using clear-text password mapper",
@@ -160,12 +190,15 @@ final class QuarkusSecurityChecks {
                     List.of("principal-query *.clear-password-mapper.enabled=true"),
                     "Switch to bcrypt-password-mapper (or another hashing mapper) and re-hash stored passwords."));
         }
-        if (!hasProtectivePolicy(s.permissions())
-                && s.protectiveAnnotationCount() == 0
-                && !s.defaultRolesAllowed()
-                && !s.denyUnannotatedEndpoints()
-                && s.endpointCount() > 0
-                && s.anyAuthMechanism()) {
+        if (evidence.observe(
+                "QS-AUTHZ-001",
+                s.endpointCount() > 0 && s.anyAuthMechanism(),
+                !hasProtectivePolicy(s.permissions())
+                        && s.protectiveAnnotationCount() == 0
+                        && !s.defaultRolesAllowed()
+                        && !s.denyUnannotatedEndpoints()
+                        && s.endpointCount() > 0
+                        && s.anyAuthMechanism())) {
             v.add(rule(
                     "QS-AUTHZ-001",
                     "No path or role authorization",
@@ -188,7 +221,7 @@ final class QuarkusSecurityChecks {
                 permitAll.add(p.name() + " (" + (p.paths() == null ? "/*" : p.paths()) + ")");
             }
         }
-        if (!permitAll.isEmpty()) {
+        if (evidence.observe("QS-AUTHZ-002", !permitAll.isEmpty())) {
             v.add(rule(
                     "QS-AUTHZ-002",
                     "Permission policy permits all paths",
@@ -200,10 +233,13 @@ final class QuarkusSecurityChecks {
                     permitAll,
                     "Scope the path, or use policy=authenticated/roles instead of permit."));
         }
-        if (s.anyAuthMechanism()
-                && !s.denyUnannotatedEndpoints()
-                && !s.defaultRolesAllowed()
-                && uncoveredEndpoints(s) > 0) {
+        if (evidence.observe(
+                "QS-AUTHZ-004",
+                s.endpointCount() > 0 && s.anyAuthMechanism(),
+                s.anyAuthMechanism()
+                        && !s.denyUnannotatedEndpoints()
+                        && !s.defaultRolesAllowed()
+                        && uncoveredEndpoints(s) > 0)) {
             v.add(
                     rule(
                             "QS-AUTHZ-004",
@@ -216,7 +252,7 @@ final class QuarkusSecurityChecks {
                             List.of(uncoveredEndpoints(s) + " declared endpoint(s) without a supported restriction"),
                             "Set quarkus.security.jaxrs.deny-unannotated-endpoints=true and mark public endpoints @PermitAll."));
         }
-        if ("enabled".equals(s.insecureRequests())) {
+        if (evidence.observe("QS-TLS-001", "enabled".equals(s.insecureRequests()))) {
             v.add(rule(
                     "QS-TLS-001",
                     "Insecure requests enabled",
@@ -228,7 +264,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.insecure-requests=enabled"),
                     "Prefer redirect once TLS is available, or document the terminating proxy."));
         }
-        if (!s.sslConfigured()) {
+        if (evidence.observe("QS-TLS-002", !s.sslConfigured())) {
             v.add(rule(
                     "QS-TLS-002",
                     "No TLS configured for the main HTTP listener",
@@ -241,7 +277,7 @@ final class QuarkusSecurityChecks {
                     List.of("no quarkus.http.ssl.* / selected quarkus.tls.* server keystore"),
                     "Configure TLS or document the terminating proxy."));
         }
-        if (s.tlsTrustAll()) {
+        if (evidence.observe("QS-TLS-003", s.tlsTrustAll())) {
             v.add(rule(
                     "QS-TLS-003",
                     "TLS certificate validation disabled",
@@ -254,7 +290,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.tls.trust-all=true (default or a named bucket)"),
                     "Remove trust-all; import the peer's CA into a trust-store instead."));
         }
-        if (s.insecureIdentityProviderUrl()) {
+        if (evidence.observe("QS-TLS-004", s.insecureIdentityProviderUrl())) {
             v.add(rule(
                     "QS-TLS-004",
                     "Identity-provider and JWK endpoints should use HTTPS",
@@ -266,7 +302,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.oidc.auth-server-url or mp.jwt.verify.publickey.location uses http://"),
                     "Use HTTPS identity-provider and JWK endpoints with certificate validation enabled."));
         }
-        if (!s.tlsHostnameVerificationDisabled().isEmpty()) {
+        if (evidence.observe("QS-TLS-005", !s.tlsHostnameVerificationDisabled().isEmpty())) {
             v.add(
                     rule(
                             "QS-TLS-005",
@@ -281,7 +317,7 @@ final class QuarkusSecurityChecks {
                             "Enable hostname verification for each applicable consumer; registry defaults depend on the consumer."));
         }
         boolean explicitWildcardCors = s.corsEnabled() && isExplicitWildcardOrigin(s.corsOrigins());
-        if (explicitWildcardCors && s.corsCredentials()) {
+        if (evidence.observe("QS-CORS-002", s.corsEnabled(), explicitWildcardCors && s.corsCredentials())) {
             v.add(rule(
                     "QS-CORS-002",
                     "CORS wildcard origin with credentials",
@@ -291,7 +327,7 @@ final class QuarkusSecurityChecks {
                     1,
                     List.of("a universal configured origin is allowed with credentials"),
                     "Pin explicit origins; never combine wildcard with credentials."));
-        } else if (explicitWildcardCors) {
+        } else if (evidence.observe("QS-CORS-001", s.corsEnabled(), explicitWildcardCors)) {
             v.add(rule(
                     "QS-CORS-001",
                     "CORS allows any origin",
@@ -303,7 +339,7 @@ final class QuarkusSecurityChecks {
                     List.of("a universal noncredentialed origin is configured"),
                     "Set quarkus.http.cors.origins to explicit origins."));
         }
-        if (s.hstsHeader() && isWeakHsts(s.hstsHeaderValue())) {
+        if (evidence.observe("QS-HDR-001", s.hstsHeader(), s.hstsHeader() && isWeakHsts(s.hstsHeaderValue()))) {
             v.add(rule(
                     "QS-HDR-001",
                     "Weak Strict-Transport-Security policy",
@@ -315,7 +351,10 @@ final class QuarkusSecurityChecks {
                     List.of("configured Strict-Transport-Security lifetime requires review"),
                     "Use max-age=31536000 (1 year); add includeSubDomains only when every subdomain is HTTPS-ready."));
         }
-        if (s.cspHeader() && isWeakCsp(s.cspHeaderValue())) {
+        if (evidence.observe(
+                "QS-HDR-002",
+                s.cspHeader() && CspPolicy.analyze(s.cspHeaderValue()).complete(),
+                s.cspHeader() && isWeakCsp(s.cspHeaderValue()))) {
             v.add(rule(
                     "QS-HDR-002",
                     "Weak Content-Security-Policy",
@@ -327,7 +366,7 @@ final class QuarkusSecurityChecks {
                     List.of("configured enforcing CSP permits unsafe or unrestricted script execution"),
                     "Remove unsafe-inline/unsafe-eval and wildcard sources; use nonces/hashes for scripts."));
         }
-        if (!s.hstsHeader() && s.sslConfigured()) {
+        if (evidence.observe("QS-HDR-003", s.sslConfigured(), !s.hstsHeader() && s.sslConfigured())) {
             v.add(rule(
                     "QS-HDR-003",
                     "Missing Strict-Transport-Security header",
@@ -340,7 +379,7 @@ final class QuarkusSecurityChecks {
                     "Add quarkus.http.header.\"Strict-Transport-Security\".value=max-age=31536000;"
                             + " includeSubDomains only when every subdomain is HTTPS-ready."));
         }
-        if (!s.cspHeader()) {
+        if (evidence.observe("QS-HDR-004", !s.cspHeader())) {
             v.add(rule(
                     "QS-HDR-004",
                     "Missing Content-Security-Policy header",
@@ -357,7 +396,7 @@ final class QuarkusSecurityChecks {
         boolean framingRestricted = s.cspHeader() && cspAnalysis.frameAncestorsPresent()
                 ? cspAnalysis.restrictiveFrameAncestors()
                 : s.xFrameOptionsHeader();
-        if (cspFramingKnown && !framingRestricted) {
+        if (evidence.observe("QS-HDR-005", cspFramingKnown, cspFramingKnown && !framingRestricted)) {
             v.add(rule(
                     "QS-HDR-005",
                     "Missing clickjacking protection",
@@ -371,7 +410,7 @@ final class QuarkusSecurityChecks {
                     "Use restrictive enforcing frame-ancestors, for example 'none'. X-Frame-Options=DENY is an"
                             + " alternative only when no enforcing ancestor directive overrides it."));
         }
-        if (!s.xContentTypeOptionsHeader()) {
+        if (evidence.observe("QS-HDR-006", !s.xContentTypeOptionsHeader())) {
             v.add(rule(
                     "QS-HDR-006",
                     "Missing X-Content-Type-Options header",
@@ -383,7 +422,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.header.\"X-Content-Type-Options\".value absent"),
                     "Add quarkus.http.header.\"X-Content-Type-Options\".value=nosniff."));
         }
-        if (s.oidcTlsVerificationNone()) {
+        if (evidence.observe("QS-DEV-001", s.oidcTlsVerificationNone())) {
             v.add(rule(
                     "QS-DEV-001",
                     "OIDC TLS verification disabled",
@@ -396,7 +435,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.oidc.tls.verification=none"),
                     "Remove the override outside local dev; never ship with verification disabled."));
         }
-        if (s.swaggerUiAlwaysInclude() || s.graphqlUiAlwaysInclude()) {
+        if (evidence.observe("QS-DEV-002", s.swaggerUiAlwaysInclude() || s.graphqlUiAlwaysInclude())) {
             List<String> alwaysIncluded = new ArrayList<>();
             if (s.swaggerUiAlwaysInclude()) {
                 alwaysIncluded.add("swagger-ui.always-include=true");
@@ -415,7 +454,7 @@ final class QuarkusSecurityChecks {
                     alwaysIncluded,
                     "Restrict to dev, or remove always-include."));
         }
-        if (s.healthUiAlwaysInclude()) {
+        if (evidence.observe("QS-DEV-003", s.healthUiAlwaysInclude())) {
             v.add(rule(
                     "QS-DEV-003",
                     "SmallRye Health UI always included",
@@ -428,7 +467,10 @@ final class QuarkusSecurityChecks {
                     "Remove the override so the Health UI is only available outside production, or protect it"
                             + " via the management interface / a permission policy."));
         }
-        if (s.oidcConfigured() && s.oidcServiceTokenConsumer() && !s.oidcAudienceConfigured()) {
+        if (evidence.observe(
+                "QS-OIDC-001",
+                s.oidcConfigured() && s.oidcServiceTokenConsumer(),
+                s.oidcConfigured() && s.oidcServiceTokenConsumer() && !s.oidcAudienceConfigured())) {
             v.add(rule(
                     "QS-OIDC-001",
                     "OIDC without token audience validation",
@@ -440,7 +482,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.oidc.auth-server-url set, quarkus.oidc.token.audience absent"),
                     "Set quarkus.oidc.token.audience to this service's expected audience."));
         }
-        if (s.oidcConfigured() && s.oidcIssuerAny()) {
+        if (evidence.observe("QS-OIDC-004", s.oidcConfigured(), s.oidcConfigured() && s.oidcIssuerAny())) {
             v.add(rule(
                     "QS-OIDC-004",
                     "OIDC token issuer validation is bypassed",
@@ -454,7 +496,13 @@ final class QuarkusSecurityChecks {
                             + " resolution when multiple issuers are intentional."));
         }
         boolean oidcWebApp = "web-app".equals(s.oidcApplicationType()) || "hybrid".equals(s.oidcApplicationType());
-        if (s.oidcConfigured() && oidcWebApp && !s.oidcCookieForceSecure() && "enabled".equals(s.insecureRequests())) {
+        if (evidence.observe(
+                "QS-OIDC-002",
+                s.oidcConfigured() && oidcWebApp,
+                s.oidcConfigured()
+                        && oidcWebApp
+                        && !s.oidcCookieForceSecure()
+                        && "enabled".equals(s.insecureRequests()))) {
             v.add(rule(
                     "QS-OIDC-002",
                     "OIDC web-app session cookie not forced secure",
@@ -467,7 +515,10 @@ final class QuarkusSecurityChecks {
                             + ", cookie-force-secure=false, HTTP accepted"),
                     "Disable or redirect HTTP and review cookie-force-secure, including trusted proxy handling."));
         }
-        if (s.oidcConfigured() && oidcWebApp && !s.oidcHasClientSecret() && !s.oidcPkceRequired()) {
+        if (evidence.observe(
+                "QS-OIDC-003",
+                s.oidcConfigured() && oidcWebApp && !s.oidcHasClientSecret(),
+                s.oidcConfigured() && oidcWebApp && !s.oidcHasClientSecret() && !s.oidcPkceRequired())) {
             v.add(rule(
                     "QS-OIDC-003",
                     "Public OIDC client without PKCE",
@@ -481,7 +532,8 @@ final class QuarkusSecurityChecks {
                             + ", no client secret, pkce-required=false"),
                     "Set quarkus.oidc.authentication.pkce-required=true for public clients."));
         }
-        if (s.managementEnabled() && s.managementHostNonLoopback()) {
+        if (evidence.observe(
+                "QS-MGMT-001", s.managementEnabled(), s.managementEnabled() && s.managementHostNonLoopback())) {
             v.add(rule(
                     "QS-MGMT-001",
                     "Management interface on a non-loopback host",
@@ -493,7 +545,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.management.enabled=true on a non-loopback host"),
                     "Bind quarkus.management.host to 127.0.0.1, or protect the management endpoints."));
         }
-        if (s.managementHostUnpinnedForProd()) {
+        if (evidence.observe("QS-MGMT-003", s.managementHostUnpinnedForProd())) {
             v.add(rule(
                     "QS-MGMT-003",
                     "Management interface has no explicit prod-scoped host binding",
@@ -507,7 +559,7 @@ final class QuarkusSecurityChecks {
                             + " %prod.quarkus.management.host absent"),
                     "Explicitly pin %prod.quarkus.management.host to 127.0.0.1, or to the intended bind address."));
         }
-        if (!s.suspectedSecretKeys().isEmpty()) {
+        if (evidence.observe("QS-CFG-001", !s.suspectedSecretKeys().isEmpty())) {
             v.add(rule(
                     "QS-CFG-001",
                     "Possible secret in configuration",
@@ -519,7 +571,7 @@ final class QuarkusSecurityChecks {
                     s.suspectedSecretKeys(),
                     "Move secrets to a vault or environment variables; never commit literals."));
         }
-        if (s.formAuth() && !s.formCookieHttpOnly()) {
+        if (evidence.observe("QS-SESSION-001", s.formAuth(), s.formAuth() && !s.formCookieHttpOnly())) {
             v.add(rule(
                     "QS-SESSION-001",
                     "Form-auth session cookie not HttpOnly",
@@ -531,7 +583,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.auth.form.http-only-cookie=false (the Quarkus default)"),
                     "Set quarkus.http.auth.form.http-only-cookie=true."));
         }
-        if (s.formAuth() && s.formCookieSameSiteNone()) {
+        if (evidence.observe("QS-SESSION-002", s.formAuth(), s.formAuth() && s.formCookieSameSiteNone())) {
             v.add(
                     rule(
                             "QS-SESSION-002",
@@ -544,7 +596,7 @@ final class QuarkusSecurityChecks {
                             List.of("quarkus.http.auth.form.cookie-same-site=none"),
                             "Use Secure with SameSite=None and verify independent CSRF defenses; choose Strict/Lax if compatible."));
         }
-        if (s.formAuth() && s.formSessionTimeoutExcessive()) {
+        if (evidence.observe("QS-SESSION-003", s.formAuth(), s.formAuth() && s.formSessionTimeoutExcessive())) {
             v.add(rule(
                     "QS-SESSION-003",
                     "Long form-auth idle timeout",
@@ -556,7 +608,7 @@ final class QuarkusSecurityChecks {
                     List.of("quarkus.http.auth.form.timeout >= 8h"),
                     "Lower the timeout (the Quarkus default is 30 minutes) and pair it with new-cookie-interval."));
         }
-        if (s.grpcReflectionEnabledInProd()) {
+        if (evidence.observe("QS-GRPC-001", s.grpcReflectionEnabledInProd())) {
             v.add(rule(
                     "QS-GRPC-001",
                     "gRPC server reflection enabled in the prod profile",
@@ -570,7 +622,8 @@ final class QuarkusSecurityChecks {
                     List.of("%prod quarkus.grpc.server.enable-reflection-service=true"),
                     "Remove the %prod override; keep reflection enabled only in %dev/%test."));
         }
-        if (s.graphqlPresent() && s.graphqlIntrospectionEnabled()) {
+        if (evidence.observe(
+                "QS-GRAPHQL-001", s.graphqlPresent(), s.graphqlPresent() && s.graphqlIntrospectionEnabled())) {
             v.add(rule(
                     "QS-GRAPHQL-001",
                     "GraphQL schema introspection enabled",
@@ -584,7 +637,7 @@ final class QuarkusSecurityChecks {
                     "Add no-introspection to quarkus.smallrye-graphql.field-visibility in %prod unless the"
                             + " schema is meant to be publicly discoverable."));
         }
-        if (!s.insecureMessagingChannels().isEmpty()) {
+        if (evidence.observe("QS-MSG-001", !s.insecureMessagingChannels().isEmpty())) {
             v.add(rule(
                     "QS-MSG-001",
                     "Messaging credentials configured without an encrypted protocol",
@@ -598,9 +651,10 @@ final class QuarkusSecurityChecks {
                     "Set security.protocol=SASL_SSL (or SSL) for each affected channel (or globally via"
                             + " kafka.security.protocol)."));
         }
-        return v.stream()
+        List<SecurityRuleResultDto> findings = v.stream()
                 .filter(result -> !s.evidence().unknownRules().contains(result.id()))
                 .toList();
+        return new Assessment(findings, evidence.usable || !findings.isEmpty());
     }
 
     private static boolean isBroadPath(String paths) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScanner.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.engine.quarkussecurity;
 
+import io.github.jdubois.bootui.core.dto.AdvisorAssessmentEvidenceDto;
 import io.github.jdubois.bootui.core.dto.SecurityReport;
 import io.github.jdubois.bootui.core.dto.SecurityRuleResultDto;
 import io.github.jdubois.bootui.core.dto.SecurityScanStatusDto;
@@ -77,7 +78,8 @@ public final class QuarkusSecurityScanner {
                     List.of(),
                     List.of(error("Quarkus security configuration could not be read.")));
         }
-        List<SecurityRuleResultDto> violations = QuarkusSecurityChecks.evaluate(snap);
+        QuarkusSecurityChecks.Assessment assessment = QuarkusSecurityChecks.assess(snap);
+        List<SecurityRuleResultDto> violations = assessment.findings();
         List<String> policyLabels = snap.permissions().stream()
                 .map(QuarkusSecurityScanner::policyLabel)
                 .toList();
@@ -97,7 +99,8 @@ public final class QuarkusSecurityScanner {
                 clock.millis(),
                 policyLabels,
                 violations,
-                errors);
+                errors,
+                assessment.usable());
     }
 
     private static String policyLabel(QuarkusSecurityPermission p) {
@@ -130,6 +133,17 @@ public final class QuarkusSecurityScanner {
             List<String> policyLabels,
             List<SecurityRuleResultDto> raw,
             List<SecurityRuleResultDto> errors) {
+        return report(status, message, scannedAt, policyLabels, raw, errors, !raw.isEmpty());
+    }
+
+    private SecurityReport report(
+            String status,
+            String message,
+            Long scannedAt,
+            List<String> policyLabels,
+            List<SecurityRuleResultDto> raw,
+            List<SecurityRuleResultDto> errors,
+            boolean usable) {
         List<SecurityRuleResultDto> violations = raw.stream().sorted(IMPORTANCE).toList();
         SecurityScanStatusDto scan = new SecurityScanStatusDto(
                 ANALYZER,
@@ -149,7 +163,8 @@ public final class QuarkusSecurityScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                errors);
+                errors,
+                new AdvisorAssessmentEvidenceDto(usable, "PARTIAL".equals(status) || !errors.isEmpty()));
     }
 
     public SecurityReport applyDismissals(SecurityReport report, Set<String> dismissedIds) {
@@ -180,7 +195,8 @@ public final class QuarkusSecurityScanner {
                 severityCounts(active),
                 scan,
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     private List<SecuritySeverityCountDto> severityCounts(List<SecurityRuleResultDto> results) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/reactivesecurity/ReactiveSecurityScanner.java
@@ -6,6 +6,7 @@ import io.github.jdubois.bootui.core.dto.SecurityScanStatusDto;
 import io.github.jdubois.bootui.core.dto.SecuritySeverityCountDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.Comparator;
@@ -147,7 +148,8 @@ public final class ReactiveSecurityScanner {
                 severityCounts(active),
                 updatedScan,
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────────
@@ -203,7 +205,9 @@ public final class ReactiveSecurityScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                analysisErrors(results));
+                analysisErrors(results),
+                AdvisorAssessmentEvidence.fromResults(
+                        results, SecurityRuleResultDto::status, "PARTIAL".equals(status)));
     }
 
     private static List<String> chainDescriptions(ReactiveSecurityContext context) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/DeclaredExceptionsHaveHandlersRule.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/DeclaredExceptionsHaveHandlersRule.java
@@ -42,7 +42,7 @@ final class DeclaredExceptionsHaveHandlersRule extends AbstractRestApiRule {
         }
         if (context.exceptionHandlers().stream()
                 .anyMatch(handler -> handler.handledExceptionTypes().isEmpty())) {
-            return RestApiRuleSupport.skipped(
+            return RestApiRuleSupport.unknown(
                     definition(),
                     "A handler or mapper has unresolved handled-exception types; the imported inventory cannot"
                             + " establish that a declaration is missing.");

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRule.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRule.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.restapi;
 
 import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 
 /**
  * One curated REST API Advisor rule. Implementations describe themselves through a stable
@@ -12,4 +13,8 @@ interface RestApiRule {
     RestApiRuleDefinition definition();
 
     RestApiRuleResultDto evaluate(RestApiContext context);
+
+    default AdvisorRuleAssessment<RestApiRuleResultDto> evaluateAssessment(RestApiContext context) {
+        return RestApiRuleSupport.assessment(evaluate(context));
+    }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleSupport.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleSupport.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.restapi;
 
 import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.support.DetailText;
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +19,7 @@ final class RestApiRuleSupport {
     static final String VIOLATION = "VIOLATION";
     static final String SKIPPED = "SKIPPED";
     static final String ERROR = "ERROR";
+    private static final String REQUIRED_EVIDENCE_UNAVAILABLE = "REQUIRED_EVIDENCE_UNAVAILABLE";
 
     private static final int MAX_SAMPLE_VIOLATIONS = 10;
 
@@ -29,6 +31,30 @@ final class RestApiRuleSupport {
 
     static RestApiRuleResultDto skipped(RestApiRuleDefinition definition, String reason) {
         return result(definition, SKIPPED, 0, List.of(detail(reason)));
+    }
+
+    static RestApiRuleResultDto unknown(RestApiRuleDefinition definition, String reason) {
+        return result(definition, REQUIRED_EVIDENCE_UNAVAILABLE, 0, List.of(detail(reason)));
+    }
+
+    static AdvisorRuleAssessment<RestApiRuleResultDto> assessment(RestApiRuleResultDto result) {
+        if (!REQUIRED_EVIDENCE_UNAVAILABLE.equals(result.status())) {
+            return new AdvisorRuleAssessment<>(result, ERROR.equals(result.status()));
+        }
+        return new AdvisorRuleAssessment<>(
+                new RestApiRuleResultDto(
+                        result.id(),
+                        result.name(),
+                        result.category(),
+                        result.severity(),
+                        result.description(),
+                        SKIPPED,
+                        result.violationCount(),
+                        result.sampleViolations(),
+                        result.recommendation(),
+                        result.learnMoreUrl(),
+                        result.dismissed()),
+                true);
     }
 
     static RestApiRuleResultDto error(RestApiRuleDefinition definition, String reason) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiRules.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.engine.restapi;
 
 import io.github.jdubois.bootui.core.dto.RestApiRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.errorcontract.ErrorBodyCategory;
 import io.github.jdubois.bootui.engine.restapi.RestApiModel.ControllerModel;
 import io.github.jdubois.bootui.engine.restapi.RestApiModel.ExceptionHandlerModel;
@@ -39,6 +40,15 @@ abstract class AbstractRestApiRule implements RestApiRule {
 
     @Override
     public final RestApiRuleResultDto evaluate(RestApiContext context) {
+        return evaluateAssessment(context).result();
+    }
+
+    @Override
+    public final AdvisorRuleAssessment<RestApiRuleResultDto> evaluateAssessment(RestApiContext context) {
+        return RestApiRuleSupport.assessment(evaluateSafely(context));
+    }
+
+    private RestApiRuleResultDto evaluateSafely(RestApiContext context) {
         try {
             return doEvaluate(context);
         } catch (RuntimeException | LinkageError ex) {
@@ -1505,13 +1515,13 @@ final class CentralizedExceptionHandlingRule extends AbstractRestApiRule {
             boolean jaxRsDeclarations = context.controllers().stream().anyMatch(ControllerModel::jaxRs)
                     || context.exceptionHandlers().stream().anyMatch(ExceptionHandlerModel::jaxRs);
             if (springDeclarations && jaxRsDeclarations) {
-                return RestApiRuleSupport.skipped(
+                return RestApiRuleSupport.unknown(
                         definition(),
                         "Application-wide error-handling presence cannot be attributed per framework in this mixed"
                                 + " Spring/Jakarta REST model; advice or mapper presence is not transferred between stacks.");
             }
             if (jaxRsDeclarations && context.exceptionHandlers().stream().noneMatch(ExceptionHandlerModel::jaxRs)) {
-                return RestApiRuleSupport.skipped(
+                return RestApiRuleSupport.unknown(
                         definition(),
                         "The aggregate error-handling flag has no corresponding Jakarta REST mapper declaration;"
                                 + " native handling presence cannot be established.");

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiScanner.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/restapi/RestApiScanner.java
@@ -7,6 +7,8 @@ import io.github.jdubois.bootui.core.dto.RestApiScanStatusDto;
 import io.github.jdubois.bootui.core.dto.RestApiSeverityCountDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -223,6 +225,7 @@ public final class RestApiScanner {
                 model.framework());
 
         List<RestApiRuleResultDto> results = new ArrayList<>();
+        boolean incompleteEvidence = false;
         for (RestApiRule rule : rules) {
             String id = rule.definition().id();
             if (model.incomplete() && COMPLETE_EXCEPTION_MODEL_RULE_IDS.contains(id)) {
@@ -238,7 +241,9 @@ public final class RestApiScanner {
                         rule.definition(), "Required framework evidence could not be read."));
                 continue;
             }
-            RestApiRuleResultDto result = evaluate(rule, context);
+            AdvisorRuleAssessment<RestApiRuleResultDto> assessment = evaluateAssessment(rule, context);
+            RestApiRuleResultDto result = assessment.result();
+            incompleteEvidence |= assessment.incomplete();
             if (RestApiRuleSupport.ERROR.equals(result.status())) {
                 failures.add("rule evaluation");
             }
@@ -251,43 +256,53 @@ public final class RestApiScanner {
                         ? "REST API rules completed against "
                                 + model.controllers().size() + " controller(s) and "
                                 + model.handlers().size() + " handler method(s) under the detected base package(s)."
+                                + (incompleteEvidence ? " Some required observations remain unknown." : "")
                         : incompleteMessage(failures),
                 clock.millis(),
                 basePackages,
                 model.controllers().size(),
                 model.handlers().size(),
                 results.size(),
-                results);
+                results,
+                incompleteEvidence || !failures.isEmpty());
     }
 
     static RestApiRuleResultDto evaluate(RestApiRule rule, RestApiContext context) {
+        return evaluateAssessment(rule, context).result();
+    }
+
+    static AdvisorRuleAssessment<RestApiRuleResultDto> evaluateAssessment(RestApiRule rule, RestApiContext context) {
         RestApiRuleDefinition definition = rule.definition();
         if (context.jaxRs() && SPRING_PROBLEM_DETAIL_RULE_IDS.contains(definition.id())) {
-            return RestApiRuleSupport.skipped(
+            return RestApiRuleSupport.assessment(RestApiRuleSupport.skipped(
                     definition,
                     "Not applicable on JAX-RS: RFC 9457 is framework-neutral, but this rule specifically detects"
                             + " Spring ProblemDetail/ErrorResponse return types; the current model cannot reliably"
-                            + " identify equivalent JAX-RS problem-details payloads.");
+                            + " identify equivalent JAX-RS problem-details payloads."));
         }
         if (context.jaxRs() && SPRING_DATA_PAGINATION_RULE_IDS.contains(definition.id())) {
-            return RestApiRuleSupport.skipped(
+            return RestApiRuleSupport.assessment(RestApiRuleSupport.skipped(
                     definition,
                     "Not applicable on JAX-RS: this rule specifically compares Spring Data Pageable inputs with"
-                            + " Page/Slice outputs.");
+                            + " Page/Slice outputs."));
         }
         if (context.jaxRs() && SPRING_PATH_BINDING_RULE_IDS.contains(definition.id())) {
-            return RestApiRuleSupport.skipped(
-                    definition,
-                    "Not applicable on JAX-RS: this rule checks Spring @PathVariable bindings or unique path-template"
-                            + " token names. Jakarta REST uses different parameter binding and token scoping semantics.");
+            return RestApiRuleSupport.assessment(
+                    RestApiRuleSupport.skipped(
+                            definition,
+                            "Not applicable on JAX-RS: this rule checks Spring @PathVariable bindings or unique path-template"
+                                    + " token names. Jakarta REST uses different parameter binding and token scoping semantics."));
         }
         try {
-            RestApiRuleResultDto result = rule.evaluate(context);
+            AdvisorRuleAssessment<RestApiRuleResultDto> assessment = rule.evaluateAssessment(context);
+            RestApiRuleResultDto result = assessment.result();
             return result == null || RestApiRuleSupport.ERROR.equals(result.status())
-                    ? RestApiRuleSupport.error(definition, "Rule evaluation failed; no conclusion was reached.")
-                    : result;
+                    ? RestApiRuleSupport.assessment(
+                            RestApiRuleSupport.error(definition, "Rule evaluation failed; no conclusion was reached."))
+                    : assessment;
         } catch (RuntimeException | LinkageError ex) {
-            return RestApiRuleSupport.error(definition, "Rule evaluation failed; no conclusion was reached.");
+            return RestApiRuleSupport.assessment(
+                    RestApiRuleSupport.error(definition, "Rule evaluation failed; no conclusion was reached."));
         }
     }
 
@@ -329,6 +344,28 @@ public final class RestApiScanner {
             int handlersAnalyzed,
             int rulesEvaluated,
             List<RestApiRuleResultDto> results) {
+        return report(
+                status,
+                message,
+                scannedAt,
+                basePackages,
+                controllersAnalyzed,
+                handlersAnalyzed,
+                rulesEvaluated,
+                results,
+                "PARTIAL".equals(status));
+    }
+
+    private RestApiReport report(
+            String status,
+            String message,
+            Long scannedAt,
+            List<String> basePackages,
+            int controllersAnalyzed,
+            int handlersAnalyzed,
+            int rulesEvaluated,
+            List<RestApiRuleResultDto> results,
+            boolean incomplete) {
         List<RestApiRuleResultDto> violations = violationResults(results);
         int violationsFound = violations.size();
         RestApiScanStatusDto scan = new RestApiScanStatusDto(
@@ -350,7 +387,8 @@ public final class RestApiScanner {
                 violationsFound,
                 severityCounts(violations),
                 scan,
-                violations);
+                violations,
+                AdvisorAssessmentEvidence.fromResults(results, RestApiRuleResultDto::status, incomplete));
     }
 
     public RestApiReport applyDismissals(RestApiReport report, Set<String> dismissedIds) {
@@ -383,7 +421,8 @@ public final class RestApiScanner {
                 violationsFound,
                 severityCounts(active),
                 updatedScan,
-                marked);
+                marked,
+                report.assessmentEvidence());
     }
 
     private List<RestApiSeverityCountDto> severityCounts(List<RestApiRuleResultDto> results) {

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReports.java
@@ -298,7 +298,8 @@ public final class DependencyReports {
                 dependency.source(),
                 (int) activeCount,
                 highestSeverity(markedVulnerabilities),
-                markedVulnerabilities);
+                markedVulnerabilities,
+                dependency.assessmentComplete());
     }
 
     /**
@@ -468,7 +469,8 @@ public final class DependencyReports {
                 dependency.source(),
                 dependency.vulnerabilityCount(),
                 dependency.highestSeverity(),
-                updated);
+                updated,
+                dependency.assessmentComplete());
     }
 
     private static DependencyVulnerabilityDto applyEpssScore(

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/advisor/AdvisorAssessmentEvidenceTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/advisor/AdvisorAssessmentEvidenceTests.java
@@ -1,0 +1,39 @@
+package io.github.jdubois.bootui.engine.advisor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class AdvisorAssessmentEvidenceTests {
+
+    @Test
+    void completedOutcomesSurviveUnrelatedMissingEvidence() {
+        for (String outcome : List.of("PASS", "VIOLATION")) {
+            var evidence = AdvisorAssessmentEvidence.fromResults(
+                    List.of(outcome, "SKIPPED", "ERROR"), Function.identity(), false);
+            assertThat(evidence.usable()).isTrue();
+            assertThat(evidence.incomplete()).isTrue();
+        }
+    }
+
+    @Test
+    void emptySkippedAndFailedEvaluationsDoNotEstablishUsableEvidence() {
+        for (List<String> outcomes : List.of(List.<String>of(), List.of("SKIPPED"), List.of("ERROR"))) {
+            var evidence = AdvisorAssessmentEvidence.fromResults(outcomes, Function.identity(), false);
+            assertThat(evidence.usable()).isFalse();
+            assertThat(evidence.incomplete()).isEqualTo(outcomes.contains("ERROR"));
+        }
+    }
+
+    @Test
+    void intentionalNonApplicabilityDoesNotMakeCompletedChecksIncomplete() {
+        var evidence = AdvisorAssessmentEvidence.fromResults(List.of("PASS", "SKIPPED"), Function.identity(), false);
+        assertThat(evidence.usable()).isTrue();
+        assertThat(evidence.incomplete()).isFalse();
+        assertThat(AdvisorAssessmentEvidence.fromResults(List.of("PASS"), Function.identity(), true)
+                        .incomplete())
+                .isTrue();
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
@@ -72,6 +72,8 @@ class HibernateScannerTests {
         HibernateReport report = scanner.scan();
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
         assertThat(report.entitiesAnalyzed()).isEqualTo(1);
         assertThat(report.rulesEvaluated()).isEqualTo(RULE_COUNT);
         assertThat(report.results())

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/memory/MemoryScannerTests.java
@@ -42,6 +42,7 @@ class MemoryScannerTests {
         assertThat(report.results()).isEmpty();
         assertThat(report.rulesEvaluated()).isZero();
         assertThat(report.localOnly()).isTrue();
+        assertThat(report.assessmentEvidence().usable()).isFalse();
     }
 
     @Test
@@ -55,6 +56,27 @@ class MemoryScannerTests {
         assertThat(report.violationsFound()).isZero();
         assertThat(report.results()).isEmpty();
         assertThat(report.summary().heapUsedPercent()).isEqualTo(25);
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
+        assertThat(report.scan().message()).contains("lack the observations");
+    }
+
+    @Test
+    void unavailableSamplesDifferFromInapplicableChecksWithoutChangingPublicOutcomes() {
+        MemoryContext context = healthyContext();
+        var unavailable = new BigObjectsRule().evaluateAssessment(context);
+        var baseline = new RecentGcOverheadRule().evaluateAssessment(context);
+        var notApplicable = new MissingHeapSizingInContainerRule().evaluateAssessment(context);
+        var completed = new HighHeapUtilizationRule().evaluateAssessment(context);
+
+        assertThat(unavailable.result().status()).isEqualTo("SKIPPED");
+        assertThat(unavailable.incomplete()).isTrue();
+        assertThat(baseline.result().status()).isEqualTo("SKIPPED");
+        assertThat(baseline.incomplete()).isTrue();
+        assertThat(notApplicable.result().status()).isEqualTo("SKIPPED");
+        assertThat(notApplicable.incomplete()).isFalse();
+        assertThat(completed.result().status()).isEqualTo("PASS");
+        assertThat(completed.incomplete()).isFalse();
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/pentesting/PentestingScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/pentesting/PentestingScannerTests.java
@@ -33,6 +33,8 @@ class PentestingScannerTests {
                 new PentestingLocalHttpResponse(403, Map.of(), "", null));
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
         assertThat(report.findings())
                 .noneSatisfy(finding -> assertThat(finding.target()).contains("JSESSIONID"));
         assertThat(report.findings())
@@ -297,6 +299,7 @@ class PentestingScannerTests {
 
         assertThat(report.localOnly()).isTrue();
         assertThat(report.scan().status()).isEqualTo("NOT_SCANNED");
+        assertThat(report.assessmentEvidence().usable()).isFalse();
         assertThat(report.checksRun()).isZero();
         assertThat(report.findings()).isEmpty();
         assertThat(report.coverage()).extracting("status").contains("NOT_RUN", "SKIPPED", "HANDOFF");
@@ -320,6 +323,7 @@ class PentestingScannerTests {
     void scannedCoverageUsesInformationalReviewPromptsWhenNoFindingIsProduced() {
         PentestingReport report =
                 scanner(new CapturingLocalHttpClient(), defaultObservation()).scan();
+        assertThat(report.assessmentEvidence().usable()).isTrue();
 
         // defaultObservation() has zero application mappings and zero SecurityFilterChain beans, so none of
         // the A01/A07 checks fire regardless of springMetadataAvailable — this pins the Spring-side baseline
@@ -559,6 +563,27 @@ class PentestingScannerTests {
                 .filteredOn(coverage -> "A02:2025".equals(coverage.category()))
                 .extracting("status")
                 .containsOnly("INDETERMINATE");
+    }
+
+    @Test
+    void diagnosticOnlyFindingsWithNoAssessedCategoryDoNotEstablishUsableEvidence() {
+        PentestingObservation observation = new PentestingObservation(
+                new PentestingEndpointInventory(0, List.of(), java.util.Set.of(), "/", false, true),
+                defaultSecurity(),
+                defaultConfig(),
+                "8123",
+                "",
+                false,
+                true,
+                true);
+        PentestingLocalHttpClient client = (method, uri, headers) ->
+                new PentestingLocalHttpResponse(0, Map.of(), null, "Local response unavailable");
+        PentestingReport report = scanner(client, observation).scan();
+        assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.findings()).extracting(PentestingFindingDto::id).containsOnly("PT-A05-001", "PT-A05-069");
+        assertThat(report.coverage()).extracting("status").doesNotContain("INFO", "REVIEW");
+        assertThat(report.assessmentEvidence().usable()).isFalse();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkusapp/QuarkusAppScannerTest.java
@@ -143,6 +143,8 @@ class QuarkusAppScannerTest {
         assertThat(report.componentsAnalyzed()).isEqualTo(4);
         assertThat(report.scan().componentsAnalyzed()).isEqualTo(4);
         assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isFalse();
         assertThat(report.scan().scannedAt()).isEqualTo(1000L);
         assertThat(report.violationsFound()).isZero();
         assertThat(report.inspected())

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/quarkussecurity/QuarkusSecurityScannerTest.java
@@ -19,6 +19,69 @@ class QuarkusSecurityScannerTest {
 
     private static final Clock CLOCK = Clock.fixed(Instant.ofEpochMilli(1000), ZoneOffset.UTC);
 
+    @Test
+    void whollyUnknownRuleEvidenceDoesNotBecomeAPerfectAssessmentFromTheRegistrySize() {
+        Snap snapshot = new Snap();
+        snapshot.evidence = new QuarkusSecurityEvidence(
+                unknownRuleIds(), List.of("No supported observations"), List.of(), List.of(), true);
+        SecurityReport report = scan(snapshot);
+        assertThat(report.rulesEvaluated()).isEqualTo(42);
+        assertThat(report.results()).isEmpty();
+        assertThat(report.assessmentEvidence().usable()).isFalse();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
+    }
+
+    @Test
+    void knownButInapplicableMechanismChecksDoNotEstablishUsableEvidence() {
+        Set<String> unknown = unknownRuleIds();
+        unknown.removeAll(Set.of(
+                "QS-AUTH-001",
+                "QS-AUTH-002",
+                "QS-AUTH-003",
+                "QS-AUTH-004",
+                "QS-AUTH-008",
+                "QS-AUTH-009",
+                "QS-AUTH-012",
+                "QS-AUTH-013",
+                "QS-AUTHZ-001",
+                "QS-AUTHZ-004",
+                "QS-OIDC-001",
+                "QS-OIDC-002",
+                "QS-OIDC-003",
+                "QS-OIDC-004",
+                "QS-MGMT-001",
+                "QS-SESSION-001",
+                "QS-SESSION-002",
+                "QS-SESSION-003",
+                "QS-GRAPHQL-001"));
+        Snap snapshot = new Snap();
+        snapshot.basic = false;
+        snapshot.endpoints = 0;
+        snapshot.evidence =
+                new QuarkusSecurityEvidence(unknown, List.of("Other checks unavailable"), List.of(), List.of(), true);
+
+        SecurityReport report = scan(snapshot);
+
+        assertThat(report.results()).isEmpty();
+        assertThat(report.assessmentEvidence().usable()).isFalse();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
+
+        snapshot.basic = true;
+        SecurityReport checked = scan(snapshot);
+        assertThat(checked.results()).isEmpty();
+        assertThat(checked.assessmentEvidence().usable()).isTrue();
+        assertThat(checked.assessmentEvidence().incomplete()).isTrue();
+    }
+
+    private static Set<String> unknownRuleIds() {
+        return java.util.stream.Stream.of(
+                        "AUTH", "AUTHZ", "TLS", "CORS", "HDR", "DEV", "OIDC", "MGMT", "CFG", "SESSION", "GRPC",
+                        "GRAPHQL", "MSG")
+                .flatMap(group -> java.util.stream.IntStream.rangeClosed(1, 20)
+                        .mapToObj(number -> "QS-" + group + "-" + String.format(java.util.Locale.ROOT, "%03d", number)))
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
     /**
      * Mutable builder whose defaults describe a hardened Quarkus app that fires zero rules, so each test can
      * flip exactly the fields under test. Mirrors the {@link QuarkusSecuritySnapshot} positional record.
@@ -198,6 +261,8 @@ class QuarkusSecurityScannerTest {
         assertThat(r.violationsFound()).isZero();
         assertThat(r.filterChainsAnalyzed()).isEqualTo(1);
         assertThat(r.scan().status()).isEqualTo("SCANNED");
+        assertThat(r.assessmentEvidence().usable()).isTrue();
+        assertThat(r.assessmentEvidence().incomplete()).isFalse();
     }
 
     @Test
@@ -1107,6 +1172,7 @@ class QuarkusSecurityScannerTest {
         int before = scanned.violationsFound();
         SecurityReport after = scanner.applyDismissals(scanned, Set.of("QS-AUTH-001"));
         assertThat(after.violationsFound()).isEqualTo(before - 1);
+        assertThat(after.assessmentEvidence()).isEqualTo(scanned.assessmentEvidence());
     }
 
     @Test
@@ -1114,6 +1180,7 @@ class QuarkusSecurityScannerTest {
         Snap s = new Snap();
         SecurityReport r = QuarkusSecurityScanner.usingSnapshot(s::build, CLOCK).initialReport();
         assertThat(r.scan().status()).isEqualTo("NOT_SCANNED");
+        assertThat(r.assessmentEvidence().usable()).isFalse();
         assertThat(r.violationsFound()).isZero();
     }
 
@@ -1144,6 +1211,8 @@ class QuarkusSecurityScannerTest {
                 true);
         SecurityReport report = scan(s);
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
         assertThat(find(report, "QS-AUTH-002")).isNotNull();
         assertThat(find(report, "QS-AUTH-004")).isNull();
         assertThat(report.analysisErrors())
@@ -1161,6 +1230,7 @@ class QuarkusSecurityScannerTest {
                         CLOCK)
                 .scan();
         assertThat(report.scan().status()).isEqualTo("ERROR");
+        assertThat(report.assessmentEvidence().usable()).isFalse();
         assertThat(report.analysisErrors()).hasSize(1);
         assertThat(report.toString()).doesNotContain("secret-value");
         assertThat(QuarkusSecurityScanner.usingSnapshot(() -> null, CLOCK)

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleAccuracyTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiRuleAccuracyTests.java
@@ -239,6 +239,11 @@ class RestApiRuleAccuracyTests {
                 context(RestApiRuleAccuracyFixtures.Responses.class, RestApiRuleAccuracyFixtures.JaxResource.class));
         assertThat(mixed.status()).isEqualTo("SKIPPED");
         assertThat(mixed.sampleViolations()).singleElement().asString().contains("cannot be attributed per framework");
+        assertThat(rule.evaluateAssessment(context(
+                                RestApiRuleAccuracyFixtures.Responses.class,
+                                RestApiRuleAccuracyFixtures.JaxResource.class))
+                        .incomplete())
+                .isTrue();
 
         var springAdviceOnly = rule.evaluate(context(
                 RestApiRuleAccuracyFixtures.DynamicAdvice.class, RestApiRuleAccuracyFixtures.JaxWithoutMapper.class));

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/restapi/RestApiScannerTests.java
@@ -335,6 +335,42 @@ class RestApiScannerTests {
         RestApiReport report = scanner.scan();
         assertThat(report.scan().status()).isEqualTo("SCANNED");
         assertThat(report.results()).extracting(RestApiRuleResultDto::id).containsExactly("RAPI-TEST-001");
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isFalse();
+    }
+
+    @Test
+    void missingRuleEvidenceQualifiesCompletedChecksWithoutChangingScanStatus() {
+        RestApiScanner scanner = fixtureScanner(
+                () -> false,
+                () -> false,
+                List.of(
+                        rule("RAPI-TEST-001", RestApiRuleSupport::pass),
+                        rule(
+                                "RAPI-TEST-002",
+                                definition -> RestApiRuleSupport.unknown(definition, "Metadata unavailable"))));
+
+        RestApiReport report = scanner.scan();
+
+        assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.rulesEvaluated()).isEqualTo(2);
+        assertThat(report.results()).isEmpty();
+        assertThat(report.assessmentEvidence().usable()).isTrue();
+        assertThat(report.assessmentEvidence().incomplete()).isTrue();
+    }
+
+    @Test
+    void allUnevaluatedRulesCannotEstablishUsableEvidence() {
+        for (RestApiRule unevaluated : List.of(
+                rule("RAPI-TEST-001", definition -> RestApiRuleSupport.skipped(definition, "Not applicable")),
+                rule("RAPI-TEST-001", definition -> RestApiRuleSupport.unknown(definition, "Metadata unavailable")))) {
+            RestApiReport report = fixtureScanner(() -> false, () -> false, List.of(unevaluated))
+                    .scan();
+            assertThat(report.scan().status()).isEqualTo("SCANNED");
+            assertThat(report.rulesEvaluated()).isEqualTo(1);
+            assertThat(report.assessmentEvidence().usable()).isFalse();
+            assertThat(report.results()).isEmpty();
+        }
     }
 
     @Test

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/vulnerabilities/DependencyReportsTests.java
@@ -116,10 +116,11 @@ class DependencyReportsTests {
         DependencyVulnerabilityDto vulnerability = new DependencyVulnerabilityDto(
                 id, "summary", "details", "HIGH", 7.5, aliases, List.of(), List.of(), false, null, null, true);
         DependencyDto dependency = new DependencyDto(
-                "org.example", "library", "1", "org.example:library", "test", 0, "NONE", List.of(vulnerability));
+                "org.example", "library", "1", "org.example:library", "test", 0, "NONE", List.of(vulnerability), true);
         List<DependencyDto> result = DependencyReports.applyEpssScores(List.of(dependency), scores);
         assertThat(result.get(0).vulnerabilityCount()).isZero();
         assertThat(result.get(0).highestSeverity()).isEqualTo("NONE");
+        assertThat(result.get(0).assessmentComplete()).isTrue();
         assertThat(vulnerability.epssScore()).isNull();
         return result.get(0).vulnerabilities().get(0);
     }
@@ -134,7 +135,15 @@ class DependencyReportsTests {
         String packageName = groupId + ":" + artifactId;
         List<DependencyVulnerabilityDto> vulnerabilities = List.of(vulnerability("V-" + artifactId, severity));
         return new DependencyDto(
-                groupId, artifactId, version, packageName, "test", vulnerabilities.size(), severity, vulnerabilities);
+                groupId,
+                artifactId,
+                version,
+                packageName,
+                "test",
+                vulnerabilities.size(),
+                severity,
+                vulnerabilities,
+                true);
     }
 
     private static DependencyVulnerabilityDto vulnerability(String id, String severity) {
@@ -334,6 +343,7 @@ class DependencyReportsTests {
         DependenciesReport updated = DependencyReports.applyDismissals(report, Set.of(key));
 
         DependencyDto dependency = updated.dependencies().get(0);
+        assertThat(dependency.assessmentComplete()).isTrue();
         assertThat(dependency.vulnerabilities())
                 .extracting(DependencyVulnerabilityDto::dismissed)
                 .containsExactly(true);

--- a/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
 
 /**
  * The Hibernate advisor runs the shared engine's mapping/identifier/fetch rules against the live JPA
@@ -31,7 +32,8 @@ test.describe('Hibernate advisor (Quarkus)', () => {
     expect(report.results.some((result) => result.id.startsWith('HIB-QUERY-'))).toBe(false)
 
     await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
-    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    expect(report.assessmentEvidence).toEqual({usable: true, incomplete: true})
+    await expectPartialAdvisorScore(page, expect, report.severityCounts)
     await expect(page.locator('main')).toContainText('Entities analysed')
 
     // Effective batching makes the stronger IDENTITY finding apply, without duplicate generic advice.

--- a/bootui-quarkus-sample-app/e2e/tests/pentesting.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/pentesting.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
 
 /**
  * The Pentesting panel runs bounded, local-only OWASP hygiene checks against the host application (never
@@ -17,7 +18,7 @@ test.describe('Pentesting advisor (Quarkus)', () => {
     const checksCard = page.locator('.advisor-summary__metric', {hasText: 'Checks run'})
     await expect(checksCard.locator('dd')).toHaveText('79', {timeout: 20_000})
     await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
-    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    await expectPartialAdvisorScore(page, expect)
     await expect(
       page.locator('.alert-warning').filter({hasText: /GET response body exceeded the 8 KiB inspection limit/})
     ).toBeVisible()

--- a/bootui-quarkus-sample-app/e2e/tests/quarkus-advisor.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/quarkus-advisor.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
 
 /**
  * The Spring advisor is replaced by a framework-aware Quarkus advisor. There is no separate
@@ -29,7 +30,8 @@ test.describe('Quarkus advisor', () => {
     expect(report.scan.message).toBeTruthy()
 
     await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
-    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    expect(report.assessmentEvidence).toEqual({usable: true, incomplete: true})
+    await expectPartialAdvisorScore(page, expect, report.severityCounts)
     await expect(page.locator('main')).toContainText('Idioms inspected')
   })
 })

--- a/bootui-quarkus-sample-app/e2e/tests/security.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/security.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
 
 /**
  * The Security panel replaces Spring's Spring-Security-coupled advisor with a Quarkus-native ruleset
@@ -15,7 +16,7 @@ test.describe('Security advisor (Quarkus)', () => {
     await page.getByRole('button', {name: 'Run security checks'}).click()
 
     await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete', {timeout: 20_000})
-    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    await expectPartialAdvisorScore(page, expect)
     await expect(page.locator('main')).toContainText('Heuristic Quarkus rules')
     await expect(page.locator('main')).toContainText('Permission policies')
   })
@@ -33,7 +34,8 @@ test.describe('Security advisor (Quarkus)', () => {
     expect(report.scan.status).toBe('PARTIAL')
     expect(report.scan.message).toBeTruthy()
     await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
-    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    expect(report.assessmentEvidence).toEqual({usable: true, incomplete: true})
+    await expectPartialAdvisorScore(page, expect, report.severityCounts)
 
     // quarkus.http.auth.basic=true with insecure-requests=enabled (the sample's default).
     const basicAuthRow = page.locator('.list-group-item', {hasText: 'QS-AUTH-002'})

--- a/bootui-quarkus-sample-app/e2e/tests/vulnerabilities.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/vulnerabilities.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore} from '../../../bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js'
 
 /**
  * The Vulnerabilities panel lists the local runtime JAR inventory (captured at Quarkus build time from
@@ -24,7 +25,10 @@ test.describe('Vulnerabilities (Quarkus)', () => {
 
     // The fixture-backed server is configured with max-packages=3, below the real inventory size.
     await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
-    await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+    await expectPartialAdvisorScore(page, expect, [
+      {severity: 'CRITICAL', count: 1},
+      {severity: 'LOW', count: 1}
+    ])
     // A truncated scan must say so rather than letting the result read as a complete one.
     const truncationWarning = page.locator('.alert-warning', {hasText: 'not sent to OSV.dev'})
     await expect(truncationWarning).toBeVisible()

--- a/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
+++ b/bootui-quarkus/src/main/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScanner.java
@@ -300,7 +300,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             packagesScanned = queryResult.packagesScanned();
             Map<String, List<String>> vulnerabilityIds = queryResult.idsByPackage();
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
-            EnrichmentResult interpretation = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
+            EnrichmentResult interpretation =
+                    enrich(dependencies, vulnerabilityIds, fetched, queryResult.completedPackages());
             List<DependencyDto> enriched = interpretation.dependencies();
             EpssResult epss = applyEpss(enriched);
             enriched = epss.dependencies();
@@ -367,13 +368,15 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             boolean paginationTruncated,
             int packagesScanned,
             int failedPackages,
-            String failure) {}
+            String failure,
+            Set<String> completedPackages) {}
 
     /** One outstanding OSV query awaiting a further page of results. */
     private record PendingQuery(DependencyDto dependency, String pageToken) {}
 
     private QueryBatchResult queryBatch(List<DependencyDto> dependencies) throws IOException, InterruptedException {
         Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        Set<String> completedPackages = new LinkedHashSet<>();
         boolean paginationTruncated = false;
         int packagesScanned = 0;
         int failedPackages = 0;
@@ -384,6 +387,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             try {
                 QueryBatchResult chunkResult = queryBatchChunk(chunk);
                 idsByPackage.putAll(chunkResult.idsByPackage());
+                completedPackages.addAll(chunkResult.completedPackages());
                 paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
                 packagesScanned += chunkResult.packagesScanned();
                 if (chunkResult.failedPackages() > 0) {
@@ -400,7 +404,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 break;
             }
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated, packagesScanned, failedPackages, failure);
+        return new QueryBatchResult(
+                idsByPackage, paginationTruncated, packagesScanned, failedPackages, failure, completedPackages);
     }
 
     private static String queryFailure(Exception exception) {
@@ -420,6 +425,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private QueryBatchResult queryBatchChunk(List<DependencyDto> dependencies)
             throws IOException, InterruptedException {
         Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        Set<String> completedPackages = new LinkedHashSet<>();
         for (DependencyDto dependency : dependencies) {
             idsByPackage.put(key(dependency), new ArrayList<>());
         }
@@ -441,7 +447,12 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     throw ex;
                 }
                 return new QueryBatchResult(
-                        idsByPackage, false, dependencies.size() - pending.size(), pending.size(), queryFailure(ex));
+                        idsByPackage,
+                        false,
+                        dependencies.size() - pending.size(),
+                        pending.size(),
+                        queryFailure(ex),
+                        completedPackages);
             }
             List<PendingQuery> nextPending = new ArrayList<>();
             for (int i = 0; i < pending.size(); i++) {
@@ -460,12 +471,15 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 String nextPageToken = text(result, "next_page_token");
                 if (nextPageToken != null) {
                     nextPending.add(new PendingQuery(query.dependency(), nextPageToken));
+                } else {
+                    completedPackages.add(key(query.dependency()));
                 }
             }
             pending = nextPending;
             page++;
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated, dependencies.size() - pending.size(), 0, null);
+        return new QueryBatchResult(
+                idsByPackage, paginationTruncated, dependencies.size() - pending.size(), 0, null, completedPackages);
     }
 
     private JsonNode queryBatchRequest(List<PendingQuery> pending) throws IOException, InterruptedException {
@@ -537,7 +551,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 .limit(Math.max(1, settings.maxAdvisories()))
                 .toList();
         if (ids.isEmpty()) {
-            return new VulnerabilityFetchResult(Map.of(), 0);
+            return new VulnerabilityFetchResult(Map.of(), 0, Set.of());
         }
         ExecutorService executor = Executors.newFixedThreadPool(Math.min(ADVISORY_FETCH_CONCURRENCY, ids.size()));
         try {
@@ -546,6 +560,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 futures.add(executor.submit(() -> fetchVulnerabilityOrNull(id)));
             }
             Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+            Set<String> resolvedAdvisories = new LinkedHashSet<>();
             int failedFetches = 0;
             for (int i = 0; i < futures.size(); i++) {
                 String expectedId = ids.get(i);
@@ -572,6 +587,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     failedFetches++;
                     continue;
                 }
+                resolvedAdvisories.add(expectedId);
                 if (isWithdrawn(vulnerability)) {
                     // POST queries exclude withdrawn records, but GET /v1/vulns/{id} returns them; keep this
                     // detail-stage check so a withdrawn advisory never becomes a finding.
@@ -579,7 +595,7 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 }
                 vulnerabilities.put(expectedId, vulnerability);
             }
-            return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
+            return new VulnerabilityFetchResult(vulnerabilities, failedFetches, resolvedAdvisories);
         } finally {
             executor.shutdownNow();
         }
@@ -613,7 +629,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return text(vulnerability, "withdrawn") != null;
     }
 
-    private record VulnerabilityFetchResult(Map<String, JsonNode> vulnerabilities, int failedFetches) {}
+    private record VulnerabilityFetchResult(
+            Map<String, JsonNode> vulnerabilities, int failedFetches, Set<String> resolvedAdvisories) {}
 
     private URI vulnerabilityUri(String id) {
         String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8).replace("+", "%20");
@@ -641,17 +658,21 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private EnrichmentResult enrich(
             List<DependencyDto> dependencies,
             Map<String, List<String>> vulnerabilityIds,
-            Map<String, JsonNode> vulnerabilities) {
+            VulnerabilityFetchResult fetched,
+            Set<String> completedPackages) {
         List<DependencyDto> enriched = new ArrayList<>();
         int unresolved = 0;
         for (DependencyDto dependency : dependencies) {
             List<DependencyVulnerabilityDto> dependencyVulnerabilities = new ArrayList<>();
+            boolean assessmentComplete = completedPackages.contains(key(dependency));
             for (String id : new LinkedHashSet<>(vulnerabilityIds.getOrDefault(key(dependency), List.of()))) {
-                JsonNode node = vulnerabilities.get(id);
+                assessmentComplete &= fetched.resolvedAdvisories().contains(id);
+                JsonNode node = fetched.vulnerabilities().get(id);
                 if (node != null) {
                     OsvAdvisoryInterpreter.Result interpretation = interpret(node, dependency);
                     if (interpretation.unresolved()) {
                         unresolved++;
+                        assessmentComplete = false;
                     }
                     dependencyVulnerabilities.add(vulnerability(node, dependency, interpretation));
                 }
@@ -665,7 +686,8 @@ public final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     dependency.source(),
                     dependencyVulnerabilities.size(),
                     DependencyReports.highestSeverity(dependencyVulnerabilities),
-                    dependencyVulnerabilities));
+                    dependencyVulnerabilities,
+                    assessmentComplete));
         }
         return new EnrichmentResult(enriched, unresolved);
     }

--- a/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
+++ b/bootui-quarkus/src/test/java/io/github/jdubois/bootui/quarkus/OsvVulnerabilityScannerTest.java
@@ -118,6 +118,14 @@ class OsvVulnerabilityScannerTest {
         assertThat(report.scan().packagesScanned()).isEqualTo(1);
         assertThat(report.scan().packagesSkipped()).isZero();
         assertThat(report.scan().message()).contains("1 package query was not completed");
+        assertThat(report.dependencies())
+                .filteredOn(d -> d.packageName().equals("org.acme:complete"))
+                .singleElement()
+                .satisfies(d -> assertThat(d.assessmentComplete()).isTrue());
+        assertThat(report.dependencies())
+                .filteredOn(d -> d.packageName().equals("org.acme:widget"))
+                .singleElement()
+                .satisfies(d -> assertThat(d.assessmentComplete()).isFalse());
         if (failure.equals("body-cap")) {
             assertThat(report.scan().message()).contains("Response body exceeds");
         }
@@ -946,6 +954,7 @@ class OsvVulnerabilityScannerTest {
         // A withdrawn advisory is intentionally dropped -- this is correct, expected behavior, not a
         // failure, so it must not degrade the scan status to PARTIAL/ERROR.
         assertThat(report.status()).isEqualTo("SCANNED");
+        assertThat(report.dependencies().get(0).assessmentComplete()).isTrue();
         assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
         assertThat(report.dependencies().get(0).vulnerabilityCount()).isZero();
         assertThat(report.vulnerable()).isZero();
@@ -971,6 +980,7 @@ class OsvVulnerabilityScannerTest {
         // The advisory that failed to fetch must not discard the one that succeeded, nor abort the
         // whole scan to ERROR the way a single-advisory IOException used to.
         assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.dependencies().get(0).assessmentComplete()).isFalse();
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
         assertThat(report.dependencies().get(0).vulnerabilities())
                 .extracting(DependencyVulnerabilityDto::id)
@@ -998,6 +1008,18 @@ class OsvVulnerabilityScannerTest {
                 report.dependencies().get(0).vulnerabilities().get(0);
         assertThat(vulnerability.severity()).isEqualTo("CRITICAL");
         assertThat(vulnerability.score()).isEqualTo(9.8d);
+    }
+
+    @Test
+    void completedQueryWithOnlyFailedDetailsHasNoCompletedAssessment() {
+        handle("/v1/querybatch", "{\"results\":[{\"vulns\":[{\"id\":\"V-FAIL\"}]}]}");
+        server.createContext("/v1/vulns/V-FAIL", exchange -> respond(exchange, 503, "unavailable"));
+        var report = scanner(250, 200)
+                .scan(DependencyInventory.complete(List.of(dependency("org.acme", "widget", "1.0.0"))));
+        assertThat(report.status()).isEqualTo("PARTIAL");
+        assertThat(report.scan().packagesScanned()).isEqualTo(1);
+        assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
+        assertThat(report.dependencies().get(0).assessmentComplete()).isFalse();
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -12,6 +12,7 @@ import io.github.jdubois.bootui.core.dto.SecurityScanStatusDto;
 import io.github.jdubois.bootui.core.dto.SecuritySeverityCountDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
@@ -168,7 +169,9 @@ final class SecurityScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                analysisErrors(results));
+                analysisErrors(results),
+                AdvisorAssessmentEvidence.fromResults(
+                        results, SecurityRuleResultDto::status, "PARTIAL".equals(status)));
     }
 
     // The most recent context, captured so the report can list chain matchers.
@@ -203,7 +206,8 @@ final class SecurityScanner {
                 severityCounts(active),
                 updatedScan,
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     static List<SecurityRuleResultDto> analysisErrors(List<SecurityRuleResultDto> results) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRule.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRule.java
@@ -1,10 +1,15 @@
 package io.github.jdubois.bootui.autoconfigure.spring;
 
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 
 interface SpringRule {
 
     SpringRuleDefinition definition();
 
     SpringRuleResultDto evaluate(SpringContext context);
+
+    default AdvisorRuleAssessment<SpringRuleResultDto> evaluateAssessment(SpringContext context) {
+        return SpringRuleSupport.assessment(evaluate(context));
+    }
 }

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRuleSupport.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRuleSupport.java
@@ -1,6 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.spring;
 
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +11,7 @@ final class SpringRuleSupport {
     static final String VIOLATION = "VIOLATION";
     static final String SKIPPED = "SKIPPED";
     static final String ERROR = "ERROR";
+    private static final String REQUIRED_EVIDENCE_UNAVAILABLE = "REQUIRED_EVIDENCE_UNAVAILABLE";
 
     static final String CRITICAL = "CRITICAL";
     static final String HIGH = "HIGH";
@@ -34,6 +36,35 @@ final class SpringRuleSupport {
 
     static SpringRuleResultDto error(SpringRuleDefinition definition, String reason) {
         return result(definition, ERROR, 0, List.of(detail(reason)));
+    }
+
+    static SpringRuleResultDto unknown(SpringRuleDefinition definition) {
+        return result(
+                definition,
+                REQUIRED_EVIDENCE_UNAVAILABLE,
+                0,
+                List.of("Required non-eager metadata is unavailable or custom; observation is unknown."));
+    }
+
+    static AdvisorRuleAssessment<SpringRuleResultDto> assessment(SpringRuleResultDto result) {
+        if (!REQUIRED_EVIDENCE_UNAVAILABLE.equals(result.status())) {
+            return new AdvisorRuleAssessment<>(result, ERROR.equals(result.status()));
+        }
+        // The marker is internal; keep the existing SKIPPED rule-result contract.
+        return new AdvisorRuleAssessment<>(
+                new SpringRuleResultDto(
+                        result.id(),
+                        result.name(),
+                        result.category(),
+                        result.severity(),
+                        result.description(),
+                        SKIPPED,
+                        result.violationCount(),
+                        result.sampleViolations(),
+                        result.recommendation(),
+                        result.learnMoreUrl(),
+                        result.dismissed()),
+                true);
     }
 
     static SpringRuleResultDto violation(SpringRuleDefinition definition, List<String> details) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRules.java
@@ -5,6 +5,7 @@ import static io.github.jdubois.bootui.autoconfigure.spring.SpringObservations.F
 import io.github.jdubois.bootui.autoconfigure.spring.SpringModel.BeanRef;
 import io.github.jdubois.bootui.autoconfigure.spring.SpringObservations.AsyncSelection;
 import io.github.jdubois.bootui.core.dto.SpringRuleResultDto;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,13 +45,19 @@ abstract class AbstractSpringRule implements SpringRule {
 
     @Override
     public final SpringRuleResultDto evaluate(SpringContext context) {
+        return evaluateAssessment(context).result();
+    }
+
+    @Override
+    public final AdvisorRuleAssessment<SpringRuleResultDto> evaluateAssessment(SpringContext context) {
         try {
-            return evaluateRule(context);
+            return SpringRuleSupport.assessment(evaluateRule(context));
         } catch (RuntimeException | LinkageError ex) {
             // Exception messages, causes and property values can contain credentials.
-            return SpringRuleSupport.error(
-                    definition,
-                    "Required configuration or metadata could not be inspected safely; no runtime conclusion was made.");
+            return SpringRuleSupport.assessment(
+                    SpringRuleSupport.error(
+                            definition,
+                            "Required configuration or metadata could not be inspected safely; no runtime conclusion was made."));
         }
     }
 
@@ -63,7 +70,7 @@ abstract class AbstractSpringRule implements SpringRule {
     }
 
     SpringRuleResultDto unknown() {
-        return skipped("Required non-eager metadata is unavailable or custom; observation is unknown.");
+        return SpringRuleSupport.unknown(definition);
     }
 
     SpringRuleResultDto violation(String detail) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScanner.java
@@ -6,6 +6,8 @@ import io.github.jdubois.bootui.core.dto.SpringScanStatusDto;
 import io.github.jdubois.bootui.core.dto.SpringSeverityCountDto;
 import io.github.jdubois.bootui.engine.action.ActionOperations;
 import io.github.jdubois.bootui.engine.action.SingleFlightAction;
+import io.github.jdubois.bootui.engine.advisor.AdvisorAssessmentEvidence;
+import io.github.jdubois.bootui.engine.advisor.AdvisorRuleAssessment;
 import io.github.jdubois.bootui.engine.support.SeverityOrder;
 import java.time.Clock;
 import java.util.ArrayList;
@@ -81,9 +83,11 @@ final class SpringScanner {
                     0,
                     List.of());
         }
-        List<SpringRuleResultDto> results = SpringRuleRegistry.activeRules().stream()
-                .map(rule -> rule.evaluate(context))
+        List<AdvisorRuleAssessment<SpringRuleResultDto>> assessments = SpringRuleRegistry.activeRules().stream()
+                .map(rule -> rule.evaluateAssessment(context))
                 .toList();
+        List<SpringRuleResultDto> results =
+                assessments.stream().map(AdvisorRuleAssessment::result).toList();
         List<String> inspected = new ArrayList<>();
         inspected.add("Bean definitions: " + context.beanDefinitionCount() + "; bounded, non-eager metadata only.");
         inspected.add("Configuration is not proof of execution, authorization, or network reachability.");
@@ -104,7 +108,9 @@ final class SpringScanner {
                 clock.millis(),
                 inspected,
                 context.beanDefinitionCount(),
-                results);
+                results,
+                !context.observations().incomplete().isEmpty()
+                        || assessments.stream().anyMatch(AdvisorRuleAssessment::incomplete));
     }
 
     private SpringReport report(
@@ -114,6 +120,17 @@ final class SpringScanner {
             List<String> inspected,
             int componentsAnalyzed,
             List<SpringRuleResultDto> results) {
+        return report(status, message, scannedAt, inspected, componentsAnalyzed, results, false);
+    }
+
+    private SpringReport report(
+            String status,
+            String message,
+            Long scannedAt,
+            List<String> inspected,
+            int componentsAnalyzed,
+            List<SpringRuleResultDto> results,
+            boolean incomplete) {
         List<SpringRuleResultDto> violations = results.stream()
                 .filter(result -> SpringRuleSupport.VIOLATION.equals(result.status()))
                 .sorted(IMPORTANCE_ORDER)
@@ -130,7 +147,8 @@ final class SpringScanner {
                 severityCounts(violations),
                 scan,
                 violations,
-                analysisErrors(results));
+                analysisErrors(results),
+                AdvisorAssessmentEvidence.fromResults(results, SpringRuleResultDto::status, incomplete));
     }
 
     SpringReport applyDismissals(SpringReport report, Set<String> dismissedIds) {
@@ -158,7 +176,8 @@ final class SpringScanner {
                         scan.componentsAnalyzed(),
                         active.size()),
                 marked,
-                report.analysisErrors());
+                report.analysisErrors(),
+                report.assessmentEvidence());
     }
 
     static List<SpringRuleResultDto> analysisErrors(List<SpringRuleResultDto> results) {

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScanner.java
@@ -277,7 +277,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             packagesScanned = queryResult.packagesScanned();
             Map<String, List<String>> vulnerabilityIds = queryResult.idsByPackage();
             VulnerabilityFetchResult fetched = fetchVulnerabilities(vulnerabilityIds);
-            EnrichmentResult interpretation = enrich(dependencies, vulnerabilityIds, fetched.vulnerabilities());
+            EnrichmentResult interpretation =
+                    enrich(dependencies, vulnerabilityIds, fetched, queryResult.completedPackages());
             List<DependencyDto> enriched = interpretation.dependencies();
             EpssResult epss = applyEpss(enriched);
             enriched = epss.dependencies();
@@ -344,13 +345,15 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             boolean paginationTruncated,
             int packagesScanned,
             int failedPackages,
-            String failure) {}
+            String failure,
+            Set<String> completedPackages) {}
 
     /** One outstanding OSV query awaiting a further page of results. */
     private record PendingQuery(DependencyDto dependency, String pageToken) {}
 
     private QueryBatchResult queryBatch(List<DependencyDto> dependencies) throws IOException, InterruptedException {
         Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        Set<String> completedPackages = new LinkedHashSet<>();
         boolean paginationTruncated = false;
         int packagesScanned = 0;
         int failedPackages = 0;
@@ -361,6 +364,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
             try {
                 QueryBatchResult chunkResult = queryBatchChunk(chunk);
                 idsByPackage.putAll(chunkResult.idsByPackage());
+                completedPackages.addAll(chunkResult.completedPackages());
                 paginationTruncated = paginationTruncated || chunkResult.paginationTruncated();
                 packagesScanned += chunkResult.packagesScanned();
                 if (chunkResult.failedPackages() > 0) {
@@ -377,7 +381,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 break;
             }
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated, packagesScanned, failedPackages, failure);
+        return new QueryBatchResult(
+                idsByPackage, paginationTruncated, packagesScanned, failedPackages, failure, completedPackages);
     }
 
     private static String queryFailure(Exception exception) {
@@ -397,6 +402,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private QueryBatchResult queryBatchChunk(List<DependencyDto> dependencies)
             throws IOException, InterruptedException {
         Map<String, List<String>> idsByPackage = new LinkedHashMap<>();
+        Set<String> completedPackages = new LinkedHashSet<>();
         for (DependencyDto dependency : dependencies) {
             idsByPackage.put(key(dependency), new ArrayList<>());
         }
@@ -418,7 +424,12 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     throw ex;
                 }
                 return new QueryBatchResult(
-                        idsByPackage, false, dependencies.size() - pending.size(), pending.size(), queryFailure(ex));
+                        idsByPackage,
+                        false,
+                        dependencies.size() - pending.size(),
+                        pending.size(),
+                        queryFailure(ex),
+                        completedPackages);
             }
             List<PendingQuery> nextPending = new ArrayList<>();
             for (int i = 0; i < pending.size(); i++) {
@@ -437,12 +448,15 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 String nextPageToken = text(result, "next_page_token");
                 if (nextPageToken != null) {
                     nextPending.add(new PendingQuery(query.dependency(), nextPageToken));
+                } else {
+                    completedPackages.add(key(query.dependency()));
                 }
             }
             pending = nextPending;
             page++;
         }
-        return new QueryBatchResult(idsByPackage, paginationTruncated, dependencies.size() - pending.size(), 0, null);
+        return new QueryBatchResult(
+                idsByPackage, paginationTruncated, dependencies.size() - pending.size(), 0, null, completedPackages);
     }
 
     private JsonNode queryBatchRequest(List<PendingQuery> pending) throws IOException, InterruptedException {
@@ -514,7 +528,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 .limit(Math.max(1, properties.getMaxAdvisories()))
                 .toList();
         if (ids.isEmpty()) {
-            return new VulnerabilityFetchResult(Map.of(), 0);
+            return new VulnerabilityFetchResult(Map.of(), 0, Set.of());
         }
         ExecutorService executor = Executors.newFixedThreadPool(Math.min(ADVISORY_FETCH_CONCURRENCY, ids.size()));
         try {
@@ -523,6 +537,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 futures.add(executor.submit(() -> fetchVulnerabilityOrNull(id)));
             }
             Map<String, JsonNode> vulnerabilities = new LinkedHashMap<>();
+            Set<String> resolvedAdvisories = new LinkedHashSet<>();
             int failedFetches = 0;
             for (int i = 0; i < futures.size(); i++) {
                 String expectedId = ids.get(i);
@@ -548,6 +563,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     failedFetches++;
                     continue;
                 }
+                resolvedAdvisories.add(expectedId);
                 if (isWithdrawn(vulnerability)) {
                     // POST queries exclude withdrawn records, but GET /v1/vulns/{id} returns them; keep this
                     // detail-stage check so a withdrawn advisory never becomes a finding.
@@ -555,7 +571,7 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                 }
                 vulnerabilities.put(expectedId, vulnerability);
             }
-            return new VulnerabilityFetchResult(vulnerabilities, failedFetches);
+            return new VulnerabilityFetchResult(vulnerabilities, failedFetches, resolvedAdvisories);
         } finally {
             executor.shutdownNow();
         }
@@ -589,7 +605,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
         return text(vulnerability, "withdrawn") != null;
     }
 
-    private record VulnerabilityFetchResult(Map<String, JsonNode> vulnerabilities, int failedFetches) {}
+    private record VulnerabilityFetchResult(
+            Map<String, JsonNode> vulnerabilities, int failedFetches, Set<String> resolvedAdvisories) {}
 
     private URI vulnerabilityUri(String id) {
         String encoded = URLEncoder.encode(id, StandardCharsets.UTF_8).replace("+", "%20");
@@ -617,17 +634,21 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
     private EnrichmentResult enrich(
             List<DependencyDto> dependencies,
             Map<String, List<String>> vulnerabilityIds,
-            Map<String, JsonNode> vulnerabilities) {
+            VulnerabilityFetchResult fetched,
+            Set<String> completedPackages) {
         List<DependencyDto> enriched = new ArrayList<>();
         int unresolved = 0;
         for (DependencyDto dependency : dependencies) {
             List<DependencyVulnerabilityDto> dependencyVulnerabilities = new ArrayList<>();
+            boolean assessmentComplete = completedPackages.contains(key(dependency));
             for (String id : new LinkedHashSet<>(vulnerabilityIds.getOrDefault(key(dependency), List.of()))) {
-                JsonNode node = vulnerabilities.get(id);
+                assessmentComplete &= fetched.resolvedAdvisories().contains(id);
+                JsonNode node = fetched.vulnerabilities().get(id);
                 if (node != null) {
                     OsvAdvisoryInterpreter.Result interpretation = interpret(node, dependency);
                     if (interpretation.unresolved()) {
                         unresolved++;
+                        assessmentComplete = false;
                     }
                     dependencyVulnerabilities.add(vulnerability(node, dependency, interpretation));
                 }
@@ -641,7 +662,8 @@ final class OsvVulnerabilityScanner implements VulnerabilityScanner {
                     dependency.source(),
                     dependencyVulnerabilities.size(),
                     DependencyReports.highestSeverity(dependencyVulnerabilities),
-                    dependencyVulnerabilities));
+                    dependencyVulnerabilities,
+                    assessmentComplete));
         }
         return new EnrichmentResult(enriched, unresolved);
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/AdvisorEvidenceSerializationTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/AdvisorEvidenceSerializationTests.java
@@ -1,0 +1,59 @@
+package io.github.jdubois.bootui.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.jdubois.bootui.core.dto.AdvisorAssessmentEvidenceDto;
+import io.github.jdubois.bootui.core.dto.ArchitectureReport;
+import io.github.jdubois.bootui.core.dto.DatabaseAdvisorReport;
+import io.github.jdubois.bootui.core.dto.DependencyDto;
+import io.github.jdubois.bootui.core.dto.HibernateReport;
+import io.github.jdubois.bootui.core.dto.MemoryReport;
+import io.github.jdubois.bootui.core.dto.PentestingReport;
+import io.github.jdubois.bootui.core.dto.RestApiReport;
+import io.github.jdubois.bootui.core.dto.SecurityReport;
+import io.github.jdubois.bootui.core.dto.SpringReport;
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AdvisorEvidenceSerializationTests {
+
+    @ParameterizedTest
+    @ValueSource(
+            classes = {
+                ArchitectureReport.class, MemoryReport.class, RestApiReport.class, SpringReport.class,
+                DatabaseAdvisorReport.class, HibernateReport.class, SecurityReport.class, PentestingReport.class
+            })
+    void assessmentFactsSerializeIdenticallyAcrossJacksonGenerations(Class<?> type) throws Exception {
+        var components = type.getRecordComponents();
+        var signature = Arrays.stream(components).map(RecordComponent::getType).toArray(Class<?>[]::new);
+        Object[] values = Arrays.stream(components)
+                .map(component -> {
+                    if (component.getType() == AdvisorAssessmentEvidenceDto.class)
+                        return new AdvisorAssessmentEvidenceDto(true, true);
+                    if (component.getType() == boolean.class) return true;
+                    if (component.getType() == int.class) return 0;
+                    if (component.getType() == List.class) return List.of();
+                    return null;
+                })
+                .toArray();
+        Object report = type.getDeclaredConstructor(signature).newInstance(values);
+        String jackson2 = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(report);
+        String jackson3 = new tools.jackson.databind.ObjectMapper().writeValueAsString(report);
+        assertThat(jackson3).isEqualTo(jackson2);
+        assertThat(jackson2).contains("\"assessmentEvidence\":{\"usable\":true,\"incomplete\":true}");
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void dependencyCompletionIsAnAdditiveBooleanInBothAdapters(boolean complete) throws Exception {
+        var dependency =
+                new DependencyDto("example", "library", "1", "example:library", "test", 0, "NONE", List.of(), complete);
+        String jackson2 = new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(dependency);
+        String jackson3 = new tools.jackson.databind.ObjectMapper().writeValueAsString(dependency);
+        assertThat(jackson3).isEqualTo(jackson2);
+        assertThat(jackson2).contains("\"assessmentComplete\":" + complete);
+    }
+}

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringRulesTests.java
@@ -22,6 +22,24 @@ import org.springframework.mock.env.MockEnvironment;
 
 /** Requirement boundaries; real discovery/provenance is covered separately in SpringInventoryTests. */
 class SpringRulesTests {
+    @Test
+    void assessmentDistinguishesRequiredUnknownFromIntentionalNonApplicabilityWithoutChangingStatuses() {
+        var definition = new BeanDefinitionOverridingRule().definition();
+        var unknown = SpringRuleSupport.assessment(SpringRuleSupport.unknown(definition));
+        var skipped = SpringRuleSupport.assessment(SpringRuleSupport.skipped(definition, "Not applicable"));
+        assertThat(unknown.result().status()).isEqualTo("SKIPPED");
+        assertThat(skipped.result().status()).isEqualTo("SKIPPED");
+        assertThat(unknown.incomplete()).isTrue();
+        assertThat(skipped.incomplete()).isFalse();
+
+        var rule = new BeanDefinitionOverridingRule();
+        var context = SpringContext.builder(new MockEnvironment())
+                .observations(facts(Map.of()))
+                .build();
+        assertThat(rule.evaluate(context).status()).isEqualTo("SKIPPED");
+        assertThat(rule.evaluateAssessment(context).incomplete()).isTrue();
+    }
+
     static SpringObservations facts(Map<Fact, Object> facts) {
         return new SpringObservations(facts, List.of());
     }

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/spring/SpringScannerTests.java
@@ -44,6 +44,7 @@ class SpringScannerTests {
         assertThat(report.violationsFound()).isZero();
         assertThat(report.results()).isEmpty();
         assertThat(report.scan().scannedAt()).isNull();
+        assertThat(report.assessmentEvidence().usable()).isFalse();
     }
 
     @Test
@@ -101,6 +102,7 @@ class SpringScannerTests {
                 .extracting(SpringSeverityCountDto::severity)
                 .containsExactly("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO");
         assertThat(report.inspected()).isNotEmpty();
+        assertThat(report.assessmentEvidence().usable()).isTrue();
     }
 
     @Test
@@ -121,6 +123,7 @@ class SpringScannerTests {
         assertThat(report.rulesEvaluated()).isEqualTo(RULE_COUNT);
         assertThat(report.violationsFound()).isZero();
         assertThat(report.results()).isEmpty();
+        assertThat(report.assessmentEvidence().usable()).isTrue();
         assertThat(report.severityCounts())
                 .allSatisfy(count -> assertThat(count.count()).isZero());
     }
@@ -193,6 +196,7 @@ class SpringScannerTests {
         assertThat(report.results()).extracting(SpringRuleResultDto::id).contains(dismissedId);
 
         SpringReport dismissed = scanner.applyDismissals(report, Set.of(dismissedId));
+        assertThat(dismissed.assessmentEvidence()).isEqualTo(report.assessmentEvidence());
 
         // The dismissed rule is still present but flagged, so the UI can list it under "Dismissed".
         assertThat(dismissed.results()).hasSameSizeAs(report.results());

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/web/OsvVulnerabilityScannerTests.java
@@ -116,6 +116,14 @@ class OsvVulnerabilityScannerTests {
         assertThat(report.scan().packagesScanned()).isEqualTo(1);
         assertThat(report.scan().packagesSkipped()).isZero();
         assertThat(report.scan().message()).contains("1 package query was not completed");
+        assertThat(report.dependencies())
+                .filteredOn(d -> d.packageName().equals("org.acme:complete"))
+                .singleElement()
+                .satisfies(d -> assertThat(d.assessmentComplete()).isTrue());
+        assertThat(report.dependencies())
+                .filteredOn(d -> d.packageName().equals("org.acme:widget"))
+                .singleElement()
+                .satisfies(d -> assertThat(d.assessmentComplete()).isFalse());
         if (failure.equals("body-cap")) {
             assertThat(report.scan().message()).contains("Response body exceeds");
         }
@@ -1000,6 +1008,7 @@ class OsvVulnerabilityScannerTests {
         // A withdrawn advisory is intentionally dropped -- this is correct, expected behavior, not a
         // failure, so it must not degrade the scan status to PARTIAL/ERROR.
         assertThat(report.scan().status()).isEqualTo("SCANNED");
+        assertThat(report.dependencies().get(0).assessmentComplete()).isTrue();
         assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
         assertThat(report.dependencies().get(0).vulnerabilityCount()).isZero();
         assertThat(report.vulnerable()).isZero();
@@ -1040,6 +1049,7 @@ class OsvVulnerabilityScannerTests {
         // The advisory that failed to fetch must not discard the one that succeeded, nor abort the whole
         // scan to ERROR the way a single-advisory IOException used to.
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
+        assertThat(report.dependencies().get(0).assessmentComplete()).isFalse();
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
         assertThat(report.dependencies().get(0).vulnerabilities())
                 .extracting("id")
@@ -1086,6 +1096,8 @@ class OsvVulnerabilityScannerTests {
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.scan().message()).contains("1 advisory fetch failed");
         assertThat(report.dependencies().get(0).vulnerabilities()).isEmpty();
+        assertThat(report.scan().packagesScanned()).isEqualTo(1);
+        assertThat(report.dependencies().get(0).assessmentComplete()).isFalse();
     }
 
     @Test

--- a/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
+++ b/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
@@ -13,12 +13,27 @@ const scannerIds = [
   'github'
 ]
 
+export function expectedAdvisorScore(counts) {
+  const weights = {CRITICAL: 25, HIGH: 10, MEDIUM: 3, LOW: 1, INFO: 0, NONE: 0}
+  return Math.max(0, 100 - counts.reduce((penalty, entry) => penalty + (weights[entry.severity] || 0) * entry.count, 0))
+}
+
+export async function expectPartialAdvisorScore(page, expect, counts = null) {
+  await expect(page.locator('.advisor-score-card')).toContainText('Partial assessment')
+  await expect(page.locator('.advisor-score-card')).toContainText('missing checks are not passes')
+  await expect(page.locator('.advisor-summary__gauge')).toHaveAttribute('aria-label', /Partial assessment/)
+  await expect(page.locator('.advisor-summary__value')).toHaveText(
+    counts ? String(expectedAdvisorScore(counts)) : /^(?:100|[1-9]?[0-9])$/
+  )
+}
+
 function architectureReport(status, dismissed = false) {
   return {
     scan: {status, scannedAt: 1700000000000, message: 'Available evidence retained.'},
     severityCounts: [{severity: 'HIGH', count: dismissed ? 0 : 1}],
     basePackages: ['example.app'],
     rulesEvaluated: 1,
+    assessmentEvidence: {usable: true, incomplete: status === 'PARTIAL'},
     violationsFound: dismissed ? 0 : 1,
     classesAnalyzed: 2,
     disclaimer: 'Heuristic findings.',
@@ -46,7 +61,8 @@ function unscannedReport() {
     severityCounts: [],
     results: [],
     violationsFound: 0,
-    rulesEvaluated: 0
+    rulesEvaluated: 0,
+    assessmentEvidence: {usable: false, incomplete: true}
   }
 }
 
@@ -105,6 +121,7 @@ function vulnerabilityReport(dismissed, coverageStatus = 'COMPLETE') {
         artifactId: 'library',
         version: '1.0.0',
         source: 'test',
+        assessmentComplete: true,
         highestSeverity: dismissed ? 'NONE' : 'UNKNOWN',
         vulnerabilityCount: dismissed ? 0 : 1,
         vulnerabilities: [
@@ -193,12 +210,14 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
         }
         await page.getByRole('button', {name: 'Run Hibernate checks', exact: true}).click()
         await expect(page.getByText('Retained Hibernate finding', {exact: true})).toBeVisible()
-        await expect(page.locator('.advisor-score-card')).toContainText('Incomplete')
+        await expect(page.locator('.advisor-score-card')).toContainText('Partial assessment')
+        await expect(page.locator('.advisor-summary__value')).toHaveText('90')
         const readsBeforeReturn = reads
         await page.locator('a[href$="#/overview"]').first().click()
         await expect(card).toContainText('Incomplete')
         await expect(card).toContainText('1 high')
-        await expect(card.locator('.scanner-score')).toHaveCount(0)
+        await expect(card.locator('.scanner-score')).toHaveText('90')
+        await expect(page.locator('.overall-card')).toContainText('Partial assessment')
         expect(reads).toBe(readsBeforeReturn + 1)
         expect(writes).toEqual([`${apiPath}/hibernate/scan`])
         // A restarted server explicitly reports no scan; old findings must disappear.
@@ -279,12 +298,13 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       releaseScan()
       await expect(card).toContainText('Incomplete')
       await expect(card).toContainText('1 high')
-      await expect(card.locator('.scanner-score')).toHaveCount(0)
+      await expect(card.locator('.scanner-score')).toHaveText('90')
+      await expect(page.locator('.overall-card')).toContainText('Partial assessment')
       await expect.poll(() => reads).toBe(3)
       expect(scans).toBe(1)
     })
 
-    test('retains incomplete findings and removes only their score from the aggregate', async ({page}) => {
+    test('includes usable partial findings and removes only unusable scores from the aggregate', async ({page}) => {
       let status = 'NOT_SCANNED'
       let scans = 0
       await page.route(`**${apiPath}/architecture{,/scan}`, async (route) => {
@@ -305,53 +325,59 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       for (const next of ['PARTIAL', 'ERROR', 'DISABLED', 'NOT_SCANNED']) {
         status = next
         await card.getByRole('button', {name: 'Re-run scan', exact: true}).click()
-        await expect(card.locator('.scanner-score')).toHaveCount(0)
+        if (next === 'PARTIAL') {
+          await expect(card.locator('.scanner-score')).toHaveText('90')
+          await expect(overall).toContainText('Partial assessment')
+        } else await expect(card.locator('.scanner-score')).toHaveCount(0)
         await expect(card).toContainText('1 high')
-        await expect(overall).toContainText('0 of 2 scanners scored')
-        await expect(overall.locator('.overall-gauge')).toHaveCount(0)
+        await expect(overall).toContainText(`${next === 'PARTIAL' ? 1 : 0} of 2 scanners scored`)
+        await expect(overall.locator('.overall-gauge')).toHaveCount(next === 'PARTIAL' ? 1 : 0)
       }
       status = 'PARTIAL'
       await card.getByRole('link', {name: 'Open panel'}).click()
-      await expect(page.locator('.advisor-score-card')).toContainText('Incomplete')
+      await expect(page.locator('.advisor-score-card')).toContainText('Partial assessment')
       await expect(page.getByText('Retained architecture finding', {exact: true})).toBeVisible()
-      await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+      await expect(page.locator('.advisor-summary__value')).toHaveText('90')
     })
 
-    test('dismisses and restores a complete report finding with exact score changes', async ({page}) => {
-      let dismissed = false
-      let scans = 0
-      await page.route(`**${apiPath}/architecture{,/scan}`, async (route) => {
-        if (route.request().method() === 'POST') scans++
-        await route.fulfill({json: architectureReport('SCANNED', dismissed)})
+    for (const status of ['SCANNED', 'PARTIAL']) {
+      test(`dismisses and restores a ${status} report finding with exact score changes`, async ({page}) => {
+        let dismissed = false
+        let scans = 0
+        await page.route(`**${apiPath}/architecture{,/scan}`, async (route) => {
+          if (route.request().method() === 'POST') scans++
+          await route.fulfill({json: architectureReport(status, dismissed)})
+        })
+        await page.route(`**${apiPath}/dismissed-rules/ARCH-TEST-1`, async (route) => {
+          expect(['POST', 'DELETE']).toContain(route.request().method())
+          dismissed = route.request().method() === 'POST'
+          await route.fulfill({json: {dismissed: dismissed ? ['ARCH-TEST-1'] : []}})
+        })
+        await page.goto(`${uiPath}/#/architecture`)
+        await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+        const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
+        await page.locator('a[href$="#/overview"]').first().click()
+        await expect(card.locator('.scanner-score')).toHaveText('90')
+        await card.getByRole('link', {name: 'Open panel'}).click()
+        await page.getByRole('button', {name: /Dismiss$/}).click()
+        await expect(page.locator('.list-group-item.opacity-50')).toContainText('ARCH-TEST-1')
+        await expect(page.locator('.advisor-summary__dismissed')).toContainText(
+          '1 dismissed rule(s) excluded from this score'
+        )
+        await expect(page.locator('.advisor-summary__value')).toHaveText('100')
+        await page.locator('a[href$="#/overview"]').first().click()
+        await expect(card.locator('.scanner-score')).toHaveText('100')
+        await card.getByRole('link', {name: 'Open panel'}).click()
+        await page.getByRole('button', {name: /Restore$/}).click()
+        await expect(page.locator('.list-group-item.opacity-50')).toHaveCount(0)
+        await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
+        await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+        await page.locator('a[href$="#/overview"]').first().click()
+        await expect(card.locator('.scanner-score')).toHaveText('90')
+        if (status === 'PARTIAL') await expect(page.locator('.overall-card')).toContainText('Partial assessment')
+        expect(scans).toBe(0)
       })
-      await page.route(`**${apiPath}/dismissed-rules/ARCH-TEST-1`, async (route) => {
-        expect(['POST', 'DELETE']).toContain(route.request().method())
-        dismissed = route.request().method() === 'POST'
-        await route.fulfill({json: {dismissed: dismissed ? ['ARCH-TEST-1'] : []}})
-      })
-      await page.goto(`${uiPath}/#/architecture`)
-      await expect(page.locator('.advisor-summary__value')).toHaveText('90')
-      const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
-      await page.locator('a[href$="#/overview"]').first().click()
-      await expect(card.locator('.scanner-score')).toHaveText('90')
-      await card.getByRole('link', {name: 'Open panel'}).click()
-      await page.getByRole('button', {name: /Dismiss$/}).click()
-      await expect(page.locator('.list-group-item.opacity-50')).toContainText('ARCH-TEST-1')
-      await expect(page.locator('.advisor-summary__dismissed')).toContainText(
-        '1 dismissed rule(s) excluded from this score'
-      )
-      await expect(page.locator('.advisor-summary__value')).toHaveText('100')
-      await page.locator('a[href$="#/overview"]').first().click()
-      await expect(card.locator('.scanner-score')).toHaveText('100')
-      await card.getByRole('link', {name: 'Open panel'}).click()
-      await page.getByRole('button', {name: /Restore$/}).click()
-      await expect(page.locator('.list-group-item.opacity-50')).toHaveCount(0)
-      await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
-      await expect(page.locator('.advisor-summary__value')).toHaveText('90')
-      await page.locator('a[href$="#/overview"]').first().click()
-      await expect(card.locator('.scanner-score')).toHaveText('90')
-      expect(scans).toBe(0)
-    })
+    }
 
     test('refreshes UNKNOWN dismissal and restore eligibility using only cached report GETs', async ({page}) => {
       let dismissed = false
@@ -369,7 +395,7 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       const card = page.locator('.scanner-card').filter({hasText: 'Vulnerabilities'})
       await expect(card).toBeVisible()
       expect(scans).toBe(0)
-      await expect(card).toContainText('Active findings have unknown severity')
+      await expect(card).toContainText('active finding(s) have unknown severity')
       await expect(card).toContainText('1 unknown')
       await card.getByRole('link', {name: 'Open panel'}).click()
       await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
@@ -390,9 +416,11 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
         coverageStatus = next
         await card.getByRole('link', {name: 'Open panel'}).click()
         await expect(page.locator('.advisor-score-card')).toContainText('coverage')
-        await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+        await expect(page.locator('.advisor-summary__value')).toHaveText('100')
+        await expect(page.locator('.advisor-score-card')).toContainText('Partial assessment')
         await page.locator('a[href$="#/overview"]').first().click()
-        await expect(card.locator('.scanner-score')).toHaveCount(0)
+        await expect(card.locator('.scanner-score')).toHaveText('100')
+        await expect(page.locator('.overall-card')).toContainText('Partial assessment')
       }
       expect(scans).toBe(0)
     })
@@ -407,18 +435,123 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
         await page.route(`**${apiPath}/architecture`, (route) => route.fulfill({json: architectureReport('PARTIAL')}))
         await page.goto(`${uiPath}/#/architecture`)
         const summary = page.locator('.advisor-score-card')
-        await expect(summary).toContainText('Incomplete')
-        await expect(summary).toContainText('no score is calculated')
-        await expect(summary.locator('[role="img"]')).toHaveCount(0)
+        await expect(summary).toContainText('Partial assessment')
+        await expect(summary).toContainText('missing checks are not passes')
+        await expect(summary.getByRole('img', {name: /90 out of 100.*Partial assessment/})).toBeVisible()
         await expect(page.getByText('Retained architecture finding', {exact: true})).toBeVisible()
         if (Number(width) < 992) await page.getByRole('button', {name: 'Open navigation menu'}).click()
         await page.locator('a[href$="#/overview"]').first().click()
         const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
         await expect(card).toContainText('Incomplete')
         await expect(card).toContainText('1 high')
-        await expect(card.locator('.scanner-score')).toHaveCount(0)
+        await expect(card.locator('.scanner-score')).toHaveText('90')
+        await expect(page.locator('.overall-card')).toContainText('Partial assessment')
+        await expect(
+          page.locator('.overall-card').getByRole('img', {name: /90 out of 100.*Partial assessment/})
+        ).toBeVisible()
+        const gauge = await page.locator('.overall-gauge').boundingBox()
+        expect(Math.abs(gauge.width - gauge.height)).toBeLessThan(1)
         expect(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true)
       })
     }
+
+    for (const [name, status, usable, counts, expected] of [
+      ['completed checks without findings', 'SCANNED', true, [], '100'],
+      ['partial checks without findings', 'PARTIAL', true, [], '100'],
+      ['zero evaluated checks', 'SCANNED', false, [], null],
+      ['all skipped checks', 'PARTIAL', false, [], null],
+      ['wholly failed checks', 'ERROR', false, [{severity: 'HIGH', count: 1}], null],
+      ['disabled advisor', 'DISABLED', false, [{severity: 'HIGH', count: 1}], null],
+      ['invalid counts', 'PARTIAL', true, [{severity: 'HIGH', count: -1}], null]
+    ]) {
+      test(`applies shared evidence policy to ${name} on cached Overview load`, async ({page}) => {
+        const writes = []
+        page.on('request', (request) => {
+          if (request.method() !== 'GET') writes.push(request.method())
+        })
+        await page.route(`**${apiPath}/architecture`, (route) =>
+          route.fulfill({
+            json: {
+              ...architectureReport(String(status)),
+              severityCounts: counts,
+              results: [],
+              violationsFound: 0,
+              rulesEvaluated: name === 'zero evaluated checks' ? 0 : 1,
+              assessmentEvidence: {usable, incomplete: status === 'PARTIAL'}
+            }
+          })
+        )
+        await page.goto(`${uiPath}/#/overview`)
+        const card = page.locator('.scanner-card').filter({hasText: 'Architecture'})
+        await expect(card).toBeVisible()
+        if (expected) {
+          await expect(card.locator('.scanner-score')).toHaveText(String(expected))
+          if (status === 'PARTIAL') {
+            await expect(card).toContainText('No findings in evaluated evidence')
+            await expect(page.locator('.overall-card')).toContainText('Partial assessment')
+          }
+        } else {
+          await expect(card.locator('.scanner-score')).toHaveCount(0)
+          await expect(card).toContainText('Not scored')
+          await expect(page.locator('.overall-card')).toContainText('0 of 2 scanners scored')
+        }
+        expect(writes).toEqual([])
+      })
+    }
+
+    test('scores known vulnerability evidence without treating UNKNOWN or incomplete inventory as safe', async ({
+      page
+    }) => {
+      const report = vulnerabilityReport(false, 'INCOMPLETE')
+      const known = {...report.dependencies[0].vulnerabilities[0], id: 'GHSA-test-known', severity: 'HIGH'}
+      report.dependencies[0].vulnerabilities.push(known)
+      report.dependencies[0].vulnerabilityCount = 2
+      report.dependencies[0].highestSeverity = 'HIGH'
+      report.severityCounts.push({severity: 'HIGH', count: 1})
+      const writes = []
+      page.on('request', (request) => {
+        if (request.method() !== 'GET') writes.push(request.method())
+      })
+      await page.route(`**${apiPath}/vulnerabilities`, (route) => route.fulfill({json: report}))
+      await page.goto(`${uiPath}/#/vulnerabilities`)
+      await expect(page.locator('.advisor-summary__value')).toHaveText('90')
+      await expect(page.locator('.advisor-score-card')).toContainText('Partial assessment')
+      await expect(page.locator('.advisor-score-card')).toContainText('not included in the score or considered safe')
+      await expect(page.getByText('GHSA-test-unknown', {exact: true})).toBeVisible()
+      await expect(page.getByText('GHSA-test-known', {exact: true})).toBeVisible()
+      await page.locator('a[href$="#/overview"]').first().click()
+      const card = page.locator('.scanner-card').filter({hasText: 'Vulnerabilities'})
+      await expect(card.locator('.scanner-score')).toHaveText('90')
+      await expect(card).toContainText('1 high')
+      await expect(card).toContainText('1 unknown')
+      await expect(page.locator('.overall-card')).toContainText('Partial assessment')
+      expect(writes).toEqual([])
+    })
+
+    test('uses the exact mean of complete and partial contributions while qualifying the aggregate', async ({page}) => {
+      const report = vulnerabilityReport(false, 'INCOMPLETE')
+      report.dependencies[0].vulnerabilities = [1, 2, 3].map((index) => ({
+        ...report.dependencies[0].vulnerabilities[0],
+        id: `GHSA-test-high-${index}`,
+        severity: 'HIGH'
+      }))
+      report.dependencies[0].vulnerabilityCount = 3
+      report.dependencies[0].highestSeverity = 'HIGH'
+      report.severityCounts = [{severity: 'HIGH', count: 3}]
+      await page.route(`**${apiPath}/architecture`, (route) => route.fulfill({json: architectureReport('SCANNED')}))
+      await page.route(`**${apiPath}/vulnerabilities`, (route) => route.fulfill({json: report}))
+      await page.goto(`${uiPath}/#/overview`)
+      const overall = page.locator('.overall-card')
+      await expect(overall.locator('.overall-gauge__value')).toHaveText('80')
+      await expect(overall).toContainText('2 of 2 scanners scored')
+      await expect(overall).toContainText('Partial assessment')
+      await expect(overall.getByRole('img')).toHaveAttribute('aria-label', /80 out of 100.*Partial assessment/)
+      await expect(
+        page.locator('.scanner-card').filter({hasText: 'Architecture'}).locator('.scanner-score')
+      ).toHaveText('90')
+      await expect(
+        page.locator('.scanner-card').filter({hasText: 'Vulnerabilities'}).locator('.scanner-score')
+      ).toHaveText('70')
+    })
   })
 }

--- a/bootui-spring-sample-app/e2e/tests/advisor-dismiss.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/advisor-dismiss.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore, expectedAdvisorScore} from '../scenarios/advisor-scoring.js'
 
 /**
  * Removes every dismissed advisor rule so each test starts and ends from a
@@ -38,9 +39,9 @@ async function findingsCount(metric) {
 /**
  * @param {import('@playwright/test').Page} page
  */
-async function expectIncompleteAssessment(page) {
+async function expectIncompleteAssessment(page, counts) {
   await expect(page.locator('.advisor-summary__metric--status .badge')).toHaveText('Incomplete')
-  await expect(page.locator('.advisor-summary__gauge')).toHaveCount(0)
+  await expectPartialAdvisorScore(page, expect, counts)
 }
 
 test.describe('Advisor rule dismiss/restore', () => {
@@ -56,7 +57,7 @@ test.describe('Advisor rule dismiss/restore', () => {
     await clearDismissedRules(request)
   })
 
-  test('dismisses and restores a real finding without scoring an incomplete report', async ({openView, page}) => {
+  test('dismisses and restores a real finding while preserving partial qualification', async ({openView, page}) => {
     await openView('hibernate', 'Hibernate')
 
     const scanResponse = page.waitForResponse(
@@ -69,6 +70,7 @@ test.describe('Advisor rule dismiss/restore', () => {
     const report = await response.json()
     expect(report.scan.status).toBe('PARTIAL')
     expect(report.scan.message).toBeTruthy()
+    expect(report.assessmentEvidence).toEqual({usable: true, incomplete: true})
 
     // Wait for the rule-results list to populate with at least one dismissible finding.
     const activeItems = page.locator('.list-group-item').filter({has: page.getByRole('button', {name: 'Dismiss'})})
@@ -80,7 +82,7 @@ test.describe('Advisor rule dismiss/restore', () => {
     // Nothing is dismissed yet, so the dismissed-note line is absent.
     await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
 
-    await expectIncompleteAssessment(page)
+    await expectIncompleteAssessment(page, report.severityCounts)
 
     // Capture the rule id of the first active finding so we can target it precisely.
     const firstActive = activeItems.first()
@@ -93,28 +95,36 @@ test.describe('Advisor rule dismiss/restore', () => {
     const dismissedItemFor = (id) =>
       page.locator('.list-group-item.opacity-50').filter({has: page.getByText(id, {exact: true})})
 
+    const dismissedResponse = page.waitForResponse(
+      (response) => response.request().method() === 'GET' && /\/hibernate$/.test(new URL(response.url()).pathname)
+    )
     await firstActive.getByRole('button', {name: 'Dismiss'}).click()
+    const dismissedReport = await (await dismissedResponse).json()
+    expect(dismissedReport.assessmentEvidence).toEqual(report.assessmentEvidence)
+    expect(expectedAdvisorScore(dismissedReport.severityCounts)).toBeGreaterThanOrEqual(
+      expectedAdvisorScore(report.severityCounts)
+    )
 
     // Dismissal changes the active findings, not the incomplete assessment's eligibility.
     const dismissedItem = dismissedItemFor(ruleId)
     await expect(dismissedItem).toBeVisible()
     await expect(page.getByText('— not counted in score')).toBeVisible()
     await expect(page.locator('.advisor-summary__dismissed')).toContainText(
-      '1 dismissed rule(s) excluded from active findings'
+      '1 dismissed rule(s) excluded from this score'
     )
     await expect.poll(async () => findingsCount(findingsCard)).toBe(before - 1)
-    await expectIncompleteAssessment(page)
+    await expectIncompleteAssessment(page, dismissedReport.severityCounts)
 
     // The rule is no longer offered as an active (dismissible) finding.
     await expect(activeItemFor(ruleId)).toHaveCount(0)
 
-    // Restoring returns the finding to the active list without inventing a score.
+    // Restoring returns both the finding and its original score penalty.
     await dismissedItem.getByRole('button', {name: 'Restore'}).click()
 
     await expect(dismissedItemFor(ruleId)).toHaveCount(0)
     await expect(page.locator('.advisor-summary__dismissed')).toHaveCount(0)
     await expect.poll(async () => findingsCount(findingsCard)).toBe(before)
-    await expectIncompleteAssessment(page)
+    await expectIncompleteAssessment(page, report.severityCounts)
     await expect(activeItemFor(ruleId)).toHaveCount(1)
   })
 })

--- a/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
@@ -1,5 +1,6 @@
 // @ts-check
 import {expect, test} from './fixtures.js'
+import {expectPartialAdvisorScore} from '../scenarios/advisor-scoring.js'
 
 test.describe('Hibernate Advisor view', () => {
   test('runs mapped-entity checks and shows the sample advisor fixtures', async ({openView, page}) => {
@@ -18,6 +19,8 @@ test.describe('Hibernate Advisor view', () => {
     expect(report.rulesEvaluated).toBe(70)
     expect(report.scan.status).toBe('PARTIAL')
     expect(report.scan.message).toBeTruthy()
+    expect(report.assessmentEvidence).toEqual({usable: true, incomplete: true})
+    await expectPartialAdvisorScore(page, expect, report.severityCounts)
     expect(report.entitiesAnalyzed).toBeGreaterThan(0)
     expect(new Set(report.results.map((result) => result.id)).size).toBe(report.results.length)
     for (const id of ['HIB-FETCH-004', 'HIB-MAP-012', 'HIB-MAP-019', 'HIB-ENTITY-003', 'HIB-ENTITY-004']) {

--- a/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/vulnerabilities.spec.js
@@ -74,7 +74,7 @@ const scannedReport = {
         vulnerability('GHSA-AAAA-0000-0000', 'CRITICAL', 'Critical vulnerability in alpha-lib', '1.0.2')
       ]
     }
-  ]
+  ].map((dependency) => ({...dependency, assessmentComplete: true}))
 }
 
 test.describe('Vulnerabilities view', () => {
@@ -106,6 +106,8 @@ test.describe('Vulnerabilities view', () => {
 
     await page.getByRole('button', {name: 'Scan with OSV.dev'}).click()
     await expect(page.getByText('Scan complete', {exact: true})).toBeVisible()
+    await expect(page.locator('.advisor-summary__value')).toHaveText('39')
+    await expect(page.locator('.advisor-score-card')).not.toContainText('Partial assessment')
     await expect(page.getByText('No vulnerability scan data yet')).toHaveCount(0)
     await expect(page.locator('#vulnerableOnly')).toBeChecked()
     await expect(page.getByText('3 of 4 dependencies')).toBeVisible()
@@ -180,6 +182,7 @@ function dependency(groupId, artifactId, version) {
     source: 'test',
     vulnerabilityCount: 0,
     highestSeverity: 'NONE',
+    assessmentComplete: false,
     vulnerabilities: []
   }
 }

--- a/bootui-ui/src/main/frontend/src/utils/scannerScore.js
+++ b/bootui-ui/src/main/frontend/src/utils/scannerScore.js
@@ -1,4 +1,4 @@
-import {isCompleteScan, scanStatusLabel} from './scanStatus.js'
+import {scanStatusLabel} from './scanStatus.js'
 
 // Simple weighted-penalty scoring model shared by the advisor panels and Overview.
 // Each finding subtracts a fixed number of points from a perfect score of 100.
@@ -24,51 +24,182 @@ export function isKnownSeverity(severity) {
 
 export function advisorAssessment(report, {vulnerabilities = false} = {}) {
   const status = report?.scan?.status
-  const unscored = (label, reason, invalid = false) => ({score: null, label, reason, invalid})
-  if (!isCompleteScan(status)) {
-    const message = typeof report?.scan?.message === 'string' ? report.scan.message.trim() : ''
-    const withDetails = (reason) => (message ? `${reason} ${message}` : reason)
-    if (status === 'PARTIAL') {
-      return unscored(
-        'Incomplete',
-        withDetails('The scan is incomplete. Available findings are retained, but no score is calculated.')
-      )
-    }
+  const message = typeof report?.scan?.message === 'string' ? report.scan.message.trim() : ''
+  const withDetails = (reason) => (message ? `${reason} ${message}` : reason)
+  const unscored = (reason, code, invalid = false, evidenceReasons = []) => ({
+    score: null,
+    completeness: 'none',
+    label: 'Not scored',
+    reason: withDetails(reason),
+    reasonCodes: [code, ...evidenceReasons],
+    invalid
+  })
+  if (!['SCANNED', 'PARTIAL'].includes(status) || (vulnerabilities && report.scanningEnabled === false)) {
     return unscored(
-      'Not scored',
-      withDetails(
-        status === 'NOT_SCANNED'
-          ? 'Run a scan to calculate a score.'
-          : `${scanStatusLabel(status)}. A completed scan is required to calculate a score.`
-      )
+      status === 'NOT_SCANNED'
+        ? 'Run a scan to calculate a score.'
+        : `${report?.scanningEnabled === false ? 'Scanning disabled' : scanStatusLabel(status)}. No usable assessment is available.`,
+      'SCAN_UNAVAILABLE'
     )
   }
   const counts = report?.severityCounts
   if (!isValidSeveritySummary(counts, {vulnerabilities})) {
-    return unscored('Not scored', 'Scanner returned an invalid severity summary.', true)
+    return unscored('Scanner returned an invalid severity summary.', 'INVALID_SUMMARY', true)
   }
+  if (!validEvidenceCounts(report)) {
+    return unscored('Scanner returned invalid assessment counts.', 'INVALID_COUNTS', true)
+  }
+
+  const reasons = []
+  const reasonCodes = []
+  const addReason = (code, reason) => {
+    reasonCodes.push(code)
+    reasons.push(reason)
+  }
+  if (status === 'PARTIAL') addReason('PARTIAL_SCAN', 'The scan is incomplete.')
+  const knownFindings = counts.some((entry) => entry.severity.toUpperCase() !== 'UNKNOWN' && entry.count > 0)
+  let usable = false
   if (vulnerabilities) {
+    const dependencies = report.dependencies
+    if (
+      dependencies != null &&
+      (!Array.isArray(dependencies) ||
+        dependencies.some(
+          (dependency) =>
+            !dependency ||
+            (dependency.assessmentComplete != null && typeof dependency.assessmentComplete !== 'boolean') ||
+            (Object.hasOwn(dependency, 'vulnerabilityCount') && !validCount(dependency.vulnerabilityCount)) ||
+            !Array.isArray(dependency.vulnerabilities) ||
+            dependency.vulnerabilities.some(
+              (finding) =>
+                !finding ||
+                (Object.hasOwn(finding, 'dismissed') && typeof finding.dismissed !== 'boolean') ||
+                typeof finding.severity !== 'string' ||
+                !(isKnownSeverity(finding.severity) || ['UNKNOWN', 'NONE'].includes(finding.severity.toUpperCase()))
+            )
+        ))
+    ) {
+      return unscored('Scanner returned invalid dependency assessment evidence.', 'INVALID_EVIDENCE', true)
+    }
+    const activeFindings = (dependencies || []).flatMap((dependency) =>
+      dependency.vulnerabilities.filter((finding) => !finding.dismissed)
+    )
+    if (dependencies && !matchingVulnerabilityCounts(counts, activeFindings)) {
+      return unscored('Scanner returned an inconsistent severity summary.', 'INVALID_SUMMARY', true)
+    }
+    const unknownCount = counts
+      .filter((entry) => entry.severity.toUpperCase() === 'UNKNOWN')
+      .reduce((total, entry) => total + entry.count, 0)
+    const completedKnownPackage = (dependencies || []).some(
+      (dependency) =>
+        dependency.assessmentComplete === true &&
+        !dependency.vulnerabilities.some(
+          (finding) => !finding.dismissed && finding.severity.toUpperCase() === 'UNKNOWN'
+        )
+    )
+    usable = knownFindings || completedKnownPackage
     if (report.coverage?.status !== 'COMPLETE') {
-      return unscored(
-        'Incomplete',
+      addReason(
+        'INVENTORY_COVERAGE',
         report.coverage?.status === 'INCOMPLETE'
-          ? 'Dependency inventory coverage is incomplete. Available findings are retained, but no score is calculated.'
-          : 'Dependency inventory coverage is unknown. Complete coverage is required to calculate a score.'
+          ? 'Dependency inventory coverage is incomplete.'
+          : 'Dependency inventory coverage is unknown.'
       )
     }
-    if (counts.some((entry) => entry.severity.toUpperCase() === 'UNKNOWN' && entry.count > 0)) {
-      return unscored(
-        'Incomplete',
-        'Active findings have unknown severity. No score is calculated until their severity is known or they are dismissed.'
+    if (unknownCount > 0) {
+      addReason(
+        'UNKNOWN_SEVERITY',
+        `${unknownCount} active finding(s) have unknown severity. They remain visible but are not included in the score or considered safe.`
       )
+    }
+    if (!dependencies || dependencies.some((dependency) => dependency.assessmentComplete !== true)) {
+      addReason('DEPENDENCY_EVIDENCE', 'Some package queries or advisory details were not fully assessed.')
+    }
+    if (report.scan?.packagesSkipped > 0) {
+      addReason('SKIPPED_PACKAGES', `${report.scan.packagesSkipped} package(s) were not scanned.`)
+    }
+  } else {
+    const evidence = report.assessmentEvidence
+    if (evidence != null && (typeof evidence.usable !== 'boolean' || typeof evidence.incomplete !== 'boolean')) {
+      return unscored('Scanner returned invalid assessment evidence.', 'INVALID_EVIDENCE', true)
+    }
+    usable = evidence ? evidence.usable : knownFindings
+    if (!evidence || evidence.incomplete) {
+      addReason('INCOMPLETE_EVIDENCE', 'Some required checks could not be assessed, or their coverage is unknown.')
     }
   }
-  return {score: scoreFromSeverityCounts(counts), label: '', reason: '', invalid: false}
+  if (!usable) {
+    return unscored(
+      `No usable assessment is available. Skipped, failed, or wholly unknown results do not establish a score.${reasons.length ? ` ${reasons.join(' ')}` : ''}`,
+      'NO_USABLE_EVIDENCE',
+      false,
+      reasonCodes
+    )
+  }
+  const partial = reasonCodes.length > 0
+  return {
+    score: scoreFromSeverityCounts(counts.filter((entry) => entry.severity.toUpperCase() !== 'UNKNOWN')),
+    completeness: partial ? 'partial' : 'complete',
+    label: partial ? 'Partial assessment' : '',
+    reason: partial
+      ? withDetails(`Score covers evaluated evidence only; missing checks are not passes. ${reasons.join(' ')}`)
+      : '',
+    reasonCodes,
+    invalid: false
+  }
+}
+
+function validEvidenceCounts(report) {
+  const fields = [
+    'rulesEvaluated',
+    'rulesSkipped',
+    'rulesErrored',
+    'checksRun',
+    'violationsFound',
+    'findingsFound',
+    'total',
+    'vulnerable'
+  ]
+  if (fields.some((field) => Object.hasOwn(report, field) && !validCount(report[field]))) return false
+  for (const field of [...fields, 'packagesScanned', 'packagesSkipped', 'vulnerabilitiesFound']) {
+    if (Object.hasOwn(report.scan, field) && !validCount(report.scan[field])) return false
+  }
+  if (
+    Number.isInteger(report.rulesSkipped) &&
+    Number.isInteger(report.rulesErrored) &&
+    report.rulesSkipped + report.rulesErrored > report.rulesEvaluated
+  ) {
+    return false
+  }
+  const coverage = report.coverage
+  return ['archivesFound', 'archivesIdentified', 'archivesUnidentified'].every(
+    (field) => !coverage || !Object.hasOwn(coverage, field) || validCount(coverage[field])
+  )
+}
+
+function validCount(count) {
+  return Number.isSafeInteger(count) && count >= 0
+}
+
+function matchingVulnerabilityCounts(counts, findings) {
+  const actual = new Map()
+  for (const finding of findings) {
+    const severity = finding.severity.toUpperCase()
+    actual.set(severity, (actual.get(severity) || 0) + 1)
+  }
+  return (
+    counts.every((entry) => entry.count === (actual.get(entry.severity.toUpperCase()) || 0)) &&
+    [...actual].every(([severity, count]) =>
+      counts.some((entry) => entry.severity.toUpperCase() === severity && entry.count === count)
+    )
+  )
 }
 
 export function isValidSeveritySummary(counts, {vulnerabilities = false} = {}) {
   return (
     Array.isArray(counts) &&
+    new Set(counts.map((entry) => (typeof entry?.severity === 'string' ? entry.severity.toUpperCase() : null))).size ===
+      counts.length &&
     !counts.some(
       (entry) =>
         !entry ||
@@ -80,9 +211,7 @@ export function isValidSeveritySummary(counts, {vulnerabilities = false} = {}) {
             typeof entry.severity === 'string' &&
             ['UNKNOWN', 'NONE'].includes(entry.severity.toUpperCase()))
         ) ||
-        typeof entry.count !== 'number' ||
-        !Number.isFinite(entry.count) ||
-        entry.count < 0
+        !validCount(entry.count)
     )
   )
 }
@@ -108,6 +237,17 @@ export function overallScore(scores) {
   if (!valid.length) return null
   const sum = valid.reduce((total, score) => total + score, 0)
   return clampScore(sum / valid.length)
+}
+
+export function overallAssessment(assessments) {
+  const contributors = assessments.filter((assessment) => Number.isFinite(assessment.score))
+  const partialCount = contributors.filter((assessment) => assessment.completeness === 'partial').length
+  return {
+    score: overallScore(contributors.map((assessment) => assessment.score)),
+    completeness: contributors.length === 0 ? 'none' : partialCount > 0 ? 'partial' : 'complete',
+    partialCount,
+    scoredCount: contributors.length
+  }
 }
 
 // Maps a score to a qualitative band used for color + label.

--- a/bootui-ui/src/main/frontend/src/utils/scannerScore.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/scannerScore.test.js
@@ -2,6 +2,7 @@ import {describe, expect, it} from 'vitest'
 
 import {
   advisorAssessment,
+  overallAssessment,
   overallScore,
   scoreBand,
   scoreBandLabel,
@@ -12,12 +13,13 @@ import {
 const completeReport = (overrides = {}) => ({
   scan: {status: 'SCANNED'},
   severityCounts: [],
+  assessmentEvidence: {usable: true, incomplete: false},
   coverage: {status: 'COMPLETE'},
   ...overrides
 })
 
 describe('advisorAssessment', () => {
-  it.each(['PARTIAL', 'ERROR', 'DISABLED', 'NOT_SCANNED', undefined, 'UNRECOGNIZED'])(
+  it.each(['ERROR', 'DISABLED', 'NOT_SCANNED', undefined, 'UNRECOGNIZED'])(
     'never scores %s even with retained findings',
     (status) => {
       const report = completeReport({scan: {status}, severityCounts: [{severity: 'HIGH', count: 1}]})
@@ -27,12 +29,67 @@ describe('advisorAssessment', () => {
     }
   )
 
-  it('scores complete applicable evaluation without treating skipped rules as failures', () => {
-    const report = completeReport({results: [{status: 'SKIPPED'}], rulesEvaluated: 0})
+  it('scores completed applicable evaluation without treating wrong-dialect skips as failures', () => {
+    const report = completeReport({results: [], rulesEvaluated: 10, rulesSkipped: 9, rulesErrored: 0})
     expect(advisorAssessment(report).score).toBe(100)
     report.severityCounts = [{severity: 'CRITICAL', count: 5}]
     expect(advisorAssessment(report).score).toBe(0)
   })
+
+  it.each([
+    [[], 100],
+    [[{severity: 'HIGH', count: 1}], 90],
+    [[{severity: 'INFO', count: 2}], 100]
+  ])('scores usable partial evidence %j with explicit qualification', (severityCounts, score) => {
+    expect(advisorAssessment(completeReport({scan: {status: 'PARTIAL'}, severityCounts}))).toMatchObject({
+      score,
+      completeness: 'partial',
+      label: 'Partial assessment'
+    })
+  })
+
+  it.each(['SCANNED', 'PARTIAL'])(
+    'does not turn all-skipped, zero, or failed evaluations into %s success',
+    (status) => {
+      for (const rulesEvaluated of [0, 70]) {
+        expect(
+          advisorAssessment(
+            completeReport({
+              scan: {status},
+              rulesEvaluated,
+              assessmentEvidence: {usable: false, incomplete: status === 'PARTIAL'}
+            })
+          )
+        ).toMatchObject({score: null, completeness: 'none'})
+      }
+    }
+  )
+
+  it('qualifies incomplete collection even when the execution status is SCANNED', () => {
+    expect(advisorAssessment(completeReport({assessmentEvidence: {usable: true, incomplete: true}}))).toMatchObject({
+      score: 100,
+      completeness: 'partial'
+    })
+  })
+
+  it('does not infer completed checks from a legacy attempted-rule count', () => {
+    expect(advisorAssessment(completeReport({assessmentEvidence: null, rulesEvaluated: 70})).score).toBeNull()
+    expect(
+      advisorAssessment(
+        completeReport({
+          assessmentEvidence: null,
+          severityCounts: [{severity: 'HIGH', count: 1}]
+        })
+      )
+    ).toMatchObject({score: 90, completeness: 'partial'})
+  })
+
+  it.each([-1, NaN, Infinity, 0.5, '1', null, Number.MAX_SAFE_INTEGER + 1])(
+    'rejects invalid evidence count %s',
+    (rulesEvaluated) => {
+      expect(advisorAssessment(completeReport({rulesEvaluated}))).toMatchObject({score: null, invalid: true})
+    }
+  )
 
   it('keeps diagnostic details visible beside an incomplete assessment', () => {
     expect(
@@ -52,6 +109,13 @@ describe('advisorAssessment', () => {
     [{severity: 'HIGH', count: '1'}],
     [{severity: 'HIGH', count: NaN}],
     [{severity: 'HIGH', count: Infinity}],
+    [{severity: 'HIGH', count: 0.5}],
+    [{severity: 'HIGH', count: Number.MAX_SAFE_INTEGER + 1}],
+    [
+      {severity: 'HIGH', count: 1},
+      {severity: 'high', count: 1}
+    ],
+    [{severity: {toUpperCase: 1}, count: 1}],
     [{severity: 'UNKNOWN', count: 0}],
     [{severity: 'NONE', count: 1}]
   ])('rejects malformed generic summary %j instead of generating a score', (severityCounts) => {
@@ -59,14 +123,20 @@ describe('advisorAssessment', () => {
   })
 
   it.each(['INCOMPLETE', 'UNAVAILABLE', 'OTHER', undefined])(
-    'requires complete vulnerability coverage: %s',
+    'scores usable vulnerability evidence with qualified inventory coverage: %s',
     (status) => {
-      const report = completeReport({coverage: status ? {status} : undefined})
-      expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({score: null, label: 'Incomplete'})
+      const report = completeReport({
+        coverage: status ? {status} : undefined,
+        dependencies: [{assessmentComplete: true, vulnerabilities: []}]
+      })
+      expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({
+        score: 100,
+        label: 'Partial assessment'
+      })
     }
   )
 
-  it('scores NONE, but active UNKNOWN prevents a vulnerability score', () => {
+  it('scores known severities including NONE while explicitly excluding active UNKNOWN', () => {
     const report = completeReport({
       severityCounts: [
         {severity: 'NONE', count: 2},
@@ -75,11 +145,63 @@ describe('advisorAssessment', () => {
     })
     expect(advisorAssessment(report, {vulnerabilities: true}).score).toBe(90)
     report.severityCounts.push({severity: 'UNKNOWN', count: 1})
-    expect(advisorAssessment(report, {vulnerabilities: true}).score).toBeNull()
+    expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({score: 90, completeness: 'partial'})
     report.severityCounts[2].count = 0
     expect(advisorAssessment(report, {vulnerabilities: true}).score).toBe(90)
     report.severityCounts[2] = {severity: 'unknown', count: 1}
+    expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({score: 90, completeness: 'partial'})
+  })
+
+  it('distinguishes wholly UNKNOWN from UNKNOWN alongside an independently assessed package', () => {
+    const report = completeReport({
+      severityCounts: [{severity: 'UNKNOWN', count: 1}],
+      dependencies: [{assessmentComplete: true, vulnerabilities: [{severity: 'UNKNOWN'}]}]
+    })
     expect(advisorAssessment(report, {vulnerabilities: true}).score).toBeNull()
+    report.dependencies.push({assessmentComplete: true, vulnerabilities: []})
+    expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({score: 100, completeness: 'partial'})
+  })
+
+  it('does not mistake completed query pagination for successful advisory detail assessment', () => {
+    const report = completeReport({
+      scan: {status: 'PARTIAL', packagesScanned: 5},
+      dependencies: [{assessmentComplete: false, vulnerabilities: []}]
+    })
+    expect(advisorAssessment(report, {vulnerabilities: true}).score).toBeNull()
+    report.dependencies[0].assessmentComplete = true
+    expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({score: 100, completeness: 'partial'})
+  })
+
+  it('rejects inconsistent vulnerability counts instead of losing a known finding', () => {
+    const report = completeReport({
+      dependencies: [{assessmentComplete: true, vulnerabilities: [{severity: 'HIGH'}]}]
+    })
+    expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({score: null, invalid: true})
+  })
+
+  it.each(['false', 1, null])(
+    'rejects malformed dismissal %s instead of treating UNKNOWN as dismissed',
+    (dismissed) => {
+      const report = completeReport({
+        dependencies: [{assessmentComplete: true, vulnerabilities: [{severity: 'UNKNOWN', dismissed}]}]
+      })
+      expect(advisorAssessment(report, {vulnerabilities: true})).toMatchObject({
+        score: null,
+        invalid: true,
+        reasonCodes: ['INVALID_EVIDENCE']
+      })
+    }
+  )
+
+  it('aggregates numeric partial contributors without changing weights or including unusable reports', () => {
+    expect(
+      overallAssessment([
+        {score: 90, completeness: 'complete'},
+        {score: 70, completeness: 'partial'},
+        {score: null, completeness: 'none'}
+      ])
+    ).toEqual({score: 80, completeness: 'partial', partialCount: 1, scoredCount: 2})
+    expect(overallAssessment([])).toEqual({score: null, completeness: 'none', partialCount: 0, scoredCount: 0})
   })
 })
 

--- a/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.js
@@ -74,7 +74,7 @@ export function useAdvisorPanel(props, options) {
 
   const emptyRuleResultsTitle = computed(() => {
     if (!hasScanData.value) return options.emptyScanPrompt
-    if (score.value === null) return 'No findings in the available results'
+    if (assessment.value.completeness !== 'complete') return 'No findings in the available results'
     if (!report.value?.rulesEvaluated) return 'No rules were evaluated'
     return options.emptyNoFindings
   })

--- a/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.test.js
+++ b/bootui-ui/src/main/frontend/src/utils/useAdvisorPanel.test.js
@@ -8,7 +8,8 @@ const report = (status) => ({
   scan: {status},
   severityCounts: [{severity: 'HIGH', count: 1}],
   results: [finding],
-  rulesEvaluated: 1
+  rulesEvaluated: 1,
+  assessmentEvidence: {usable: true, incomplete: status === 'PARTIAL'}
 })
 let panel
 const Host = defineComponent({
@@ -21,16 +22,19 @@ const Host = defineComponent({
 describe('advisor panel scoring', () => {
   afterEach(() => vi.unstubAllGlobals())
 
-  it.each(['PARTIAL', 'ERROR', 'DISABLED'])('keeps findings from %s without a score', async (status) => {
-    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(report(status)))))
-    const wrapper = mount(Host)
-    await flushPromises()
-    expect(panel.hasScanData).toBe(true)
-    expect(panel.score).toBeNull()
-    expect(panel.visibleResults).toEqual([finding])
-    expect(panel.emptyRuleResultsTitle).toBe('No findings in the available results')
-    wrapper.unmount()
-  })
+  it.each(['PARTIAL', 'ERROR', 'DISABLED'])(
+    'keeps findings from %s with evidence-based eligibility',
+    async (status) => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(report(status)))))
+      const wrapper = mount(Host)
+      await flushPromises()
+      expect(panel.hasScanData).toBe(true)
+      expect(panel.score).toBe(status === 'PARTIAL' ? 90 : null)
+      expect(panel.visibleResults).toEqual([finding])
+      expect(panel.emptyRuleResultsTitle).toBe('No findings in the available results')
+      wrapper.unmount()
+    }
+  )
 
   it('replaces accepted scores only when a new report is received', async () => {
     let body = report('SCANNED')
@@ -51,7 +55,8 @@ describe('advisor panel scoring', () => {
     failure = false
     body = report('PARTIAL')
     await panel.runScan()
-    expect(panel.score).toBeNull()
+    expect(panel.score).toBe(90)
+    expect(panel.assessment.completeness).toBe('partial')
     expect(panel.visibleResults).toEqual([finding])
     body = report('SCANNED')
     await panel.runScan()

--- a/bootui-ui/src/main/frontend/src/views/Architecture.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.test.js
@@ -23,6 +23,7 @@ function architectureReport(
 ) {
   return {
     localOnly: true,
+    assessmentEvidence: {usable: true, incomplete: false},
     disclaimer: 'Architecture disclaimer.',
     basePackages: ['com.example'],
     classesAnalyzed: 12,

--- a/bootui-ui/src/main/frontend/src/views/Architecture.vue
+++ b/bootui-ui/src/main/frontend/src/views/Architecture.vue
@@ -47,6 +47,7 @@ const panel = useAdvisorPanel(props, {
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"

--- a/bootui-ui/src/main/frontend/src/views/DatabaseAdvisor.test.js
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseAdvisor.test.js
@@ -41,6 +41,7 @@ function advisorReport(results, overrides = {}) {
     violationsFound,
     rulesSkipped: 0,
     rulesErrored: 0,
+    assessmentEvidence: {usable: true, incomplete: false},
     truncated: false,
     severityCounts: [
       {severity: 'HIGH', count: severityCount(results, 'HIGH')},
@@ -176,8 +177,9 @@ describe('DatabaseAdvisor', () => {
     )
 
     expect(wrapper.text()).toContain('Incomplete')
-    expect(wrapper.find('.advisor-summary__gauge').exists()).toBe(false)
-    expect(wrapper.text()).toContain('Incomplete scan.')
+    expect(wrapper.find('.advisor-summary__value').text()).toBe('100')
+    expect(wrapper.text()).toContain('Partial assessment')
+    expect(wrapper.text()).toContain('missing checks are not passes')
     expect(wrapper.text()).toContain('1 datasource could not be read')
     expect(wrapper.text()).toContain('Unreadable')
     expect(wrapper.text()).toContain('No findings in the available results')

--- a/bootui-ui/src/main/frontend/src/views/DatabaseAdvisor.vue
+++ b/bootui-ui/src/main/frontend/src/views/DatabaseAdvisor.vue
@@ -107,6 +107,7 @@ function diagnosticClass(level) {
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"
@@ -237,7 +238,9 @@ function diagnosticClass(level) {
           <span
             v-if="panel.score !== null && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
-            >No findings</span
+            >{{
+              panel.assessment.completeness === 'partial' ? 'No findings in evaluated evidence' : 'No findings'
+            }}</span
           >
         </div>
         <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">

--- a/bootui-ui/src/main/frontend/src/views/Hibernate.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Hibernate.test.js
@@ -21,6 +21,7 @@ function ruleResult(id, name, severity, status, violationCount = 0) {
 function advisorReport(results, violationsFound = results.filter((result) => result.status === 'VIOLATION').length) {
   return {
     localOnly: true,
+    assessmentEvidence: {usable: true, incomplete: false},
     disclaimer: 'Hibernate disclaimer.',
     entityPackages: ['com.example'],
     entitiesAnalyzed: 3,

--- a/bootui-ui/src/main/frontend/src/views/Hibernate.vue
+++ b/bootui-ui/src/main/frontend/src/views/Hibernate.vue
@@ -47,6 +47,7 @@ const panel = useAdvisorPanel(props, {
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"
@@ -135,7 +136,9 @@ const panel = useAdvisorPanel(props, {
           <span
             v-if="panel.score !== null && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
-            >No findings</span
+            >{{
+              panel.assessment.completeness === 'partial' ? 'No findings in evaluated evidence' : 'No findings'
+            }}</span
           >
         </div>
         <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">

--- a/bootui-ui/src/main/frontend/src/views/Memory.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Memory.test.js
@@ -21,6 +21,7 @@ function ruleResult(id, name, severity, status, violationCount = 0) {
 function advisorReport(results, violationsFound = results.filter((result) => result.status === 'VIOLATION').length) {
   return {
     localOnly: true,
+    assessmentEvidence: {usable: true, incomplete: false},
     disclaimer: 'Memory disclaimer.',
     rulesEvaluated: 22,
     violationsFound,

--- a/bootui-ui/src/main/frontend/src/views/Memory.vue
+++ b/bootui-ui/src/main/frontend/src/views/Memory.vue
@@ -62,6 +62,7 @@ function formatBytes(value) {
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"
@@ -165,7 +166,9 @@ function formatBytes(value) {
           <span
             v-if="panel.score !== null && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
-            >No findings</span
+            >{{
+              panel.assessment.completeness === 'partial' ? 'No findings in evaluated evidence' : 'No findings'
+            }}</span
           >
         </div>
         <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">

--- a/bootui-ui/src/main/frontend/src/views/Overview.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Overview.test.js
@@ -13,7 +13,20 @@ function architectureScore(wrapper) {
 }
 
 function severityReport(severityCounts, status = 'SCANNED') {
-  return {severityCounts, scan: {status}, coverage: {status: 'COMPLETE'}}
+  return {
+    severityCounts,
+    scan: {status},
+    assessmentEvidence: {usable: true, incomplete: status === 'PARTIAL'},
+    coverage: {status: 'COMPLETE'},
+    dependencies: [
+      {
+        assessmentComplete: true,
+        vulnerabilities: severityCounts.flatMap(({severity, count}) =>
+          Array.from({length: count}, () => ({severity, dismissed: false}))
+        )
+      }
+    ]
+  }
 }
 
 function githubReport({connected = true, authenticated = true, alerts = 0} = {}) {
@@ -207,9 +220,9 @@ describe('Overview', () => {
       const card = scannerCard(wrapper, 'Hibernate')
       expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/hibernate'])
       expect(card.text()).toContain('1 high')
-      expect(card.find('.scanner-score').exists()).toBe(status === 'SCANNED')
-      if (status === 'SCANNED') expect(card.find('.scanner-score').text()).toBe('90')
-      if (status === 'PARTIAL') expect(card.text()).toContain('Incomplete')
+      expect(card.find('.scanner-score').exists()).toBe(['SCANNED', 'PARTIAL'].includes(status))
+      if (['SCANNED', 'PARTIAL'].includes(status)) expect(card.find('.scanner-score').text()).toBe('90')
+      if (status === 'PARTIAL') expect(card.text()).toContain('Partial assessment')
       if (status === 'NOT_SCANNED') {
         expect(card.props('state')).toBe('idle')
         expect(card.find('button').text()).toBe('Run scan')
@@ -231,7 +244,8 @@ describe('Overview', () => {
     const card = scannerCard(wrapper, 'Hibernate')
     expect(card.text()).toContain('Incomplete')
     expect(card.text()).toContain('1 high')
-    expect(card.find('.scanner-score').exists()).toBe(false)
+    expect(card.find('.scanner-score').text()).toBe('90')
+    expect(wrapper.find('.overall-card').text()).toContain('Partial assessment')
     expect(fetch.mock.calls.map(([url]) => url)).toEqual(['api/hibernate', 'api/hibernate'])
   })
 
@@ -352,7 +366,8 @@ describe('Overview', () => {
     await flushPromises()
     expect(scannerCard(wrapper, 'Architecture').text()).toContain('Incomplete')
     expect(scannerCard(wrapper, 'Architecture').text()).toContain('1 high')
-    expect(wrapper.text()).toContain('0 of 1 scanners scored')
+    expect(wrapper.text()).toContain('1 of 1 scanners scored')
+    expect(architectureScore(wrapper)).toBe('90')
   })
 
   it('computes a score after running a scanner on demand', async () => {
@@ -521,7 +536,7 @@ describe('Overview', () => {
     await runButton.trigger('click')
     await flushPromises()
 
-    expect(wrapper.text()).toContain('Unable to run Architecture')
+    expect(wrapper.text()).toContain('invalid severity summary')
     expect(wrapper.text()).toContain('0 of 1 scanners scored')
     expect(wrapper.text()).not.toContain('100 / 100')
   })
@@ -696,12 +711,12 @@ describe('Overview', () => {
       body = {...body, scan: {status}}
       card.vm.$emit('run')
       await flushPromises()
-      expect(card.find('.scanner-score').exists()).toBe(false)
+      expect(card.find('.scanner-score').exists()).toBe(status === 'PARTIAL')
       expect(card.text()).toContain('1 high')
-      expect(wrapper.text()).toContain('0 of 1 scanners scored')
-      expect(wrapper.find('.overall-gauge').exists()).toBe(false)
+      expect(wrapper.text()).toContain(`${status === 'PARTIAL' ? 1 : 0} of 1 scanners scored`)
+      expect(wrapper.find('.overall-gauge').exists()).toBe(status === 'PARTIAL')
       expect(card.text()).not.toContain('No findings')
-      if (status === 'PARTIAL') expect(card.text()).toContain('Incomplete')
+      if (status === 'PARTIAL') expect(card.text()).toContain('Partial assessment')
     }
   )
 
@@ -719,10 +734,12 @@ describe('Overview', () => {
       .find((b) => b.text().includes('Run all scanners'))
       .trigger('click')
     await flushPromises()
-    expect(wrapper.find('.overall-gauge__value').text()).toBe('80')
-    expect(wrapper.find('.overall-card').text()).toContain('2 of 4 scanners scored')
-    expect(wrapper.find('.overall-card').text()).not.toContain('Security')
-    expect(wrapper.find('.overall-card').text()).not.toContain('Vulnerabilities')
+    expect(wrapper.find('.overall-gauge__value').text()).toBe('90')
+    expect(wrapper.find('.overall-card').text()).toContain('4 of 4 scanners scored')
+    expect(wrapper.find('.overall-card').text()).toContain('Security')
+    expect(wrapper.find('.overall-card').text()).toContain('Vulnerabilities')
+    expect(wrapper.find('.overall-card').text()).toContain('Partial assessment')
+    expect(wrapper.find('.overall-gauge').attributes('aria-label')).toContain('Partial assessment')
     expect(wrapper.find('.overall-card').text()).toContain('Mean of scored scanners only')
   })
 
@@ -736,10 +753,10 @@ describe('Overview', () => {
     const {wrapper, show} = mountKeptAlive(onlyPanels('vulnerabilities'))
     await flushPromises()
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(wrapper.text()).toContain('0 of 1 scanners scored')
+    expect(wrapper.text()).toContain('1 of 1 scanners scored')
     for (const [unknown, score] of [
       [0, '90'],
-      [1, null],
+      [1, '90'],
       [0, '90']
     ]) {
       body = severityReport([
@@ -753,6 +770,7 @@ describe('Overview', () => {
       const card = scannerCard(wrapper, 'Vulnerabilities')
       expect(card.find('.scanner-score').exists()).toBe(score !== null)
       if (score) expect(card.find('.scanner-score').text()).toBe(score)
+      expect(card.props('scoreCompleteness')).toBe(unknown ? 'partial' : 'complete')
       expect(card.text()).toContain('1 high')
     }
     expect(fetchMock.mock.calls.filter(([, init]) => init?.method === 'POST')).toHaveLength(0)
@@ -824,7 +842,8 @@ describe('Overview', () => {
     finishScan(new Response(JSON.stringify(severityReport([], cachedStatus))))
     await flushPromises()
     expect(wrapper.text()).toContain('Incomplete')
-    expect(wrapper.text()).toContain('0 of 1 scanners scored')
+    expect(wrapper.text()).toContain('1 of 1 scanners scored')
+    expect(wrapper.find('.overall-card').text()).toContain('Partial assessment')
     expect(fetch.mock.calls.filter(([, init]) => !init?.method)).toHaveLength(2)
   })
 

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -8,7 +8,7 @@ import {scanStatusBadgeClass, scanStatusLabel} from '../utils/scanStatus.js'
 import {
   advisorAssessment,
   isValidSeveritySummary,
-  overallScore,
+  overallAssessment,
   scoreBandLabel,
   scoreBandTone,
   scoreFromSeverityCounts
@@ -132,6 +132,7 @@ function newScannerState() {
   return {
     state: 'idle',
     score: null,
+    completeness: 'none',
     hasReport: false,
     scoreLabel: '',
     scoreReason: '',
@@ -159,11 +160,11 @@ function nextToken(id) {
 
 function applyReport(def, state, report) {
   const assessment = advisorAssessment(report, {vulnerabilities: def.id === 'vulnerabilities'})
-  if (assessment.invalid) throw new Error(assessment.reason)
   const validSummary = isValidSeveritySummary(report?.severityCounts, {vulnerabilities: def.id === 'vulnerabilities'})
   state.hasReport = true
   state.severityCounts = validSummary ? report.severityCounts : []
   state.score = assessment.score
+  state.completeness = assessment.completeness
   state.scoreLabel = assessment.label
   state.scoreReason = assessment.reason
   const status = report?.scan?.status
@@ -171,7 +172,11 @@ function applyReport(def, state, report) {
   state.statusTone = scanStatusBadgeClass(status)
   state.state = status === 'NOT_SCANNED' ? 'idle' : 'done'
   state.error = null
-  state.warning = validSummary ? null : 'The report has an invalid severity summary. Its counts cannot be displayed.'
+  state.warning = assessment.invalid
+    ? assessment.reason
+    : validSummary
+      ? null
+      : 'The report has an invalid severity summary. Its counts cannot be displayed.'
 }
 
 const visibleScanners = computed(() => scannerDefs.filter((def) => panelAvailable(def.id)))
@@ -285,13 +290,20 @@ const githubScored = computed(
 
 const contributors = computed(() => {
   const items = visibleScanners.value
-    .map((def) => ({title: displayTitle(def), score: scanners[def.id].score}))
+    .map((def) => ({
+      title: displayTitle(def),
+      score: scanners[def.id].score,
+      completeness: scanners[def.id].completeness
+    }))
     .filter((item) => Number.isFinite(item.score))
-  if (githubVisible.value && githubScored.value) items.push({title: 'GitHub', score: github.score})
+  if (githubVisible.value && githubScored.value)
+    items.push({title: 'GitHub', score: github.score, completeness: 'complete'})
   return items
 })
 
-const overall = computed(() => overallScore(contributors.value.map((item) => item.score)))
+const combinedAssessment = computed(() => overallAssessment(contributors.value))
+const overall = computed(() => combinedAssessment.value.score)
+const overallPartial = computed(() => combinedAssessment.value.completeness === 'partial')
 const scoredCount = computed(() => contributors.value.length)
 
 const totalCount = computed(() => visibleScanners.value.length + (githubVisible.value ? 1 : 0))
@@ -300,12 +312,20 @@ const anyRunning = computed(
   () => github.state === 'running' || visibleScanners.value.some((def) => scanners[def.id].state === 'running')
 )
 
-const overallBandLabel = computed(() => (Number.isFinite(overall.value) ? scoreBandLabel(overall.value) : 'Not scored'))
+const overallBandLabel = computed(() =>
+  Number.isFinite(overall.value)
+    ? `${scoreBandLabel(overall.value)}${overallPartial.value ? ' in evaluated evidence' : ''}`
+    : 'Not scored'
+)
 const overallBandTone = computed(() => (Number.isFinite(overall.value) ? scoreBandTone(overall.value) : 'secondary'))
+const overallDescription = computed(
+  () =>
+    `Overall score: ${overall.value} out of 100 — ${overallBandLabel.value}${overallPartial.value ? ' — Partial assessment' : ''}`
+)
 
 const overallContributions = computed(() =>
   contributors.value
-    .map((item) => ({title: item.title, deduction: item.score - 100}))
+    .map((item) => ({title: item.title, deduction: item.score - 100, partial: item.completeness === 'partial'}))
     .sort((a, b) => a.deduction - b.deduction)
 )
 
@@ -395,26 +415,30 @@ watch(
             <div v-if="scoredCount > 0" class="flex-shrink-0 min-w-0">
               <h3 class="fs-6 text-muted fw-semibold mb-0">Overall score</h3>
               <div class="d-flex align-items-center gap-3 mt-2">
-                <div :class="['overall-gauge', `overall-gauge--${overallBandTone}`]">
+                <div
+                  :class="['overall-gauge', `overall-gauge--${overallBandTone}`]"
+                  role="img"
+                  :aria-label="overallDescription"
+                >
                   <span class="overall-gauge__value">{{ Number.isFinite(overall) ? overall : '—' }}</span>
                   <span class="overall-gauge__max">/ 100</span>
                 </div>
                 <div class="min-w-0">
                   <span
-                    :class="[
-                      'badge',
-                      `text-bg-${overallBandTone}`,
-                      'fs-6',
-                      'text-truncate',
-                      'd-inline-block',
-                      'mw-100'
-                    ]"
+                    :class="['badge', `text-bg-${overallBandTone}`, 'fs-6', 'text-wrap', 'd-inline-block', 'mw-100']"
                     >{{ overallBandLabel }}</span
                   >
                   <div class="text-muted small mt-2 text-truncate">
                     {{ scoredCount }} of {{ totalCount }} scanners scored
                   </div>
                   <div class="text-muted small">Mean of scored scanners only.</div>
+                  <div v-if="overallPartial" class="small mt-2">
+                    <strong>Partial assessment</strong>
+                    <div class="text-muted">
+                      {{ combinedAssessment.partialCount }} partial contributor(s). The score covers evaluated evidence,
+                      not complete health.
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
@@ -427,7 +451,7 @@ watch(
                     :key="item.title"
                     class="col-sm-6 col-lg-4 d-flex justify-content-between align-items-center small min-w-0"
                   >
-                    <span class="text-muted text-truncate me-2">{{ item.title }}</span>
+                    <span class="text-muted me-2"> {{ item.title }}<span v-if="item.partial"> · Partial</span> </span>
                     <span
                       :class="[
                         'flex-shrink-0',
@@ -439,14 +463,14 @@ watch(
                   </div>
                 </div>
                 <p v-else class="text-success small mb-0">
-                  <i class="bi bi-check-circle me-1"></i>All scanned advisors are passing.
+                  <i class="bi bi-check-circle me-1"></i>No active findings in evaluated evidence.
                 </p>
               </template>
               <div v-else>
                 <h3 class="fs-6 text-muted fw-semibold mb-0">Overall score</h3>
                 <p class="text-muted small mb-0 mt-1">
                   {{ scoredCount }} of {{ totalCount }} scanners scored — run the advisors to compute a combined score
-                  from complete assessments.
+                  from usable assessments.
                 </p>
               </div>
             </div>
@@ -550,6 +574,7 @@ watch(
           :to="def.to"
           :state="scanners[def.id].state"
           :score="scanners[def.id].score"
+          :score-completeness="scanners[def.id].completeness"
           :has-report="scanners[def.id].hasReport"
           :score-label="scanners[def.id].scoreLabel"
           :score-reason="scanners[def.id].scoreReason"
@@ -576,6 +601,7 @@ watch(
   border-radius: 50%;
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   height: 6.5rem;
   justify-content: center;
   width: 6.5rem;

--- a/bootui-ui/src/main/frontend/src/views/Pentesting.vue
+++ b/bootui-ui/src/main/frontend/src/views/Pentesting.vue
@@ -69,6 +69,7 @@ function coverageStatusLabel(status) {
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"

--- a/bootui-ui/src/main/frontend/src/views/RestApi.test.js
+++ b/bootui-ui/src/main/frontend/src/views/RestApi.test.js
@@ -26,6 +26,7 @@ function ruleResult(id, name, severity, status, violationCount = 0) {
 function restApiReport(results, violationsFound = results.filter((result) => result.status === 'VIOLATION').length) {
   return {
     localOnly: true,
+    assessmentEvidence: {usable: true, incomplete: false},
     disclaimer: 'REST API disclaimer.',
     basePackages: ['com.example'],
     controllersAnalyzed: 4,

--- a/bootui-ui/src/main/frontend/src/views/RestApi.vue
+++ b/bootui-ui/src/main/frontend/src/views/RestApi.vue
@@ -135,6 +135,7 @@ watch(contractFilter, () => contract.scheduleReload())
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"
@@ -223,7 +224,9 @@ watch(contractFilter, () => contract.scheduleReload())
           <span
             v-if="panel.score !== null && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
-            >No findings</span
+            >{{
+              panel.assessment.completeness === 'partial' ? 'No findings in evaluated evidence' : 'No findings'
+            }}</span
           >
         </div>
         <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">

--- a/bootui-ui/src/main/frontend/src/views/Security.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Security.test.js
@@ -22,6 +22,7 @@ function ruleResult(id, name, severity, status, violationCount = 0) {
 function advisorReport(results, violationsFound = results.filter((result) => result.status === 'VIOLATION').length) {
   return {
     localOnly: true,
+    assessmentEvidence: {usable: true, incomplete: false},
     disclaimer: 'Security disclaimer.',
     filterChains: ['any request'],
     filterChainsAnalyzed: 1,

--- a/bootui-ui/src/main/frontend/src/views/Security.vue
+++ b/bootui-ui/src/main/frontend/src/views/Security.vue
@@ -60,6 +60,7 @@ const panel = useAdvisorPanel(props, {
     <template v-else-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"
@@ -146,7 +147,9 @@ const panel = useAdvisorPanel(props, {
           <span
             v-if="panel.score !== null && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
-            >No findings</span
+            >{{
+              panel.assessment.completeness === 'partial' ? 'No findings in evaluated evidence' : 'No findings'
+            }}</span
           >
         </div>
         <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">

--- a/bootui-ui/src/main/frontend/src/views/Spring.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Spring.test.js
@@ -22,6 +22,7 @@ function ruleResult(id, name, severity, status, violationCount = 0) {
 function advisorReport(results, violationsFound = results.filter((result) => result.status === 'VIOLATION').length) {
   return {
     localOnly: true,
+    assessmentEvidence: {usable: true, incomplete: false},
     disclaimer: 'Spring disclaimer.',
     inspected: ['Active profiles: none', 'Bean definitions: 120'],
     componentsAnalyzed: 120,

--- a/bootui-ui/src/main/frontend/src/views/Spring.vue
+++ b/bootui-ui/src/main/frontend/src/views/Spring.vue
@@ -64,6 +64,7 @@ const panel = useAdvisorPanel(props, {
     <template v-if="panel.report">
       <AdvisorSummary
         :score="panel.score"
+        :score-completeness="panel.assessment.completeness"
         :score-label="panel.assessment.label"
         :score-reason="panel.assessment.reason"
         :dismissed-count="panel.dismissedResults.length"
@@ -150,7 +151,9 @@ const panel = useAdvisorPanel(props, {
           <span
             v-if="panel.score !== null && panel.visibleResults.length === 0 && panel.dismissedResults.length === 0"
             class="badge text-bg-success"
-            >No findings</span
+            >{{
+              panel.assessment.completeness === 'partial' ? 'No findings in evaluated evidence' : 'No findings'
+            }}</span
           >
         </div>
         <div v-if="panel.visibleResults.length === 0" class="card-body text-center text-muted py-5">

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.test.js
@@ -30,6 +30,7 @@ function dependency(packageName, version, vulnerabilities, highestSeverity) {
     source: 'test',
     vulnerabilityCount: vulnerabilities.filter((v) => !v.dismissed).length,
     highestSeverity,
+    assessmentComplete: true,
     vulnerabilities
   }
 }
@@ -56,12 +57,12 @@ function report(
     scanningEnabled: true,
     total: dependencies.length,
     vulnerable,
-    severityCounts: [
-      {severity: 'CRITICAL', count: 0},
-      {severity: 'HIGH', count: 0},
-      {severity: 'MEDIUM', count: 0},
-      {severity: 'LOW', count: 0}
-    ],
+    severityCounts: ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO', 'NONE', 'UNKNOWN'].map((severity) => ({
+      severity,
+      count: dependencies
+        .flatMap((dependency) => dependency.vulnerabilities)
+        .filter((finding) => !finding.dismissed && finding.severity === severity).length
+    })),
     scan: {
       scanner: 'OSV.dev',
       status,
@@ -113,35 +114,31 @@ describe('Vulnerabilities', () => {
     vi.unstubAllGlobals()
   })
 
-  it.each(['INCOMPLETE', 'UNAVAILABLE', undefined])('withholds scores for %s inventory coverage', async (status) => {
-    const {wrapper} = await mountWithReports([report([], 0, 'SCANNED', {coverage: status ? coverage({status}) : null})])
-    expect(wrapper.find('.advisor-summary__gauge').exists()).toBe(false)
-    expect(wrapper.find('.advisor-score-card').text()).toContain('Incomplete')
-    expect(wrapper.find('.advisor-score-card').text()).toContain('coverage')
-  })
+  it.each(['INCOMPLETE', 'UNAVAILABLE', undefined])(
+    'qualifies usable scores for %s inventory coverage',
+    async (status) => {
+      const {wrapper} = await mountWithReports([
+        report([dependency('org.example:sample', '1.0', [], 'NONE')], 0, 'SCANNED', {
+          coverage: status ? coverage({status}) : null
+        })
+      ])
+      expect(wrapper.find('.advisor-summary__value').text()).toBe('100')
+      expect(wrapper.find('.advisor-score-card').text()).toContain('Partial assessment')
+      expect(wrapper.find('.advisor-score-card').text()).toContain('coverage')
+    }
+  )
 
   it('recomputes the score after dismissing and restoring an UNKNOWN finding', async () => {
     const unknown = vulnerability('GHSA-unknown', 'UNKNOWN')
-    const active = report([dependency('org.example:sample', '1.0', [unknown], 'UNKNOWN')], 1, 'SCANNED', {
-      severityCounts: [
-        {severity: 'UNKNOWN', count: 1},
-        {severity: 'NONE', count: 1}
-      ]
-    })
+    const active = report([dependency('org.example:sample', '1.0', [unknown], 'UNKNOWN')])
     const dismissed = report(
       [dependency('org.example:sample', '1.0', [{...unknown, dismissed: true}], 'NONE')],
       0,
-      'SCANNED',
-      {
-        severityCounts: [
-          {severity: 'UNKNOWN', count: 0},
-          {severity: 'NONE', count: 1}
-        ]
-      }
+      'SCANNED'
     )
     const {wrapper, fetchMock} = await mountWithReports([active, dismissed, active])
     expect(wrapper.find('.advisor-summary__gauge').exists()).toBe(false)
-    expect(wrapper.text()).toContain('Active findings have unknown severity')
+    expect(wrapper.text()).toContain('active finding(s) have unknown severity')
     await wrapper
       .findAll('button')
       .find((b) => b.text().trim() === 'Dismiss')

--- a/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
+++ b/bootui-ui/src/main/frontend/src/views/Vulnerabilities.vue
@@ -99,7 +99,7 @@ function emptyAdvisoryText() {
   const status = data.value?.scan?.status
   if (status === 'NOT_SCANNED' || status === 'DISABLED') return 'Not scanned'
   if (status === 'ERROR') return 'Unknown (scan failed)'
-  if (status === 'PARTIAL') return 'No finding in partial result'
+  if (assessment.value.completeness !== 'complete') return 'No finding in partial result'
   return 'None found'
 }
 
@@ -328,6 +328,7 @@ onMounted(loadDependencies)
 
       <AdvisorSummary
         :score="assessment.score"
+        :score-completeness="assessment.completeness"
         :score-label="assessment.label"
         :score-reason="assessment.reason"
         :scan-status-label="scanStatusLabel(data.scan.status)"

--- a/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.test.js
@@ -18,6 +18,23 @@ const baseProps = {
 }
 
 describe('AdvisorSummary', () => {
+  it('keeps numeric partial qualification and missing coverage visible and accessible', () => {
+    const wrapper = mount(AdvisorSummary, {
+      props: {
+        ...baseProps,
+        score: 100,
+        scoreCompleteness: 'partial',
+        scoreLabel: 'Partial assessment',
+        scoreReason: 'Index semantics were not fully assessed.'
+      }
+    })
+    expect(wrapper.find('.advisor-summary__value').text()).toBe('100')
+    expect(wrapper.find('.advisor-score-card').text()).toContain('Partial assessment')
+    expect(wrapper.find('.advisor-score-card').text()).toContain('Index semantics')
+    expect(wrapper.find('[role="img"]').attributes('aria-label')).toContain('Partial assessment')
+    expect(wrapper.text()).not.toMatch(/Good(?!.*evaluated)/)
+  })
+
   it('renders the score gauge, /100, and qualitative band when a score is provided', () => {
     const wrapper = mount(AdvisorSummary, {props: {...baseProps, score: 90}})
     expect(wrapper.find('.advisor-score-card').exists()).toBe(true)

--- a/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/AdvisorSummary.vue
@@ -4,6 +4,7 @@ import {scoreBandLabel, scoreBandTone} from '../../utils/scannerScore.js'
 
 const props = defineProps({
   score: {type: Number, default: null},
+  scoreCompleteness: {type: String, default: 'complete'},
   scoreLabel: {type: String, default: ''},
   scoreReason: {type: String, default: ''},
   dismissedCount: {type: Number, default: 0},
@@ -14,13 +15,18 @@ const props = defineProps({
 })
 
 const hasScore = computed(() => Number.isFinite(props.score))
+const partial = computed(() => props.scoreCompleteness === 'partial')
 const metricList = computed(
   () => /** @type {Array<{label: string, value: string|number, hint?: string}>} */ (props.metrics || [])
 )
-const bandLabel = computed(() => (hasScore.value ? scoreBandLabel(props.score) : null))
+const bandLabel = computed(() =>
+  hasScore.value ? `${scoreBandLabel(props.score)}${partial.value ? ' in evaluated evidence' : ''}` : null
+)
 const bandTone = computed(() => (hasScore.value ? scoreBandTone(props.score) : 'secondary'))
 const gaugeLabel = computed(() =>
-  hasScore.value ? `Advisor score: ${props.score} out of 100 — ${bandLabel.value}` : null
+  hasScore.value
+    ? `Advisor score: ${props.score} out of 100 — ${bandLabel.value}${partial.value ? ' — Partial assessment' : ''}`
+    : null
 )
 </script>
 
@@ -35,13 +41,13 @@ const gaugeLabel = computed(() =>
           </div>
           <div class="advisor-summary__band">
             <div class="advisor-summary__band-label">Advisor score</div>
-            <span :class="['badge', `text-bg-${bandTone}`, 'fs-6']">{{ bandLabel }}</span>
+            <span :class="['badge', `text-bg-${bandTone}`, 'fs-6', 'text-wrap']">{{ bandLabel }}</span>
           </div>
         </div>
 
         <div v-if="hasScore" class="advisor-summary__divider" aria-hidden="true"></div>
 
-        <div v-if="!hasScore && scoreLabel" class="advisor-summary__assessment">
+        <div v-if="scoreLabel" class="advisor-summary__assessment">
           <div class="fw-semibold">{{ scoreLabel }}</div>
           <div class="small text-muted">{{ scoreReason }}</div>
         </div>
@@ -82,11 +88,13 @@ const gaugeLabel = computed(() =>
   display: flex;
   align-items: center;
   gap: 0.9rem;
-  flex-shrink: 0;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .advisor-summary__assessment {
   flex: 1 1 16rem;
+  overflow-wrap: anywhere;
 }
 
 /* Tone (success/warning/danger) is carried by the global, theme-tuned .text-* utility
@@ -101,6 +109,7 @@ const gaugeLabel = computed(() =>
   height: 4.75rem;
   border: 0.3rem solid currentColor;
   border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .advisor-summary__value {

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.test.js
@@ -3,6 +3,27 @@ import {describe, expect, it} from 'vitest'
 import ScannerScoreCard from './ScannerScoreCard.vue'
 
 describe('ScannerScoreCard', () => {
+  it('qualifies a high partial score without a clean-health claim', () => {
+    const wrapper = mount(ScannerScoreCard, {
+      global: {stubs: {RouterLink: true}},
+      props: {
+        title: 'Database',
+        state: 'done',
+        hasReport: true,
+        score: 100,
+        scoreCompleteness: 'partial',
+        scoreLabel: 'Partial assessment',
+        scoreReason: 'Some index metadata was unavailable.',
+        severityCounts: []
+      }
+    })
+    expect(wrapper.find('.scanner-score').text()).toBe('100')
+    expect(wrapper.text()).toContain('Partial assessment')
+    expect(wrapper.text()).toContain('Some index metadata')
+    expect(wrapper.text()).toContain('No findings in evaluated evidence')
+    expect(wrapper.find('[role="img"]').attributes('aria-label')).toContain('Partial assessment')
+  })
+
   it('keeps incomplete findings visible without a score or idle/clean claim', () => {
     const wrapper = mount(ScannerScoreCard, {
       global: {stubs: {RouterLink: true}},

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
@@ -12,6 +12,7 @@ const props = defineProps({
   // idle | running | done | error
   state: {type: String, default: 'idle'},
   score: {type: Number, default: null},
+  scoreCompleteness: {type: String, default: 'complete'},
   hasReport: {type: Boolean, default: false},
   scoreLabel: {type: String, default: 'Not scored'},
   scoreReason: {type: String, default: ''},
@@ -44,8 +45,15 @@ const topSeverities = computed(() =>
 )
 
 const hasScore = computed(() => Number.isFinite(props.score))
-const bandLabel = computed(() => (hasScore.value ? scoreBandLabel(props.score) : null))
+const partial = computed(() => props.scoreCompleteness === 'partial')
+const bandLabel = computed(() =>
+  hasScore.value ? `${scoreBandLabel(props.score)}${partial.value ? ' in evaluated evidence' : ''}` : null
+)
 const bandTone = computed(() => (hasScore.value ? scoreBandTone(props.score) : 'secondary'))
+const scoreDescription = computed(
+  () =>
+    `${props.title} score: ${props.score} out of 100 — ${bandLabel.value}${partial.value ? ' — Partial assessment' : ''}`
+)
 
 function severityTone(severity) {
   return SEVERITY_TONES[String(severity).toUpperCase()] || 'text-bg-light border'
@@ -84,17 +92,17 @@ function onRun() {
             Showing the last report.
           </div>
           <template v-if="hasScore">
-            <div class="d-flex align-items-baseline gap-2">
+            <div class="d-flex align-items-baseline gap-2" role="img" :aria-label="scoreDescription">
               <span :class="['scanner-score', `scanner-score--${bandTone}`]">{{ score }}</span>
               <span class="text-muted small">/ 100</span>
-              <span :class="['badge', `text-bg-${bandTone}`, 'ms-auto']">{{ bandLabel }}</span>
+              <span :class="['badge', `text-bg-${bandTone}`, 'ms-auto', 'text-wrap']">{{ bandLabel }}</span>
             </div>
           </template>
-          <div v-else-if="hasReport">
+          <div v-if="hasReport && scoreLabel" class="scanner-assessment mt-2">
             <div class="fw-semibold">{{ scoreLabel }}</div>
             <div class="text-muted small">{{ scoreReason }}</div>
           </div>
-          <div v-else-if="state === 'idle'" class="text-muted small">{{ idleHint }}</div>
+          <div v-else-if="!hasReport && !hasScore && state === 'idle'" class="text-muted small">{{ idleHint }}</div>
           <template v-if="hasReport || hasScore">
             <div v-if="topSeverities.length" class="d-flex flex-wrap gap-1 mt-2">
               <span
@@ -105,8 +113,8 @@ function onRun() {
                 {{ entry.count }} {{ entry.severity.toLowerCase() }}
               </span>
             </div>
-            <div v-else-if="hasScore" class="text-success small mt-2">
-              <i class="bi bi-check-circle me-1"></i>No findings
+            <div v-else-if="hasScore" :class="[partial ? 'text-muted' : 'text-success', 'small mt-2']">
+              <i class="bi bi-check-circle me-1"></i>{{ partial ? 'No findings in evaluated evidence' : 'No findings' }}
             </div>
           </template>
         </slot>
@@ -195,6 +203,11 @@ function onRun() {
   font-size: 2.1rem;
   font-weight: 850;
   line-height: 1;
+  flex-shrink: 0;
+}
+
+.scanner-assessment {
+  overflow-wrap: anywhere;
 }
 
 .scanner-score--success {

--- a/docs/AI-AGENTS.md
+++ b/docs/AI-AGENTS.md
@@ -207,10 +207,13 @@ the classpath) are simply not advertised.
 ### Reading a bounded result
 
 Advisor tool success means a report was returned, not that its assessment is complete or healthy. Inspect
-`scan.status` and the retained diagnostics: only `SCANNED` reports are eligible for the UI's numeric score;
-`PARTIAL`, `ERROR`, and `DISABLED` reports remain useful but unscored. Vulnerability scoring also requires
-`coverage.status=COMPLETE` and no active UNKNOWN severity findings. Missing coverage is unknown; NONE (CVSS zero)
-has no penalty, and dismissed findings are excluded from the severity summary.
+`scan.status`, `assessmentEvidence` and retained diagnostics. `SCANNED` and `PARTIAL` reports with usable evidence
+and valid counts can score; partial scores explicitly cover evaluated evidence only. All-skipped, wholly failed,
+disabled, unscanned or unusable reports remain unscored. For Vulnerabilities, `dependencies[].assessmentComplete`
+records completed query/detail/association evidence, separately from inventory coverage and severity. Known findings
+remain scoreable alongside active UNKNOWN findings, but UNKNOWN is never treated as safe and forces partial
+qualification. Wholly UNKNOWN evidence without another completed known assessment has no score. NONE (CVSS zero)
+has no penalty, and dismissed findings are excluded from the severity summary without erasing coverage gaps.
 
 The aggregate Overview score is calculated in the browser, not by a separate MCP or CLI scorer. `get_overview`
 (`bootui overview`) returns application context, not that aggregate. CLI transport success and unchanged JSON output

--- a/docs/ARCHITECTURE-CHECKS.md
+++ b/docs/ARCHITECTURE-CHECKS.md
@@ -4,6 +4,9 @@ The Architecture panel runs a fixed, zero-config [ArchUnit](https://www.archunit
 application's own classes. This page lists every rule that ships with BootUI today, what it inspects, when it fires, and
 what to do about it.
 
+Reports include `assessmentEvidence` from actual rule outcomes before passing/skipped results are filtered.
+Usable partial evidence scores with explicit qualification under the [shared policy](features/advisors.md#score-eligibility).
+
 Each rule is a small class registered in
 [`ArchitectureRuleRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/architecture/ArchitectureRuleRegistry.java)
 and implemented in

--- a/docs/DATABASE-ADVISOR-CHECKS.md
+++ b/docs/DATABASE-ADVISOR-CHECKS.md
@@ -8,6 +8,10 @@ These are structural observations and review prompts, not workload forecasts, bu
 automatic migration instructions. A finding describes the available evidence, not everything the database
 could contain. See [the advisor page](features/advisors.md#database) for availability.
 
+`assessmentEvidence` retains successful applicable evaluations despite unrelated missing metadata. For example, a
+readable H2 schema may produce a numeric **Partial assessment** while index semantics remain limited. Wrong-dialect
+N/A checks are not missing coverage; see the [shared scoring policy](features/advisors.md#score-eligibility).
+
 ## Availability and bounds
 
 Spring MVC, Spring WebFlux and Quarkus use the same engine and report contract. Native adapters discover and

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -7,6 +7,9 @@ available; it does not intercept runtime queries, invoke repositories, execute S
 The checks are heuristic review prompts. They highlight common Hibernate/JPA performance and maintainability risks, but
 the right remediation still depends on the application's query patterns and data model.
 
+`assessmentEvidence` records actual completed applicable persistence-unit checks or retained findings; the registry
+size is not proof of a usable assessment. Partial scores follow the [shared policy](features/advisors.md#score-eligibility).
+
 ## Availability and bounds
 
 The panel is available only when Hibernate ORM and an `EntityManagerFactory` bean are present. If either is missing, or if

--- a/docs/MEMORY-CHECKS.md
+++ b/docs/MEMORY-CHECKS.md
@@ -4,6 +4,12 @@ The Memory advisor evaluates **36 stable rules** against explicit, on-demand JVM
 Spring WebFlux, and Quarkus use the same framework-neutral collector, rules, report, and dismissal IDs. MCP and
 the CLI expose that same report. Reading the cached report does not scan, collect a histogram, or start a recording.
 
+`assessmentEvidence` records actual usable rule outcomes and missing required evidence, not just attempted rules.
+The [shared scoring policy](features/advisors.md#score-eligibility) preserves usable partial scores and their limitations.
+Unavailable metrics, missing histograms, and missing comparison baselines qualify an otherwise usable assessment as
+partial even when the unchanged scan status is `SCANNED`. Genuine N/A conditions, such as container-only checks on a
+host with no detected container limit or collector-specific checks on another collector, do not alone make it partial.
+
 Findings are review prompts, not proof of a leak, a sizing prescription, or a production-readiness assessment.
 All numerical thresholds below are **BootUI heuristics**, not Oracle-endorsed universal warning thresholds.
 Interpret them against representative steady-state and burst workloads.

--- a/docs/PENTEST-CHECKS.md
+++ b/docs/PENTEST-CHECKS.md
@@ -4,6 +4,10 @@ The Pentesting panel runs a fixed, local-only set of
 [OWASP Top 10:2025](https://owasp.org/Top10/2025/)-aligned hygiene checks against the host application. This page lists
 every check that ships with BootUI today, what it inspects, when it fires, and what to do about it.
 
+`assessmentEvidence` derives usability from assessed category evidence, not the active-check registry size.
+Diagnostic-only probe failures and wholly indeterminate/N/A coverage cannot establish a score. Usable partial
+assessments follow the [shared policy](features/advisors.md#score-eligibility), retaining every coverage limitation.
+
 Each check is a small class registered in
 [`PentestingCheckRegistry`](https://github.com/jdubois/boot-ui/blob/main/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/pentesting/PentestingCheckRegistry.java)
 and implemented in

--- a/docs/QUARKUS-ADVISOR-CHECKS.md
+++ b/docs/QUARKUS-ADVISOR-CHECKS.md
@@ -2,7 +2,7 @@
 
 The Quarkus application advisor is the Quarkus flavor of the shared **Spring** panel:
 the panel ID remains `spring`, the endpoint remains `/bootui/api/spring`, and the shared
-`SpringReport` JSON and dismissal contract are unchanged. It is separate from the
+`SpringReport` JSON and dismissal contract remain shared with Spring. It is separate from the
 [Quarkus Security advisor](QUARKUS-CHECKS.md).
 
 The advisor has **13 active rules**. It inspects application-owned build metadata and
@@ -12,6 +12,9 @@ traffic, or changes configuration. Findings are review prompts, not proof of a r
 measured performance failure, or the configuration of an unseen deployment.
 
 ## Evidence and availability
+
+Reports add `assessmentEvidence` for usable checked outcomes and incomplete coverage, without changing rule or scan
+statuses. Usable partial scores follow the [shared policy](features/advisors.md#score-eligibility).
 
 CDI evidence comes from Arc's resolved application class beans, including effective scope
 and injection points, rather than counts of directly declared scope annotations.

--- a/docs/QUARKUS-CHECKS.md
+++ b/docs/QUARKUS-CHECKS.md
@@ -12,6 +12,9 @@ exposes credentials or secrets, or modifies the
 configuration. Findings are heuristic review prompts; the right remediation depends on the application's
 threat model and deployment topology.
 
+`assessmentEvidence` records known evaluated conditions or confirmed findings, not the 42-rule registry size.
+Wholly unknown evidence stays unscored; usable partial scores follow the [shared policy](features/advisors.md#score-eligibility).
+
 OIDC checks aggregate the active default tenant and active named tenants; a tenant with
 `quarkus.oidc[.<tenant>].tenant-enabled=false` is excluded.
 

--- a/docs/REST-API-CHECKS.md
+++ b/docs/REST-API-CHECKS.md
@@ -83,6 +83,9 @@ base-package discovery failure.
 Incomplete extraction suppresses absence-based ERR-001 and ERR-009 conclusions while preserving reliable positive
 findings. An unresolved mapper type that the bounded model intentionally cannot resolve also makes ERR-009 `SKIPPED`,
 but that uncertainty alone is not an extraction failure and does not automatically make the scan `PARTIAL`.
+It does mark `assessmentEvidence.incomplete`: usable findings and completed checks can still score, with a partial
+qualification. The same distinction applies when mixed-framework declarations cannot establish native handler presence.
+Retired or wrong-framework checks remain N/A and do not alone make the assessment partial.
 
 Intentional inapplicability is different: retired emissions, unsupported framework facts, and genuinely unknown dynamic
 responses return `SKIPPED` where necessary and do **not** automatically make the scan partial. `SCANNED` means analysis
@@ -117,8 +120,9 @@ Spring or MicroProfile OpenAPI on Quarkus. Both annotation families are recogniz
 mandatory. Missing annotations are not proof that generated or static documentation is absent.
 
 The shared advisor score weights concrete findings, not just violated rule IDs; dismissing a rule removes its
-findings from that calculation. Only a complete `SCANNED` report is score-eligible. This audit does not change the
-score formula or UI.
+findings from that calculation. Under the shared [score eligibility](features/advisors.md#score-eligibility) policy,
+usable `SCANNED` and `PARTIAL` evidence scores with unchanged weights. Missing required evidence qualifies the number
+as **Partial assessment** rather than erasing evaluated results. The evidence audit itself did not change the formula.
 
 ## Routing & HTTP method mapping
 

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -9,6 +9,9 @@ traffic, or modify security configuration. Credentials, keys and session identif
 The checks are heuristic review prompts. They highlight common Spring Security hardening gaps, but the right remediation
 still depends on the application's threat model and deployment topology.
 
+Both servlet and reactive reports carry `assessmentEvidence` captured from actual rule outcomes before filtering.
+Usable partial evidence remains scoreable with visible limits under the [shared policy](features/advisors.md#score-eligibility).
+
 Actuator exposure checks ignore BootUI's own low-priority local actuator defaults. Those defaults are merged into
 Spring Boot's shared `defaultProperties` source (only for keys the host has not set) so local panels can read Actuator
 data, and host `management.*` settings always win. If the host application explicitly configures actuator exposure

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -731,9 +731,8 @@ Acceptance criteria:
 Purpose: answer "Which Maven dependencies can the local provider identify, and do any have known vulnerabilities?"
 
 The [Vulnerabilities checks catalogue](VULNERABILITIES-CHECKS.md) defines the supported evidence interpretation,
-official sources/version caveats, full audit disposition, and deferred limitations. Advisor scoring, Overview/gauges,
-score eligibility, and dismissal refresh are handed off to the independent central scoring workstream; they are not
-implemented by this interpretation/reporting change.
+official sources/version caveats, full audit disposition, and deferred limitations. The shared
+[score eligibility policy](features/advisors.md#score-eligibility) applies to the dedicated panel and Overview.
 
 Data sources:
 
@@ -752,14 +751,28 @@ Features:
 - Provide an explicit "Scan with OSV.dev" action that sends Maven package names and versions to OSV.dev.
 - Show scan status, vulnerable dependency count, advisory count, severity breakdown, advisory links, aliases, and fixed
   versions when available.
-- Calculate the same numeric score in the panel and Overview only for `SCANNED` reports with a valid severity
-  summary, `coverage.status=COMPLETE`, and no active UNKNOWN severity. NONE (CVSS zero) has no penalty; dismissed
-  UNKNOWN findings do not block scoring, but restoring them does. Missing coverage is unknown, not complete.
-  As with every scored advisor, PARTIAL displays Incomplete without a number, and ERROR/DISABLED/NOT_SCANNED never
-  score. Retain findings and diagnostic reports independently of eligibility. Overall averages and counts only
-  eligible scores, without changing the available-scanner total; report refresh after dismissal is GET-only.
-  Preserve the last accepted report on busy or transport failure, but replace its score when a new authoritative
-  incomplete or failed report arrives. Intentional rule inapplicability is not missing required evidence.
+- Calculate the same numeric score in the panel and Overview for `SCANNED` or `PARTIAL` reports with usable assessed
+  evidence and valid, nonnegative integer severity counts. Preserve the penalties (CRITICAL 25, HIGH 10, MEDIUM 3,
+  LOW 1, INFO/NONE 0), clamp to 0–100, and use the rounded arithmetic mean of numeric contributors in Overview.
+  This is an intentional change from complete-only eligibility. A partial score must display **Partial assessment**,
+  qualify its band and accessible gauge name, and explain that missing checks are not passes. No findings after
+  some completed checks may score 100, but only for evaluated evidence, never as complete health.
+- Shared rule reports add immutable `assessmentEvidence: {usable, incomplete}` facts captured before PASS/SKIPPED
+  results are filtered. Registry/attempt counters alone do not establish completed checks. Vulnerability dependency
+  rows add `assessmentComplete`, true only after query pagination, required advisory details and package association
+  interpretation finish. Query counts alone cannot prove successful assessment.
+- Active UNKNOWN findings remain visible and explicitly excluded from penalties, not treated as safe. Known findings
+  or an independently completed package with no active UNKNOWN establish usable evidence. Wholly UNKNOWN evidence
+  without such an assessment has no score. Missing/incomplete inventory, incomplete package assessments, skipped
+  packages and active UNKNOWN qualify a usable score as partial. Dismissed findings no longer contribute penalties,
+  but dismissal never clears missing coverage. Intentional wrong-dialect/N/A checks do not imply incomplete coverage.
+- ERROR/DISABLED/NOT_SCANNED, all-skipped/all-failed or otherwise unusable assessments, and invalid/negative/nonfinite/
+  fractional/unsafe counts never score. Retain findings and diagnostics independently of eligibility. Include partial
+  numeric contributions in Overview and explicitly mark the aggregate partial whenever one contributes, without
+  changing the available-scanner total. Informational/readiness panels remain unscored.
+- Report refresh after dismissal is GET-only. Preserve the last accepted report and its qualification on busy or
+  transport failure; a new authoritative report replaces both. Do not alter backend statuses, trigger scans on load,
+  infer coverage percentages from incompatible counters, or discard findings to obtain a score.
 - Interpret affected entries in the JSON-free shared engine with exact `Maven` ecosystem and package matching, allowing
   only the literal `*` package wildcard, not arbitrary globs or other Maven repository ecosystems. Explicit versions
   and supported Maven `ECOSYSTEM` ranges form a union across matching entries. Applicability is matched, not matched,

--- a/docs/SPRING-CHECKS.md
+++ b/docs/SPRING-CHECKS.md
@@ -10,6 +10,10 @@ The same ruleset runs on Spring MVC and WebFlux. Servlet OSIV guidance is inappl
 
 ## Availability and bounds
 
+`assessmentEvidence` distinguishes completed checks from unavailable required observations and intentional N/A.
+Public rule/scan statuses stay unchanged; the [shared scoring policy](features/advisors.md#score-eligibility) qualifies
+usable incomplete assessments instead of discarding their score.
+
 The panel is always available when the Spring advisor is enabled. Scanning is explicit and on demand; GET returns the cached report. Collection uses bounded, non-eager bean metadata and does not create lazy beans, invoke application customizers, open database connections, or probe remote services. Missing required evidence is unevaluated, not a successful check; inspection failures and invalid bindings are reported without raw exception messages or property values. The Rule results panel lists findings, ordered by severity, finding count, and rule ID.
 
 ## Severity scale

--- a/docs/VULNERABILITIES-CHECKS.md
+++ b/docs/VULNERABILITIES-CHECKS.md
@@ -6,9 +6,10 @@ interpretation; Spring and Quarkus retain their native HTTP/JSON adapters.
 
 This catalogue records the evidence rules and complete audit disposition for
 [#978](https://github.com/jdubois/boot-ui/issues/978). Research did not submit a dependency inventory or run an external
-scan. The change concerns OSV interpretation and reporting, not inventory repairs or a new scanner. **Advisor scores,
-Overview, gauges, score eligibility, and dismissal refresh are handed off to the independent central scoring workstream;
-they are not implemented by this change.** Security and Pentesting remain separate advisors.
+scan. That change concerned OSV interpretation and reporting, not inventory repairs or a new scanner. Its scoring
+handoff is addressed by the subsequent user-approved [shared scoring policy](features/advisors.md#score-eligibility)
+([#989](https://github.com/jdubois/boot-ui/issues/989)): usable partial evidence scores with explicit qualification.
+Security and Pentesting remain separate advisors.
 
 ## Reading the result
 
@@ -26,7 +27,13 @@ Keep three kinds of evidence separate:
 finding was retained in that partial result. Even a completed lookup does not prove the application safe, reachable code
 free of vulnerabilities, or the upstream database exhaustive.
 
-The immutable DTO fields, routes, MCP tools, CLI commands, configuration defaults, and
+Dependency DTOs additionally expose `assessmentComplete`: query pagination completed, every required detail was
+resolved (including valid withdrawals), and no package association remained unresolved. Unqueried/bounded-away
+packages or failed details cannot masquerade as a clean assessment. This fact does not assert known severity or
+complete inventory. Known findings still count when another detail fails; UNKNOWN findings stay visible and are
+explicitly unscored. A wholly UNKNOWN result without independently usable evidence remains unscored.
+
+Routes, MCP tools, CLI commands, configuration defaults, and
 `advisoryId::packageName` dismissal identities do not change. Findings count **advisory occurrences per dependency**,
 not unique CVEs: different advisory IDs can describe the same CVE.
 
@@ -314,7 +321,8 @@ These are acceptance cases for the implementation, **not a claim that validation
 - Equivalent neutral results through Jackson 3 and Jackson 2, unchanged cached/dismiss/restore identities and policy,
   no GET-triggered external calls, and retained partial browser rows with accurate local EPSS wording.
 
-Scoring/Overview regression obligations remain with the central scoring change. Inventory repair acceptance cases,
+Scoring/Overview regression obligations are covered by the central partial-assessment change; the HANDOFF rows above
+record the original audit boundary, not current score eligibility. Inventory repair acceptance cases,
 CVSS v4, total scan deadline, date/model provenance, reachability, automated upgrades, and presentation version sorting
 are deferred, not silently included in this evidence-interpreter change.
 

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -2,23 +2,41 @@
 
 BootUI's advisors run explicit, on-demand, rule-based scans and surface severity-ranked findings that feed the weighted
 score on the Overview dashboard. Each advisor is read-only and inspects a different facet of the application — compiled
-architecture, the REST layer, the live Spring context, persistence, JVM memory, and security. A complete advisor
+architecture, the REST layer, the live Spring context, persistence, JVM memory, and security. A usable advisor
 assessment shows the same 0–100 score in its panel and Overview (100 minus the weighted finding penalty).
 
 ### Score eligibility
 
-A diagnostic report is not necessarily eligible for a score. Only `SCANNED` reports with a valid severity summary
-score. `PARTIAL` reports show **Incomplete**, without a numeric score; failed, disabled, and unscanned reports also
-remain unscored. Findings, severity counts, and diagnostics remain available even when the assessment is incomplete.
-Intentionally skipped, inapplicable rules do not by themselves make a scan incomplete.
+A diagnostic report is not necessarily eligible for a score. `SCANNED` and `PARTIAL` reports score when they contain
+usable evaluated evidence and a valid severity summary. A numeric **Partial assessment** score covers only what was
+checked: missing checks are not passes, and a good score does not mean complete health. The scan's **Incomplete**
+status and missing-evidence explanation stay visible. `ERROR`, `DISABLED`, `NOT_SCANNED`, all-skipped/all-failed
+evaluations, and reports with no usable evidence remain unscored. Invalid, negative, fractional, nonfinite or unsafe
+counts never become a perfect score. Findings and diagnostics remain available independently of scoring.
 
-Vulnerabilities also requires `coverage.status=COMPLETE` and no active `UNKNOWN` severity findings. Missing or
-unavailable coverage is unknown, not complete. `NONE` (CVSS zero) is scoreable with no penalty. Dismissing an UNKNOWN
-finding can restore eligibility; restoring it removes the score again. Coverage is only as reliable as the
-inventory provider's report: this presentation policy cannot detect an inventory that incorrectly claims completeness.
+Architecture, Memory, REST API, Spring/Quarkus application, Database, Hibernate, Security and Pentesting expose
+`assessmentEvidence: {usable, incomplete}`. The engine records these facts before filtering passing/skipped results:
+at least one successful applicable evaluation or confirmed finding establishes usable evidence. Registry sizes and
+attempt counters are not proof of a completed check. Intentional wrong-dialect/N/A rules do not by themselves make
+coverage incomplete, and incompatible counters are never converted into a coverage percentage.
 
-During a new request, or if transport fails, the last accepted report remains visible. A newly received incomplete,
-failed, or disabled report replaces the previous assessment and immediately removes its score from Overview.
+Vulnerabilities uses known-severity findings or a dependency whose `assessmentComplete` is true and has no active
+UNKNOWN finding. This field requires completed query pagination, resolved advisory details, and interpreted package
+associations; completed query counts alone are insufficient. `NONE` (CVSS zero) has no penalty. Active `UNKNOWN`
+findings remain visible and explicitly unscored, never considered safe. Known HIGH plus UNKNOWN therefore scores 90
+with **Partial assessment**; wholly UNKNOWN evidence without another usable assessed package has no score.
+Missing/incomplete inventory, skipped packages or incomplete package assessments qualify any usable score as partial.
+Dismissal changes active penalties and can restore eligibility for an otherwise fully assessed UNKNOWN-only package;
+it never removes inventory or query-coverage gaps. Provider overclaims of inventory completeness remain outside this
+presentation policy.
+
+The existing penalties remain CRITICAL 25, HIGH 10, MEDIUM 3, LOW 1, INFO/NONE 0, clamped to 0–100. Overview keeps the
+rounded arithmetic mean of numeric contributors, including usable partial scores, and marks the aggregate partial
+whenever one contributes. Informational and readiness panels do not gain scores.
+
+During a new request, or if transport fails, the last accepted report and its qualification remain visible. A newly
+received authoritative report replaces the previous assessment: usable partial evidence updates its score and
+qualification; failed, disabled, invalid or unusable evidence removes its contribution.
 
 ### Single-flight scans
 
@@ -507,8 +525,9 @@ include raw response bodies, cookie values, credentials, or full issuer URLs. Fi
 proof of exploitability or a replacement for a full security assessment.
 
 The 79 active checks each carry a stable identifier, OWASP 2025 category, evidence source, and recommendation. No-finding
-category coverage is informational rather than a pass. Failed or bounded-away evidence produces a `PARTIAL` scan, hides
-the advisor score, and marks affected no-finding coverage `INDETERMINATE`; known findings remain `REVIEW` with limits.
+category coverage is informational rather than a pass. Failed or bounded-away evidence produces a `PARTIAL` scan and
+marks affected no-finding coverage `INDETERMINATE`; known findings remain `REVIEW` with limits. Usable evaluated
+evidence still scores with **Partial assessment** and its missing-coverage explanation.
 See [PENTEST-CHECKS.md](../PENTEST-CHECKS.md) for the
 full catalogue, limits, mappings, and retired IDs.
 
@@ -536,8 +555,8 @@ advisories alphabetized within the same severity.
 
 The [Vulnerabilities checks catalogue](../VULNERABILITIES-CHECKS.md) documents the interpretation rules, official
 sources/version caveats, full audit disposition, and deferred inventory limitations. A completed lookup is not proof
-of application safety or complete runtime discovery. Advisor scoring, Overview/gauges, and dismissal refresh belong
-to the independent central scoring workstream, not the evidence-interpretation change described here.
+of application safety or complete runtime discovery. The shared [score eligibility](#score-eligibility) policy applies
+to both the dedicated panel and Overview, including dismissal refresh and partial coverage.
 
 ### Severity scoring
 

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -20,20 +20,25 @@ Each scanner card shows its status and retained severity counts, with a 0–100 
 The severity-based scanners are Architecture,
 Memory, REST API, Spring, Database, Hibernate, Security, Pentesting, and Vulnerabilities. Each starts at 100 and
 subtracts a fixed weighted penalty per finding — critical 25, high 10, medium 3, low 1 — so a complete clean scan stays
-at 100. `PARTIAL` shows **Incomplete**, never a number; `ERROR`, `DISABLED`, and `NOT_SCANNED` do not score.
-Vulnerabilities additionally requires complete dependency inventory coverage and no active UNKNOWN severity;
-NONE has no penalty. Missing coverage is unknown. See [Score eligibility](advisors.md#score-eligibility).
+at 100. Usable `PARTIAL` evidence also scores, with **Partial assessment** next to the number and a missing-coverage
+explanation. A good partial score means few problems in evaluated evidence, not complete health.
+`ERROR`, `DISABLED`, `NOT_SCANNED`, invalid counts and reports without usable evidence do not score.
+Vulnerabilities scores known evidence while leaving active UNKNOWN findings visible and explicitly unscored;
+UNKNOWN, incomplete inventory or incomplete package assessments qualify the score as partial. NONE has no penalty.
+See [Score eligibility](advisors.md#score-eligibility).
 
 GitHub is not a severity scanner. It connects to the local repository and contributes a score derived from open security
 alerts, but only when the credential is connected and authenticated.
 
 The overall score, scored count, and contribution breakdown include only scanners that actually scored. The available
 scanner total does not shrink when a report is incomplete: "2 of 4 scanners scored" means the mean covers two
-assessments, not that all four passed. Disabled and unavailable panels are excluded; automatic reads wait for the
+assessments, not that all four passed. The rounded arithmetic mean is **Partial assessment** whenever a partial score
+contributes; the breakdown identifies those contributors and the card states their count. Disabled and unavailable panels are excluded; automatic reads wait for the
 panel manifest and only use supported, enabled advisor endpoints.
 Returning from a panel refreshes cached reports with GET requests, including Vulnerabilities after
 dismissal or restoration. A busy or failed request retains the last accepted report with a warning or error; an
-authoritative new incomplete/failed report replaces its old score. A `NOT_SCANNED` response, such as after an application
+authoritative new report replaces its old score and qualification, withholding the number only if unusable, invalid,
+failed or disabled. A `NOT_SCANNED` response, such as after an application
 restart, replaces the old findings and returns the card to **Run scan**. An Overview scan already in progress finishes
 before the return-navigation refresh reads its updated report.
 


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Implements the **user-approved change from complete-only scoring to evidence-based scoring** across the nine existing scored advisors and Overview, retaining numeric scores from usable observations while visibly qualifying incomplete coverage.

This is the scoring-only dependent layer for #988, targeting **`jdubois-synchronize-overview-reports`**, not `main`. The original `09419df` ancestor is preserved. The dependency branch subsequently incorporated #987; those App/main/route-asset changes are inherited unchanged and are not part of this PR's diff. No merge or auto-merge is requested.

Head: `39f13646824450922ea41cb0fb572678d44cedb5`. Base: `f6b650f2ebec35303072f5c7e3728604533ac5ba`. Scoring delta: 105 files, +2,098 / −455, two commits including dependency synchronization.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

A useful partial assessment was previously denied a score even when checks completed and confirmed findings survived. For example, limited H2 index semantics or unresolved mappings should not invalidate the Database advisor's actual observations. This is a deliberate policy change, **not concealment of scanner failures**: missing checks never become passes, findings remain visible, and backend statuses are not rewritten.

Closes #989

The shared policy retains the existing 25/10/3/1/0 severity penalties, 0–100 clamp and arithmetic mean. Partial contributors qualify Overview's aggregate; a high score means few weighted problems in evaluated evidence, not complete health. Disabled, wholly failed, invalid, all-skipped and otherwise unusable assessments remain unscored. Vulnerability UNKNOWN findings remain visible and explicitly unscored; independently usable evidence is required before any number is shown.

The approved additive evidence contract is necessary because attempted-rule and registry-size counters do not prove completed assessments:

- Eight rule-advisor reports expose `assessmentEvidence: {usable, incomplete}`; shared scanners record actual outcomes before filtering, with unavailable evidence distinguished from genuine N/A.
- Vulnerability dependencies expose `assessmentComplete`, separating completed queries from successfully resolved advisory details and package associations. Both OSV adapters, dismissal copies and EPSS enrichment preserve it.
- Existing DTO constructors remain available; Jackson 2/3 byte-parity and MVC/WebFlux/Quarkus API, MCP and CLI conformance cover the additive fields. No server scores, commands, scans-on-load or new external work are introduced.

The slice covers Architecture, Memory, REST API, Spring/Quarkus application, Database, Hibernate, Security, Pentesting and Vulnerabilities. Informational and readiness panels remain unscored. Existing cached-report hydration, request-token protection, dismissal/restore and safety policy are preserved.

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Java 17 `./mvnw -B -ntp -Pcoverage clean install` passed all 35 reactor modules. Targeted evidence/scanner/OSV/serialization regressions passed. Final UI coverage was rerun after dependency synchronization and the mobile gauge correction: **1,174 tests passed**.

| Browser suite | Result |
| --- | --- |
| Spring MVC | 208 passed; 6 existing Docker-profile gates |
| Spring WebFlux | 40 passed |
| Custom MVC/WebFlux mounts | 67 passed; 1 existing MVC-only gate |
| Quarkus | 144 passed; 1 existing opt-in live-OSV gate |

All **95 shared scoring scenarios** passed across the five runtime/mount variants. These cover cached and panel-originated results, complete/partial/error/disabled/no-usable cases, exact aggregates, invalid counters, UNKNOWN and inventory gaps, dismissal/restore, light/dark/mobile qualification, circular gauge geometry and no-auto-scan boundaries. No skips, retries, timeouts or thresholds were added to hide failures. Runtime suites ran serially with an isolated Maven repository and a local OSV fixture; all owned servers have stopped and the exclusive runtime slot is released.

Spotless, all three Prettier checks, and the bounded design review passed. Matched before/after captures also asserted accessible partial labels, mobile overflow and no mutations. The inherited gauge font sizes were left unchanged; this is not a redesign.

Current-head CI was explicitly dispatched because the normal workflow only triggers for `main` PR bases: https://github.com/jdubois/boot-ui/actions/runs/34193963988

**External local limitation:** the VuePress dependency restore still receives the pre-existing feed 404 for `fast-uri@3.1.7`. No dependency manifest, registry or workflow was changed to bypass it.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

The same bounded cached evidence in both versions: one confirmed HIGH architecture finding with incomplete metadata, plus a completed clean Memory assessment. Previously Architecture was excluded and Overview showed 100; now Architecture scores 90 and the mean is 95, explicitly partial. Desktop captures are 1600×900 WebP at quality 80, with both scroll containers reset.

| Surface | Before | After |
| --- | --- | --- |
| Overview | ![Overview before: partial finding excluded from a 100 aggregate](https://github.com/user-attachments/assets/8302d2d6-6df5-4352-9130-1680dcbda21a) | ![Overview after: 95 aggregate qualified as a partial assessment](https://github.com/user-attachments/assets/dff0c51e-60ac-4d62-8b20-91d5ed9f6242) |
| Advisor | ![Advisor before: incomplete report without a numeric score](https://github.com/user-attachments/assets/09967651-b318-400d-b0ff-dac51a1f7b57) | ![Advisor after: 90 score beside the missing-coverage explanation and retained finding](https://github.com/user-attachments/assets/1ee9b832-e68c-4c66-a4fa-698877153c49) |

<details>
<summary>Dark theme at 390px</summary>

<img src="https://github.com/user-attachments/assets/709f7c21-af54-4ded-a49d-c4bfc8192411" width="260" alt="Mobile Overview with a circular gauge and visible partial qualification" />
<img src="https://github.com/user-attachments/assets/81c2edca-36ed-4095-ada5-5c7273eb6da5" width="260" alt="Mobile advisor retaining the numeric score and wrapping its coverage explanation" />

</details>

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed