### PR TITLE
Fix Docker AOT crashes from CPU-specific cached adapters

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -39,7 +39,10 @@ name: Publish Docker images
 #      /actuator/health for status UP; the Quarkus image has no Actuator, so it polls
 #      the BootUI panel manifest GET /bootui/api/panels), BootUI's back end must be
 #      active (GET /bootui/api/panels) and the BootUI front end must be served
-#      (GET /bootui/). The CRaC image additionally stops the
+#      (GET /bootui/). The AOT image additionally verifies that CPU-specific method
+#      adapter caching is disabled and runs the local Overview advisor scans, since
+#      a healthy startup alone does not exercise the cached adapters that can crash.
+#      The CRaC image additionally stops the
 #      container and starts it again from the persisted checkpoint, verifying that the
 #      restore serves BootUI and comes up at least twice as fast as the initial
 #      boot-and-checkpoint start. Only once the smoke test passes does the job push that
@@ -415,6 +418,51 @@ jobs:
           echo "OK: BootUI front end is served (/bootui/ -> 200)."
 
           echo "Smoke test passed for ${IMAGE_REF}."
+
+      - name: Verify AOT portability settings and local advisor scans
+        if: matrix.image == 'bootui-sample-app-aot'
+        env:
+          PORT: ${{ matrix.port }}
+        run: |
+          set -euo pipefail
+
+          # A same-host smoke test cannot reproduce a CI-to-desktop CPU mismatch.
+          # Pin the JDK-8388703 workaround as well as exercising post-startup code.
+          flags=$(docker exec bootui-smoke /opt/java/bin/java \
+            -XX:+UnlockDiagnosticVMOptions -XX:+PrintFlagsFinal -version)
+          if ! grep -Eq 'bool AOTAdapterCaching[[:space:]]+=[[:space:]]+false' <<< "$flags"; then
+            echo "ERROR: CPU-specific AOT method adapter caching must be disabled." >&2
+            exit 1
+          fi
+
+          base_url="http://127.0.0.1:${PORT}"
+          cookie_jar=$(mktemp)
+          trap 'rm -f "$cookie_jar"' EXIT
+          curl -fsS --max-time 15 --cookie-jar "$cookie_jar" \
+            -o /dev/null "${base_url}/bootui/api/panels"
+          csrf_token=$(awk '$6 == "XSRF-TOKEN" {print $7}' "$cookie_jar")
+          if [ -z "$csrf_token" ]; then
+            echo "ERROR: sample app did not issue a CSRF token." >&2
+            exit 1
+          fi
+
+          # Use the browser's normal CSRF flow; do not weaken the sample's guards.
+          # OSV/EPSS vulnerability lookups are excluded to keep this smoke test local.
+          for advisor in architecture memory rest-api spring database-advisor hibernate security pentesting; do
+            echo "Scanning ${advisor}..."
+            report=$(curl -fsS --max-time 120 --request POST \
+              --cookie "$cookie_jar" \
+              --header "X-XSRF-TOKEN: ${csrf_token}" \
+              --header "Origin: ${base_url}" \
+              "${base_url}/bootui/api/${advisor}/scan")
+            if ! jq -e '.scan.status == "SCANNED" or .scan.status == "PARTIAL"' <<< "$report" >/dev/null; then
+              echo "ERROR: ${advisor} did not return a completed scan." >&2
+              echo "$report" >&2
+              exit 1
+            fi
+          done
+          curl -fsS --max-time 15 "${base_url}/actuator/health" | jq -e '.status == "UP"' >/dev/null
+          echo "OK: AOT local advisor scans completed and the app remains healthy."
 
       - name: Verify the CRaC image restarts at least 2x faster from its checkpoint
         # CRaC only: the first start above booted the app, wrote the checkpoint, then

--- a/Dockerfile-aot
+++ b/Dockerfile-aot
@@ -19,7 +19,8 @@
 #      verified, pre-linked class data directly from the cache, bypassing most of
 #      the normal class-loading pipeline. The training run is done inside this
 #      build stage using the same jlink custom runtime that the final container
-#      uses, so the cache is guaranteed to be compatible.
+#      uses. CPU-specific method adapter caching is disabled (see below) so a
+#      cache built on CI does not require the CI host's CPU instruction set.
 #      Result: 20–30 % reduction in class-loading / linking time on top of
 #      the Spring AOT saving.
 #
@@ -156,6 +157,13 @@ RUN mkdir -p /app/training && \
 # GC / heap) setting differs from the running JVM and silently falls back to
 # normal class loading, defeating the cache. The environment variables likewise
 # mirror the runtime ENV declarations so training and production are identical.
+#
+# JDK-8388703: JDK 25 through 25.0.4 can replay cached method adapters containing
+# instructions unsupported by the runtime CPU, causing SIGILL in ~AdapterBlob
+# even after startup succeeds. Disable only adapter caching during both training
+# and runtime; Spring AOT and the JDK class loading/linking cache stay enabled.
+# This matches the upstream fix scheduled for 25.0.5:
+# https://bugs.openjdk.org/browse/JDK-8388703
 # ---------------------------------------------------------------------------
 RUN cd /app/training && \
     SPRING_PROFILES_ACTIVE=dev \
@@ -163,6 +171,7 @@ RUN cd /app/training && \
     SPRING_LIQUIBASE_ENABLED=false \
     /javaruntime/bin/java \
         -XX:AOTCacheOutput=/app/app.aot \
+        -XX:+UnlockDiagnosticVMOptions -XX:-AOTAdapterCaching \
         -Xms200m -Xmx200m -XX:MaxMetaspaceSize=171m \
         -XX:+UseG1GC -XX:+UseCompactObjectHeaders \
         -Dspring.aot.enabled=true \
@@ -211,11 +220,13 @@ ENV SPRING_LIQUIBASE_ENABLED=false
 # JVM flags — same baseline as Dockerfile, extended with:
 #   -XX:AOTCache=/app/app.aot       use the JDK 25 AOT class loading cache
 #   -Dspring.aot.enabled=true       activate Spring AOT-generated factories
+#   -XX:-AOTAdapterCaching         avoid CPU-specific cached method adapters
+#                                  (requires -XX:+UnlockDiagnosticVMOptions)
 #
 # The AOT cache makes the flags -XX:+AlwaysPreTouch and -XX:+UseCompactObjectHeaders
 # slightly less critical (class metadata is pre-linked), but they are kept for
 # consistency with the plain JVM image.
-ENV JAVA_TOOL_OPTIONS="-Xms200m -Xmx200m -XX:MaxMetaspaceSize=171m -XX:ReservedCodeCacheSize=240m -XX:MaxDirectMemorySize=10m -Xss512k -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompactObjectHeaders -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -XX:AOTCache=/app/app.aot -Dspring.aot.enabled=true"
+ENV JAVA_TOOL_OPTIONS="-Xms200m -Xmx200m -XX:MaxMetaspaceSize=171m -XX:ReservedCodeCacheSize=240m -XX:MaxDirectMemorySize=10m -Xss512k -XX:+AlwaysPreTouch -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompactObjectHeaders -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -XX:AOTCache=/app/app.aot -XX:+UnlockDiagnosticVMOptions -XX:-AOTAdapterCaching -Dspring.aot.enabled=true"
 
 EXPOSE 8080
 

--- a/docs/TRY-SAMPLE-APP.md
+++ b/docs/TRY-SAMPLE-APP.md
@@ -57,6 +57,25 @@ Typical result: **~40–45 % shorter startup** vs the plain JVM image (Spring-re
 ~70–100 MB larger image (the AOT cache file). The Spring profile can still be overridden at runtime with
 `-e SPRING_PROFILES_ACTIVE=...` — nothing is frozen at build time.
 
+#### Troubleshooting a JVM crash during a scan
+
+JDK 25 through 25.0.4 can crash with `SIGILL` in `~AdapterBlob` when an AOT cache built on one CPU is used on
+another CPU with different instruction support. The app can start normally and only crash when an advisor scan
+exercises the affected code. This is [OpenJDK JDK-8388703](https://bugs.openjdk.org/browse/JDK-8388703), whose
+fix is scheduled for JDK 25.0.5.
+
+`Dockerfile-aot` disables CPU-specific **method adapter caching** during both training and runtime with
+`-XX:+UnlockDiagnosticVMOptions -XX:-AOTAdapterCaching`. Spring AOT and the JDK class loading/linking cache remain
+enabled. For an already-built image that still crashes, apply the same runtime workaround without replacing its
+existing JVM options:
+
+```bash
+docker run --rm -p 127.0.0.1:8080:8080 \
+  -e BOOTUI_TRUST_CONTAINER_GATEWAY=AUTO \
+  -e 'JDK_JAVA_OPTIONS=-XX:+UnlockDiagnosticVMOptions -XX:-AOTAdapterCaching' \
+  jdubois/bootui-sample-app-aot
+```
+
 ### GraalVM native image
 
 `jdubois/bootui-sample-app-native` is a [GraalVM](https://www.graalvm.org/) native image that starts in well under a


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Prevents the AOT sample image from crashing during advisor scans by disabling CPU-specific method adapter caching during both AOT training and runtime, while preserving Spring AOT and JDK class loading/linking caching.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

The published ARM64 image starts normally but crashes with `SIGILL` in `~AdapterBlob` when the Architecture advisor runs, including through Overview's full scan. JDK 25 can reuse cached adapters containing instructions unsupported by the runtime CPU.

This applies the upstream workaround for [JDK-8388703](https://bugs.openjdk.org/browse/JDK-8388703), whose fix is scheduled for 25.0.5. The Docker publication workflow now requires adapter caching to be disabled and exercises all eight local Overview advisors before publishing AOT images. External OSV/EPSS lookups are deliberately excluded from that smoke test. Documentation includes a runtime-only workaround for existing images.

No linked repository issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally - not run; no Java changes
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests - N/A; no API changes
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Reproduced the fatal crash with the original image and confirmed the same image works with the runtime workaround. Built the modified `Dockerfile-aot` on ARM64 and confirmed AOT-linked classes remain enabled. Executed the new workflow smoke test against the rebuilt image, then ran the existing Overview individual-scan and run-all browser scenarios. All nine advisor reports completed as `SCANNED` or `PARTIAL`, and the application remained healthy. ShellCheck, workflow formatting, and the repository's action-reference guard passed.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

N/A; no UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed