### PR TITLE
ci: restore CodeQL scanning for GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'java-kotlin', 'javascript-typescript' ]
+        language: [ 'java-kotlin', 'javascript-typescript', 'actions' ]
     steps:
       - name: Check code scanning availability
         id: code-scanning


### PR DESCRIPTION
## Summary

Add `actions` to the CodeQL language matrix alongside Java/Kotlin and JavaScript/TypeScript. This restores workflow scanning previously provided by the retired automatic setup, whose last analyses were uploaded on May 27.

Existing Java-only setup and build conditions are unchanged. This PR does not remove any historical code-scanning configurations or change repository security settings.

## Validation

- `bash .github/scripts/check-action-references.sh .github/workflows/codeql.yml`
- `git diff --check`

After merging, let the CodeQL run on `main` complete before deleting the stale automatic configurations in GitHub's tool status page.