### PR TITLE
Support optional npm registry secrets in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .git
 .gitignore
 **/node_modules
+**/.npmrc
 **/dist
 **/.vite
 **/.eslintcache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,37 @@ integration-test module and let Maven build its dependencies:
 ./mvnw -B -ntp -pl bootui-quarkus-integration-tests -am install
 ```
 
+### Docker builds behind a corporate npm registry
+
+Standard Docker builds remain the default and need no npm configuration:
+
+```bash
+docker build -t bootui-sample-app .
+```
+
+Only if your network requires a corporate npm registry and you already have a
+working `~/.npmrc`, pass that file as an optional BuildKit secret:
+
+```bash
+docker build --secret id=npmrc,src="$HOME/.npmrc" -t bootui-sample-app .
+```
+
+The same optional secret works with `-f Dockerfile-aot`, `-f Dockerfile-crac`,
+`-f Dockerfile-native`, `-f Dockerfile-webflux`, and `-f Dockerfile-quarkus`.
+For example:
+
+```bash
+docker build --secret id=npmrc,src="$HOME/.npmrc" -f Dockerfile-native -t bootui-sample-app-native .
+```
+
+BuildKit mounts the file in the build user's home only for the Maven step:
+`/root/.npmrc` for the Spring images and `/home/bootui/.npmrc` for Quarkus.
+The secret file is not copied into image layers. `.dockerignore` intentionally
+excludes all `.npmrc` files, including project-level files, from the build context;
+use the secret rather than copying registry credentials into the project.
+Without `--secret`, npm keeps its default registry configuration. There is no
+new requirement for normal developers or CI, and no secret is needed at runtime.
+
 ### Software Bill of Materials (SBOM)
 
 Generate a CycloneDX SBOM covering every dependency across the whole reactor after an install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,11 @@
 #   docker run --rm -p 8080:8080 -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO bootui-sample-app
 #   # then open http://localhost:8080/bootui
 #
+# Optional corporate npm registry (requires an existing ~/.npmrc):
+#   docker build --secret id=npmrc,src="$HOME/.npmrc" -t bootui-sample-app .
+# The secret is mounted only during Maven and is not stored in image layers.
+# Without it, npm keeps its default registry configuration.
+#
 # Enable the sample database migrations (to populate the BootUI Flyway/Liquibase panels):
 # The sample app can apply two pending Flyway migrations and two Liquibase change sets on startup
 # so those panels have data to show. They are off by default for a faster boot; turn them back on
@@ -76,6 +81,7 @@ RUN chmod +x mvnw
 # image size. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc \
     ./mvnw -B -ntp -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,

--- a/Dockerfile-aot
+++ b/Dockerfile-aot
@@ -46,6 +46,11 @@
 #
 # Or use docker-compose-aot.yml (docker compose -f docker-compose-aot.yml up --build).
 #
+# Optional corporate npm registry (requires an existing ~/.npmrc):
+#   docker build --secret id=npmrc,src="$HOME/.npmrc" -f Dockerfile-aot -t bootui-sample-app-aot .
+# The secret is mounted only during Maven and is not stored in image layers.
+# Without it, npm keeps its default registry configuration.
+#
 # Enable the sample database migrations (to populate the BootUI Flyway/Liquibase panels):
 #   docker run --rm -p 8080:8080 \
 #     -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO \
@@ -87,6 +92,7 @@ RUN chmod +x mvnw
 # not in the image. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc \
     ./mvnw -B -ntp -Paot -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,

--- a/Dockerfile-crac
+++ b/Dockerfile-crac
@@ -38,6 +38,11 @@
 #
 # Or use docker-compose-crac.yml (docker compose -f docker-compose-crac.yml up --build).
 #
+# Optional corporate npm registry (requires an existing ~/.npmrc):
+#   docker build --secret id=npmrc,src="$HOME/.npmrc" -f Dockerfile-crac -t bootui-sample-app-crac .
+# The secret is mounted only during Maven and is not stored in image layers.
+# Without it, npm keeps its default registry configuration.
+#
 # Enable the sample database migrations (to populate the BootUI Flyway/Liquibase panels):
 # The sample app can apply two pending Flyway migrations and two Liquibase change sets on startup
 # so those panels have data to show. They are off by default for a faster boot; turn them back on
@@ -76,6 +81,7 @@ RUN chmod +x mvnw
 # not in the image. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc \
     ./mvnw -B -ntp -Pcrac -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Runtime stage with a CRaC-enabled JDK (BellSoft Liberica with CRaC support).

--- a/Dockerfile-native
+++ b/Dockerfile-native
@@ -25,6 +25,11 @@
 #   docker build -f Dockerfile-native -t bootui-sample-app-native .
 #   docker run --rm -p 8080:8080 -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO bootui-sample-app-native
 #   # then open http://localhost:8080/bootui
+#
+# Optional corporate npm registry (requires an existing ~/.npmrc):
+#   docker build --secret id=npmrc,src="$HOME/.npmrc" -f Dockerfile-native -t bootui-sample-app-native .
+# The secret is mounted only during Maven and is not stored in image layers.
+# Without it, npm keeps its default registry configuration.
 
 # Build stage with GraalVM 25 (includes the native-image toolchain, JDK 25)
 FROM ghcr.io/graalvm/graalvm-community:25 AS build
@@ -63,6 +68,7 @@ ENV NATIVE_IMAGE_OPTIONS="-H:+StaticExecutableWithDynamicLibC"
 # root, so the Maven/npm home is /root.
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc \
     ./mvnw -B -ntp -Pnative -DskipTests -pl bootui-spring-sample-app -am clean package
 
 # Move the native executable to a known path (the native-maven-plugin names it

--- a/Dockerfile-quarkus
+++ b/Dockerfile-quarkus
@@ -51,6 +51,11 @@
 #   docker run --rm -p 8082:8082 -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO bootui-sample-app-quarkus
 #   # then open http://localhost:8082/bootui
 #
+# Optional corporate npm registry (requires an existing ~/.npmrc):
+#   docker build --secret id=npmrc,src="$HOME/.npmrc" -f Dockerfile-quarkus -t bootui-sample-app-quarkus .
+# The secret is mounted only during Maven and is not stored in image layers.
+# Without it, npm keeps its default registry configuration.
+#
 # Populate the Flyway/Liquibase panels with the sample migrations (off by default for a faster boot):
 #   docker run --rm -p 8082:8082 \
 #     -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO \
@@ -95,7 +100,8 @@ ENV HOME=/home/bootui
 # time, not as a Maven dependency. Without it, the runtime extension-descriptor check fails and the
 # sample's augmentation can't resolve the deployment artifact. `install` publishes it to the (cached)
 # local repository so augmentation finds it.
-RUN ./mvnw -B -ntp -DskipTests -pl bootui-quarkus-deployment,bootui-quarkus-sample-app -am clean install
+RUN --mount=type=secret,id=npmrc,target=/home/bootui/.npmrc,uid=1001,gid=1001 \
+    ./mvnw -B -ntp -DskipTests -pl bootui-quarkus-deployment,bootui-quarkus-sample-app -am clean install
 
 # Bind all interfaces so the published port is reachable from the host. 8082 matches the Quarkus
 # sample app's own local dev default (quarkus.http.port=8082 in application.properties), so this image

--- a/Dockerfile-webflux
+++ b/Dockerfile-webflux
@@ -52,6 +52,11 @@
 #   docker run --rm -p 8081:8081 -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO bootui-sample-app-webflux
 #   # then open http://localhost:8081/bootui
 #
+# Optional corporate npm registry (requires an existing ~/.npmrc):
+#   docker build --secret id=npmrc,src="$HOME/.npmrc" -f Dockerfile-webflux -t bootui-sample-app-webflux .
+# The secret is mounted only during Maven and is not stored in image layers.
+# Without it, npm keeps its default registry configuration.
+#
 # Enable the sample database migrations (to populate the BootUI Flyway/Liquibase panels):
 #   docker run --rm -p 8081:8081 \
 #     -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO \
@@ -87,6 +92,7 @@ RUN chmod +x mvnw
 # image size. (Requires BuildKit, the default in modern Docker.)
 RUN --mount=type=cache,target=/root/.m2 \
     --mount=type=cache,target=/root/.npm \
+    --mount=type=secret,id=npmrc,target=/root/.npmrc \
     ./mvnw -B -ntp -DskipTests -pl bootui-spring-webflux-sample-app -am clean package
 
 # Explode the repackaged Spring Boot jar into its layers (dependencies,


### PR DESCRIPTION
## What does this PR do?

Adds an optional BuildKit `npmrc` secret to the Maven step in all six sample Dockerfiles (JVM, AOT, CRaC, native, WebFlux, and Quarkus). Spring builds mount `/root/.npmrc`; Quarkus mounts `/home/bootui/.npmrc` with UID/GID 1001. Excludes `.npmrc` at every depth from the Docker context and documents standard versus optional corporate-registry builds in `CONTRIBUTING.md` and each Dockerfile.

## Why is this change needed?

Developers behind an npm proxy can use their existing user configuration without copying registry credentials into image layers. The secret is not required: standard developers and CI keep the existing build commands and default npm configuration. No dependency versions, runtime behavior, or release machinery change.

Closes #1005

## How was it tested?

- [ ] `./mvnw clean install` passes locally — not rerun for this container-configuration-only change; full public npm downloads are blocked by the laptop's network policy.
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests — no runtime/API changes.
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082 — reused the successful GraalVM 25 native build/smoke evidence from #1001 using the same optional secret: health UP, panels API HTTP 200, and UI HTTP 200; native compilation was not repeated.
- [ ] Ran the affected Playwright suite(s) for browser-facing changes — no browser-facing changes.
- [x] Added or updated tests where applicable — ran isolated BuildKit probes with and without the existing user npmrc secret for both root and UID 1001; confirmed readability during the secret-mounted step and no file contents in the subsequent layer. Confirmed root and nested npmrc fixtures are excluded by the actual `.dockerignore`. These probes validate mount/default behavior without claiming public npm downloads succeeded.

Additional local checks passed:
- `docker build --check` for all six Dockerfiles, with no warnings.
- `./mvnw -B -ntp spotless:apply spotless:check` with an isolated Maven repository.
- Existing action-reference and release-integrity policy scripts.
- `git diff --check`.

## Screenshots (UI changes)

Not applicable; no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes — contributor build documentation updated in `CONTRIBUTING.md`; public behavior is unchanged.
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed