### PR TITLE
Fix Docker Hub retention to delete expired image manifests

### DIFF
--- a/.github/scripts/docker_retention.py
+++ b/.github/scripts/docker_retention.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Plan and apply Docker Hub retention without deleting shared image layers.
+
+The inventory is a write-ahead journal: upload it before applying the plan so a
+failed deletion can be retried even after its last discoverable tag is gone.
+Only the Python standard library is required.
+"""
+
+import argparse
+import base64
+import json
+import os
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.error import HTTPError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+REPOSITORIES = tuple(
+    "bootui-sample-app" + suffix
+    for suffix in ("", "-aot", "-crac", "-native", "-webflux", "-quarkus")
+)
+DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+TAG = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}")
+INDEX_TYPES = {
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+}
+IMAGE_TYPES = {
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+}
+ACCEPT = ", ".join(sorted(INDEX_TYPES | IMAGE_TYPES))
+
+
+class RetentionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Response:
+    status: int
+    content: bytes = b""
+    media_type: str = ""
+
+
+def timestamp(value):
+    if not isinstance(value, str):
+        raise RetentionError("Missing or invalid push timestamp")
+    result = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if result.tzinfo is None:
+        raise RetentionError("Push timestamp must include a timezone")
+    return result.astimezone(timezone.utc)
+
+
+def iso(value):
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def check_digest(value):
+    if not isinstance(value, str) or not DIGEST.fullmatch(value):
+        raise RetentionError("Invalid manifest digest")
+    return value
+
+
+def check_namespace(value):
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", value):
+        raise RetentionError("Invalid Docker Hub namespace")
+    return value
+
+
+def read_inventory(path, namespace):
+    data = json.loads(Path(path).read_text())
+    if data.get("version") != 1 or data.get("namespace") != namespace:
+        raise RetentionError("Inventory version or namespace does not match")
+    repositories = data["repositories"]
+    if not isinstance(repositories, dict) or set(repositories) - set(REPOSITORIES):
+        raise RetentionError("Inventory contains unexpected repositories")
+    for records in repositories.values():
+        if not isinstance(records, dict):
+            raise RetentionError("Inventory manifest records must be an object")
+        for digest, pushed in records.items():
+            check_digest(digest)
+            timestamp(pushed)
+    return repositories
+
+
+def write_json(path, value):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+    temporary.replace(path)
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # None of these endpoints needs a redirect. Never forward credentials
+        # to an origin supplied by a Location or pagination header.
+        return None
+
+
+def request(method, url, headers=None, body=None):
+    data = None if body is None else json.dumps(body).encode()
+    req = Request(url, data=data, headers=headers or {}, method=method)
+    try:
+        with build_opener(NoRedirect).open(req, timeout=45) as response:
+            return Response(
+                response.status,
+                response.read(),
+                response.headers.get("Content-Type", "").split(";")[0],
+            )
+    except HTTPError as error:
+        with error:
+            return Response(error.code, error.read())
+
+
+class DockerHub:
+    def __init__(self, namespace, token="", transport=request, sleep=time.sleep):
+        self.namespace = check_namespace(namespace)
+        self.token = token
+        self.transport = transport
+        self.sleep = sleep
+        self.hub_token = None
+        self.registry_tokens = {}
+
+    def json_request(self, method, url, headers=None, body=None):
+        response = self.transport(method, url, headers, body)
+        if response.status != 200:
+            raise RetentionError(
+                f"{method} {urlsplit(url).path}: HTTP {response.status}"
+            )
+        return json.loads(response.content)
+
+    def hub_headers(self):
+        if not self.token:
+            return {}
+        if self.hub_token is None:
+            response = self.json_request(
+                "POST",
+                "https://hub.docker.com/v2/users/login",
+                {"Content-Type": "application/json"},
+                {"username": self.namespace, "password": self.token},
+            )
+            self.hub_token = response.get("token")
+            if not self.hub_token:
+                raise RetentionError("Docker Hub authentication returned no token")
+        return {"Authorization": "JWT " + self.hub_token}
+
+    def registry_headers(self, repo, write=False):
+        key = (repo, write)
+        cached = self.registry_tokens.get(key)
+        if cached is None or cached[1] <= time.monotonic():
+            if write and not self.token:
+                raise RetentionError("DOCKERHUB_TOKEN is required for deletion")
+            scope = "pull,push,delete" if write else "pull"
+            query = urlencode(
+                {
+                    "service": "registry.docker.io",
+                    "scope": f"repository:{self.namespace}/{repo}:{scope}",
+                }
+            )
+            headers = {}
+            if self.token:
+                credentials = base64.b64encode(
+                    f"{self.namespace}:{self.token}".encode()
+                ).decode()
+                headers["Authorization"] = "Basic " + credentials
+            result = self.json_request(
+                "GET", "https://auth.docker.io/token?" + query, headers
+            )
+            token = result.get("token")
+            if not token:
+                raise RetentionError("Registry authentication returned no token")
+            self.registry_tokens[key] = (
+                token,
+                time.monotonic() + min(int(result.get("expires_in", 60)), 240),
+            )
+        return {
+            "Authorization": "Bearer " + self.registry_tokens[key][0],
+            "Accept": ACCEPT,
+        }
+
+    def tags(self, repo):
+        path = f"/v2/repositories/{self.namespace}/{repo}/tags/"
+        url = "https://hub.docker.com" + path + "?page_size=100"
+        result = {}
+        pages = set()
+        while url:
+            parsed = urlsplit(url)
+            if (
+                parsed.scheme != "https"
+                or parsed.netloc != "hub.docker.com"
+                or parsed.path != path
+                or url in pages
+            ):
+                raise RetentionError("Unsafe or repeated Docker Hub pagination URL")
+            pages.add(url)
+            page = self.json_request("GET", url, self.hub_headers())
+            for tag in page["results"]:
+                name = tag["name"]
+                if not TAG.fullmatch(name) or name in result:
+                    raise RetentionError("Invalid or duplicate tag in inventory")
+                pushed = timestamp(tag["tag_last_pushed"])
+                result[name] = {
+                    "name": name,
+                    "digest": check_digest(tag["digest"]),
+                    "pushed_at": iso(pushed),
+                }
+            url = page["next"]
+        return result
+
+    def manifest_url(self, repo, digest):
+        check_digest(digest)
+        return (
+            f"https://registry-1.docker.io/v2/{self.namespace}/{repo}"
+            f"/manifests/{digest}"
+        )
+
+    def manifest(self, repo, digest):
+        url = self.manifest_url(repo, digest)
+        # HEAD does not consume Docker Hub's image-pull quota. Only indexes
+        # need a GET to discover children; leaf configurations/layers are unused.
+        response = self.transport("HEAD", url, self.registry_headers(repo), None)
+        if response.status == 404:
+            return None
+        if response.status != 200:
+            raise RetentionError(f"Reading {repo}@{digest}: HTTP {response.status}")
+        if response.media_type in IMAGE_TYPES:
+            return []
+        if response.media_type not in INDEX_TYPES:
+            raise RetentionError(f"Unsupported manifest format: {repo}@{digest}")
+        data = self.json_request("GET", url, self.registry_headers(repo))
+        if data.get("schemaVersion") != 2 or data.get("mediaType") not in INDEX_TYPES:
+            raise RetentionError(f"Unsupported image index: {repo}@{digest}")
+        return [check_digest(child["digest"]) for child in data["manifests"]]
+
+    def delete_tag(self, repo, name):
+        url = (
+            f"https://hub.docker.com/v2/repositories/{self.namespace}/{repo}"
+            f"/tags/{name}/"
+        )
+        response = self.transport("DELETE", url, self.hub_headers(), None)
+        if response.status not in (202, 204, 404):
+            raise RetentionError(f"Deleting {repo}:{name}: HTTP {response.status}")
+
+    def delete_manifest(self, repo, digest):
+        url = self.manifest_url(repo, digest)
+        headers = self.registry_headers(repo, write=True)
+        response = self.transport("DELETE", url, headers, None)
+        if response.status == 404:
+            return
+        # Docker documents that 500 can mean deletion was queued. Do not submit
+        # it again; confirm absence before deleting any dependent manifests.
+        if response.status not in (202, 500):
+            raise RetentionError(
+                f"Deleting {repo}@{digest}: HTTP {response.status}; "
+                "check delete permission and remaining references"
+            )
+        for delay in (0, 1, 2, 4, 8, 15):
+            self.sleep(delay)
+            response = self.transport("HEAD", url, self.registry_headers(repo), None)
+            if response.status == 404:
+                return
+            if response.status != 200:
+                raise RetentionError(
+                    f"Confirming deletion of {repo}@{digest}: HTTP {response.status}"
+                )
+        raise RetentionError(
+            f"Deletion still pending for {repo}@{digest}; inventory preserved for retry"
+        )
+
+
+class Graph:
+    def __init__(self, client, repo):
+        self.client = client
+        self.repo = repo
+        self.children = {}
+        self.pushed = {}
+
+    def visit(self, digest, pushed, required=False, ancestors=()):
+        if digest in ancestors:
+            raise RetentionError(f"Cyclic image index in {self.repo}")
+        if digest not in self.children:
+            self.children[digest] = self.client.manifest(self.repo, digest)
+        children = self.children[digest]
+        if children is None:
+            if required:
+                raise RetentionError(f"Referenced manifest is missing: {self.repo}@{digest}")
+            return
+        self.pushed[digest] = max(pushed, self.pushed.get(digest, pushed))
+        for child in children:
+            self.visit(child, pushed, required=required, ancestors=ancestors + (digest,))
+
+    def reachable(self, roots):
+        result = set()
+
+        def walk(digest):
+            if digest not in result:
+                result.add(digest)
+                for child in self.children[digest]:
+                    walk(child)
+
+        for root in roots:
+            walk(root)
+        return result
+
+    def deletion_order(self, candidates):
+        visited = set()
+        ordered = []
+
+        def walk(digest):
+            if digest in visited or self.children[digest] is None:
+                return
+            visited.add(digest)
+            for child in self.children[digest]:
+                walk(child)
+            if digest in candidates:
+                ordered.append(digest)
+
+        for digest in sorted(candidates):
+            walk(digest)
+        return list(reversed(ordered))
+
+
+def plan_retention(client, inventory, now, days=7, repositories=REPOSITORIES):
+    if days < 1:
+        raise RetentionError("Retention must be at least one day")
+    cutoff = now - timedelta(days=days)
+    plan = {
+        "version": 1,
+        "namespace": client.namespace,
+        "generated_at": iso(now),
+        "cutoff": iso(cutoff),
+        "repositories": {},
+    }
+    journal = {"version": 1, "namespace": client.namespace, "repositories": {}}
+    for repo in repositories:
+        tags = client.tags(repo)
+        if "latest" not in tags:
+            raise RetentionError(f"{repo}: latest is missing; refusing to prune")
+        graph = Graph(client, repo)
+        for tag in tags.values():
+            graph.visit(tag["digest"], timestamp(tag["pushed_at"]), required=True)
+        for digest, pushed in inventory.get(repo, {}).items():
+            graph.visit(digest, timestamp(pushed))
+        expired = [
+            tag
+            for tag in tags.values()
+            if tag["name"] != "latest" and timestamp(tag["pushed_at"]) < cutoff
+        ]
+        expired_names = {tag["name"] for tag in expired}
+        protected = graph.reachable(
+            tag["digest"] for tag in tags.values() if tag["name"] not in expired_names
+        )
+        candidates = {
+            digest
+            for digest, pushed in graph.pushed.items()
+            if digest not in protected and pushed < cutoff
+        }
+        plan["repositories"][repo] = {
+            "tags": expired,
+            "manifests": graph.deletion_order(candidates),
+        }
+        journal["repositories"][repo] = {
+            digest: iso(pushed) for digest, pushed in graph.pushed.items()
+        }
+        print(
+            f"{repo}: {len(expired)} expired tags, {len(candidates)} expired manifests, "
+            f"{len(protected)} protected manifests"
+        )
+    return plan, journal
+
+
+def apply_plan(client, plan, now, dry_run=False):
+    if plan.get("version") != 1 or plan.get("namespace") != client.namespace:
+        raise RetentionError("Plan version or namespace does not match")
+    generated = timestamp(plan["generated_at"])
+    if not timedelta(0) <= now - generated <= timedelta(hours=6):
+        raise RetentionError("Plan is stale or from the future; generate a new plan")
+    cutoff = timestamp(plan["cutoff"])
+    if cutoff > generated - timedelta(days=1):
+        raise RetentionError("Unsafe retention cutoff")
+    if not dry_run and not client.token:
+        raise RetentionError("DOCKERHUB_TOKEN is required for deletion")
+    for repo, operations in plan["repositories"].items():
+        if repo not in REPOSITORIES:
+            raise RetentionError("Plan contains unexpected repository")
+        planned_tags = {}
+        for tag in operations["tags"]:
+            name = tag["name"]
+            if (
+                not TAG.fullmatch(name)
+                or name == "latest"
+                or name in planned_tags
+                or timestamp(tag["pushed_at"]) >= cutoff
+            ):
+                raise RetentionError("Unsafe tag deletion in plan")
+            check_digest(tag["digest"])
+            planned_tags[name] = tag
+        for digest in operations["manifests"]:
+            check_digest(digest)
+        current = client.tags(repo)
+        if "latest" not in current:
+            raise RetentionError(f"{repo}: latest disappeared; refusing to prune")
+        for name, tag in planned_tags.items():
+            if name in current and current[name] != tag:
+                raise RetentionError(
+                    f"{repo}:{name} changed after planning; refusing to prune"
+                )
+        graph = Graph(client, repo)
+        kept = [tag for name, tag in current.items() if name not in planned_tags]
+        for tag in kept:
+            graph.visit(tag["digest"], timestamp(tag["pushed_at"]), required=True)
+        protected = graph.reachable(tag["digest"] for tag in kept)
+        # A new tag can protect a previously expired index or child. Registry
+        # reference checks are the final guard against changes after this read.
+        manifests = [d for d in operations["manifests"] if d not in protected]
+        for name in planned_tags:
+            print(f"{'Would delete' if dry_run else 'Deleting'} tag {repo}:{name}")
+            if not dry_run:
+                client.delete_tag(repo, name)
+        for digest in manifests:
+            print(f"{'Would delete' if dry_run else 'Deleting'} manifest {repo}@{digest}")
+            if not dry_run:
+                client.delete_manifest(repo, digest)
+    print(
+        "Dry run: no tags, manifests, or blobs deleted."
+        if dry_run
+        else "Manifest deletion confirmed. Docker Hub reclaims unreferenced layers asynchronously."
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--namespace", required=True)
+    subparsers = parser.add_subparsers(dest="operation", required=True)
+    planner = subparsers.add_parser("plan")
+    planner.add_argument("--inventory", required=True)
+    planner.add_argument("--inventory-out", required=True)
+    planner.add_argument("--output", required=True)
+    planner.add_argument("--days", type=int, default=7)
+    executor = subparsers.add_parser("apply")
+    executor.add_argument("--plan", required=True)
+    executor.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    client = DockerHub(args.namespace, os.environ.get("DOCKERHUB_TOKEN", ""))
+    now = datetime.now(timezone.utc)
+    if args.operation == "plan":
+        inventory = read_inventory(args.inventory, client.namespace)
+        plan, journal = plan_retention(client, inventory, now, args.days)
+        write_json(args.inventory_out, journal)
+        write_json(args.output, plan)
+    else:
+        apply_plan(client, json.loads(Path(args.plan).read_text()), now, args.dry_run)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (RetentionError, ValueError, KeyError, TypeError, OSError) as error:
+        print(f"::error::Docker retention failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/docker_retention_history.py
+++ b/.github/scripts/docker_retention_history.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Restore the retention journal, or bootstrap it from bounded Actions job logs.
+
+Usage: python3 .github/scripts/docker_retention_history.py --output PATH
+       --namespace NAME
+Requires GH_TOKEN (actions:read), GITHUB_REPOSITORY and GITHUB_RUN_ID. All remote
+requests are read-only. Reads docker-retention-inventory, also accepting its
+-RUN_ID-ATTEMPT suffix for immutable rerun uploads, including the current run's
+earlier journals. Restores inventory.json and ignores an optional plan.json.
+Bootstrap excludes the current run and covers at most 90 days; expired/deleted
+logs and older untagged manifests cannot be reconstructed and are reported.
+"""
+
+import argparse
+import io
+import json
+import os
+import re
+import sys
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+API = "https://api.github.com"
+WORKFLOW = ".github/workflows/docker-publish.yml"
+ARTIFACT = "docker-retention-inventory"
+REPOSITORIES = tuple(
+    "bootui-sample-app" + suffix
+    for suffix in ("", "-aot", "-crac", "-native", "-webflux", "-quarkus")
+)
+DIGEST = r"sha256:[0-9a-f]{64}"
+TIMED_LINE = re.compile(r"^(\d{4}-\d\d-\d\dT[\d:.]+Z) (.*)$")
+ANSI = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+MAX_BYTES = 32 * 1024 * 1024
+
+
+class HistoryError(RuntimeError):
+    pass
+
+
+class APIError(HistoryError):
+    def __init__(self, status):
+        self.status = status
+        super().__init__(f"GitHub Actions request failed (HTTP {status})")
+
+
+def timestamp(value):
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            raise ValueError()
+        return parsed.astimezone(timezone.utc)
+    except (AttributeError, TypeError, ValueError):
+        raise HistoryError("Missing or invalid UTC timestamp") from None
+
+
+def iso(value):
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def warn(message):
+    print(f"::warning::{message}", file=sys.stderr)
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def storage_url(url):
+    try:
+        parts = urlsplit(url)
+        port = parts.port
+    except ValueError:
+        return False
+    return (
+        parts.scheme == "https"
+        and not parts.username
+        and not parts.password
+        and port in (None, 443)
+        and not parts.fragment
+        and (
+            parts.hostname == "results-receiver.actions.githubusercontent.com"
+            or re.fullmatch(
+                r"productionresultssa[0-9]+\.blob\.core\.windows\.net",
+                parts.hostname or "",
+            )
+            is not None
+        )
+    )
+
+
+class GitHub:
+    def __init__(self, repository, token):
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise HistoryError("GITHUB_REPOSITORY must be owner/repository")
+        if not token or not token.isascii() or re.search(r"[\x00-\x20\x7f]", token):
+            raise HistoryError("GH_TOKEN with actions:read is required")
+        self.prefix = f"/repos/{repository}"
+        self.token = token
+        self.opener = build_opener(NoRedirect)
+
+    def get(self, path, download=False):
+        # API paths are constructed locally, never from artifact or Link URLs.
+        if not path.startswith(self.prefix + "/"):
+            raise HistoryError("Unapproved GitHub API path")
+        url = API + path
+        headers = {
+            "Authorization": "Bearer " + self.token,
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "bootui-retention-history",
+        }
+        for attempt in range(4):
+            try:
+                with self.opener.open(
+                    Request(url, headers=headers, method="GET"), timeout=45
+                ) as response:
+                    content = response.read(MAX_BYTES + 1)
+                    if len(content) > MAX_BYTES:
+                        raise HistoryError("GitHub response exceeds the size limit")
+                    return content
+            except HTTPError as error:
+                with error:
+                    if download and error.code in (301, 302, 303, 307, 308):
+                        target = error.headers.get("Location", "")
+                        if not storage_url(target):
+                            raise HistoryError("Unapproved Actions download host") from None
+                        url = target
+                        headers = {"User-Agent": "bootui-retention-history"}
+                    else:
+                        raise APIError(error.code) from None
+            except (URLError, OSError, ValueError):
+                # Exception bodies/URLs may contain signed credentials.
+                raise HistoryError("GitHub Actions download or connection failed") from None
+        raise HistoryError("Too many Actions download redirects")
+
+    def json(self, path):
+        try:
+            value = json.loads(self.get(self.prefix + path))
+        except (ValueError, UnicodeError):
+            raise HistoryError("GitHub returned invalid JSON") from None
+        if not isinstance(value, dict):
+            raise HistoryError("GitHub returned an invalid response object")
+        return value
+
+    def pages(self, path, key, params=None, first=None):
+        params = dict(params or {})
+        page = 1
+        seen = set()
+        while True:
+            data = first if page == 1 and first is not None else self.json(
+                path + "?" + urlencode({**params, "per_page": 100, "page": page})
+            )
+            entries = data.get(key)
+            total = data.get("total_count")
+            if not isinstance(entries, list) or type(total) is not int or total < 0:
+                raise HistoryError("Invalid GitHub pagination response")
+            for entry in entries:
+                if not isinstance(entry, dict) or type(entry.get("id")) is not int:
+                    raise HistoryError("Invalid GitHub list entry")
+                if entry["id"] in seen:
+                    raise HistoryError("GitHub pagination repeated an entry; retry")
+                seen.add(entry["id"])
+                yield entry
+            if len(seen) >= total:
+                return
+            if not entries:
+                raise HistoryError("GitHub pagination ended before all entries were read")
+            page += 1
+
+    def runs(self, since, until):
+        params = {"branch": "main", "created": f"{iso(since)}..{iso(until)}"}
+        path = "/actions/workflows/docker-publish.yml/runs"
+        first = self.json(
+            path + "?" + urlencode({**params, "per_page": 100, "page": 1})
+        )
+        # Actions search exposes only 1,000 results per query. Split the time
+        # range instead of silently losing runs on unusually busy repositories.
+        if first.get("total_count", 0) > 1000:
+            if until - since <= timedelta(seconds=1):
+                raise HistoryError("Too many Docker runs in a one-second history window")
+            midpoint = since + (until - since) / 2
+            seen = set()
+            for start, end in ((since, midpoint), (midpoint, until)):
+                for run in self.runs(start, end):
+                    if run["id"] not in seen:
+                        seen.add(run["id"])
+                        yield run
+        else:
+            yield from self.pages(path, "workflow_runs", params, first)
+
+    def download(self, path):
+        return self.get(self.prefix + path, download=True)
+
+
+def validate_inventory(value, namespace):
+    if (
+        not isinstance(value, dict)
+        or type(value.get("version")) is not int
+        or value["version"] != 1
+        or value.get("namespace") != namespace
+    ):
+        raise HistoryError("Inventory version or namespace does not match")
+    repositories = value.get("repositories")
+    if not isinstance(repositories, dict) or set(repositories) - set(REPOSITORIES):
+        raise HistoryError("Inventory contains unexpected repositories")
+    for records in repositories.values():
+        if not isinstance(records, dict):
+            raise HistoryError("Inventory manifest records must be objects")
+        for digest, pushed in records.items():
+            if not re.fullmatch(DIGEST, digest):
+                raise HistoryError("Inventory contains an invalid manifest digest")
+            timestamp(pushed)
+    return {
+        "version": 1,
+        "namespace": namespace,
+        "repositories": {repo: repositories.get(repo, {}) for repo in REPOSITORIES},
+    }
+
+
+def restore_inventory(github, namespace, workflow_id, now):
+    artifacts = github.pages("/actions/artifacts", "artifacts")
+    candidates = []
+    for artifact in artifacts:
+        name = artifact.get("name", "")
+        suffixed = re.fullmatch(rf"{ARTIFACT}-([0-9]+)-([0-9]+)", name)
+        if (name != ARTIFACT and not suffixed) or artifact.get("expired") is True:
+            continue
+        if artifact.get("expired") is not False:
+            raise HistoryError("Artifact expiration metadata is missing")
+        if timestamp(artifact.get("expires_at")) <= now:
+            continue
+        run = artifact.get("workflow_run") or {}
+        if run.get("head_branch") != "main":
+            continue
+        # Run/attempt suffixes let immutable artifact uploads survive reruns.
+        if suffixed and (
+            int(suffixed[1]) != run.get("id") or int(suffixed[2]) < 1
+        ):
+            continue
+        candidates.append(artifact)
+    candidates.sort(
+        key=lambda item: (timestamp(item.get("created_at")), item["id"]), reverse=True
+    )
+    for artifact in candidates:
+        run_id = artifact["workflow_run"]["id"]
+        if type(run_id) is not int:
+            raise HistoryError("Invalid artifact workflow run identity")
+        run = github.json(f"/actions/runs/{run_id}")
+        if run.get("workflow_id") != workflow_id or run.get("head_branch") != "main":
+            continue
+        content = github.download(f"/actions/artifacts/{artifact['id']}/zip")
+        try:
+            with zipfile.ZipFile(io.BytesIO(content)) as archive:
+                entries = archive.infolist()
+                names = [entry.filename for entry in entries]
+                if (
+                    names.count("inventory.json") != 1
+                    or names.count("plan.json") > 1
+                    or set(names) - {"inventory.json", "plan.json"}
+                ):
+                    raise HistoryError(
+                        "Inventory ZIP must contain inventory.json and optionally plan.json"
+                    )
+                entry = archive.getinfo("inventory.json")
+                if entry.file_size > MAX_BYTES:
+                    raise HistoryError("Inventory ZIP exceeds the size limit")
+                inventory = validate_inventory(
+                    json.loads(archive.read(entry)), namespace
+                )
+        except (zipfile.BadZipFile, ValueError, UnicodeError, RuntimeError) as error:
+            if isinstance(error, HistoryError):
+                raise
+            raise HistoryError("Cannot read inventory.json from the artifact ZIP") from None
+        print(
+            f"Restored inventory artifact {artifact['id']} from run {run_id}.",
+            file=sys.stderr,
+        )
+        return inventory
+    return None
+
+
+def log_lines(content):
+    for line in content.decode("utf-8", errors="replace").splitlines():
+        matched = TIMED_LINE.fullmatch(ANSI.sub("", line))
+        if matched:
+            yield timestamp(matched[1]), matched[2]
+
+
+def image_pattern(namespace, repository):
+    # DOCKERHUB_USERNAME is a secret in historical workflows, so GitHub masks
+    # precisely the namespace as "***"; the workflow/job/repository stay visible.
+    return rf"docker\.io/(?:{re.escape(namespace)}|\*\*\*)/{re.escape(repository)}"
+
+
+def merge_digests(content, namespace, repository):
+    image = image_pattern(namespace, repository)
+    copy = re.compile(
+        rf"#\d+ [\d.]+ copying ({DIGEST}) from {image}@({DIGEST}) to {image}"
+    )
+    push = re.compile(rf"#\d+ [\d.]+ pushing ({DIGEST}) to {image}:[\w.-]+")
+    found = set()
+    for _, line in log_lines(content):
+        copied = copy.fullmatch(line)
+        pushed = push.fullmatch(line)
+        if copied and copied[1] == copied[2]:
+            found.add(copied[1])
+        if pushed:
+            found.add(pushed[1])
+    return found
+
+
+def build_digests(content, namespace, repository, steps):
+    image = image_pattern(namespace, repository)
+    export = re.compile(
+        rf"(#\d+) exporting (?:manifest(?: list)?|attestation manifest) "
+        rf"({DIGEST})(?: [\d.]+s)? done"
+    )
+    push = re.compile(
+        rf"(#\d+) pushing manifest for {image}(?:@({DIGEST})|:[\w.-]+)?"
+        rf"(?: [\d.]+s)? done"
+    )
+    found = set()
+    lines = list(log_lines(content))
+    for step in steps:
+        if step.get("name") not in (
+            "Push the smoke-tested image by digest",
+            "Push the smoke-tested image with a retention tag",
+        ) or step.get("conclusion") == "skipped":
+            continue
+        if not step.get("started_at") or not step.get("completed_at"):
+            continue
+        start = timestamp(step["started_at"])
+        # Actions step timestamps have second precision, log records do not.
+        end = timestamp(step["completed_at"]) + timedelta(seconds=1)
+        exported = {}
+        for at, line in lines:
+            if not start <= at < end:
+                continue
+            matched = export.fullmatch(line)
+            if matched:
+                exported.setdefault(matched[1], set()).add(matched[2])
+            pushed = push.fullmatch(line)
+            if pushed:
+                found.update(exported.get(pushed[1], ()))
+                if pushed[2]:
+                    found.add(pushed[2])
+    return found
+
+
+def bootstrap(github, namespace, workflow_id, current_run, now):
+    since = now - timedelta(days=90)
+    warn(
+        f"No prior inventory: recovering available Docker publish logs since {iso(since)}. "
+        "History is incomplete outside the 90-day Actions retention window; "
+        "expired/deleted logs and older untagged manifests cannot be recovered."
+    )
+    inventory = validate_inventory(
+        {"version": 1, "namespace": namespace, "repositories": {}}, namespace
+    )
+    recovered_runs = 0
+    unavailable = 0
+
+    def logs(job):
+        nonlocal unavailable
+        try:
+            return github.download(f"/actions/jobs/{job['id']}/logs")
+        except APIError as error:
+            if error.status not in (404, 410):
+                raise
+            unavailable += 1
+            warn(
+                f"Job {job['id']} logs are unavailable (HTTP {error.status}); "
+                "expired/deleted logs leave this bootstrap incomplete."
+            )
+            return None
+
+    for run in github.runs(since, now):
+        if (
+            str(run["id"]) == current_run
+            or run.get("workflow_id") != workflow_id
+            or run.get("head_branch") != "main"
+            or run.get("status") != "completed"
+            or not since <= timestamp(run["created_at"]) <= now
+        ):
+            continue
+        pushed = iso(timestamp(run["updated_at"]))
+        jobs = list(github.pages(
+            f"/actions/runs/{run['id']}/jobs", "jobs", {"filter": "all"}
+        ))
+        recovered_runs += 1
+        for repo in REPOSITORIES:
+            found = set()
+            merged_attempts = set()
+            for job in jobs:
+                if job.get("name") != f"Merge {repo} manifests":
+                    continue
+                if job.get("conclusion") in ("skipped", None):
+                    continue
+                content = logs(job)
+                if content is None:
+                    continue
+                digests = merge_digests(content, namespace, repo)
+                found.update(digests)
+                if job.get("conclusion") == "success" and digests:
+                    merged_attempts.add(job.get("run_attempt", 1))
+                elif not digests:
+                    warn(f"Merge job {job['id']} yielded no known push records.")
+            for job in jobs:
+                if job.get("run_attempt", 1) in merged_attempts or job.get("name") not in (
+                    f"Build, smoke-test and publish {repo} (linux/amd64)",
+                    f"Build, smoke-test and publish {repo} (linux/arm64)",
+                ):
+                    continue
+                steps = [
+                    step for step in job.get("steps", [])
+                    if step.get("name") in (
+                        "Push the smoke-tested image by digest",
+                        "Push the smoke-tested image with a retention tag",
+                    ) and step.get("conclusion") != "skipped"
+                ]
+                if not steps:
+                    continue
+                content = logs(job)
+                if content is None:
+                    continue
+                digests = build_digests(content, namespace, repo, steps)
+                if not digests:
+                    warn(
+                        f"Build job {job['id']} yielded no confirmed manifest pushes; "
+                        "partial publication history may be incomplete."
+                    )
+                found.update(digests)
+            records = inventory["repositories"][repo]
+            for digest in found:
+                if digest not in records or timestamp(records[digest]) < timestamp(pushed):
+                    records[digest] = pushed
+    count = sum(len(records) for records in inventory["repositories"].values())
+    print(
+        f"Bootstrap recovered {count} known manifests from {recovered_runs} completed "
+        f"runs; {unavailable} job logs unavailable. This is bounded, best-effort history, "
+        "not proof that all historical manifests were recovered.",
+        file=sys.stderr,
+    )
+    return inventory
+
+
+def recover(github, namespace, current_run, now=None):
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", namespace):
+        raise HistoryError("Invalid Docker Hub namespace")
+    if not re.fullmatch(r"[0-9]+", current_run):
+        raise HistoryError("GITHUB_RUN_ID is required and must be numeric")
+    now = now or datetime.now(timezone.utc)
+    workflow = github.json("/actions/workflows/docker-publish.yml")
+    if workflow.get("path") != WORKFLOW or type(workflow.get("id")) is not int:
+        raise HistoryError("Docker publish workflow identity does not match")
+    restored = restore_inventory(github, namespace, workflow["id"], now)
+    if restored is not None:
+        return restored
+    return bootstrap(github, namespace, workflow["id"], current_run, now)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--namespace", required=True)
+    args = parser.parse_args(argv)
+    try:
+        github = GitHub(
+            os.environ.get("GITHUB_REPOSITORY", ""),
+            os.environ.get("GH_TOKEN", ""),
+        )
+        inventory = recover(
+            github, args.namespace, os.environ.get("GITHUB_RUN_ID", "")
+        )
+        path = Path(args.output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(inventory, indent=2, sort_keys=True) + "\n")
+    except (HistoryError, OSError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_docker_retention.py
+++ b/.github/scripts/test_docker_retention.py
@@ -1,0 +1,613 @@
+import copy
+import hashlib
+import io
+import json
+import tempfile
+import threading
+import unittest
+from contextlib import redirect_stdout
+from datetime import datetime, timedelta, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import Mock
+from urllib.parse import urlsplit
+
+from docker_retention import (
+    DockerHub,
+    NoRedirect,
+    REPOSITORIES,
+    Response,
+    RetentionError,
+    apply_plan,
+    iso,
+    plan_retention,
+    read_inventory,
+    request,
+    write_json,
+)
+
+REPO = "bootui-sample-app-quarkus"
+NOW = datetime(2026, 9, 9, 12, tzinfo=timezone.utc)
+OLD = iso(NOW - timedelta(days=8))
+NEW = iso(NOW - timedelta(days=1))
+
+
+def digest(name):
+    return "sha256:" + hashlib.sha256(name.encode()).hexdigest()
+
+
+def tag(name, image, pushed=OLD):
+    return {"name": name, "digest": digest(image), "pushed_at": pushed}
+
+
+class FakeHub:
+    namespace = "jdubois"
+    token = "test-token"
+
+    def __init__(self):
+        self.tag_data = {
+            "latest": tag("latest", "new-index", NEW),
+            "20260901": tag("20260901", "old-index"),
+            "sha-old": tag("sha-old", "old-index"),
+        }
+        self.images = {
+            digest("new-index"): [digest("shared"), digest("new-arm")],
+            digest("old-index"): [digest("shared"), digest("old-arm")],
+            digest("shared"): [],
+            digest("new-arm"): [],
+            digest("old-arm"): [],
+        }
+        self.deleted = []
+        self.fail_digest = None
+
+    def tags(self, repo):
+        return copy.deepcopy(self.tag_data)
+
+    def manifest(self, repo, image):
+        return self.images.get(image)
+
+    def delete_tag(self, repo, name):
+        self.deleted.append(("tag", name))
+        self.tag_data.pop(name, None)
+
+    def delete_manifest(self, repo, image):
+        if image == self.fail_digest:
+            raise RetentionError("Deletion still pending")
+        if any(t["digest"] == image for t in self.tag_data.values()):
+            raise AssertionError("Attempted to delete a tagged image")
+        if any(image in children for children in self.images.values()):
+            raise AssertionError("Attempted to delete a referenced child")
+        self.deleted.append(("manifest", image))
+        self.images.pop(image, None)
+
+
+class RetentionTests(unittest.TestCase):
+    def setUp(self):
+        self.hub = FakeHub()
+        self.output = io.StringIO()
+        self.redirect = redirect_stdout(self.output)
+        self.redirect.__enter__()
+        self.addCleanup(self.redirect.__exit__, None, None, None)
+
+    def plan(self, history=None):
+        return plan_retention(
+            self.hub, history or {}, NOW, repositories=(REPO,)
+        )
+
+    def test_deletes_expired_indexes_before_children_and_keeps_shared_platform(self):
+        plan, journal = self.plan()
+        operations = plan["repositories"][REPO]
+        self.assertEqual(
+            operations["manifests"], [digest("old-index"), digest("old-arm")]
+        )
+        self.assertIn(digest("old-arm"), journal["repositories"][REPO])
+        apply_plan(self.hub, plan, NOW)
+        self.assertEqual(
+            self.hub.deleted,
+            [
+                ("tag", "20260901"),
+                ("tag", "sha-old"),
+                ("manifest", digest("old-index")),
+                ("manifest", digest("old-arm")),
+            ],
+        )
+        self.assertIn(digest("shared"), self.hub.images)
+        self.assertEqual(set(self.hub.tag_data), {"latest"})
+
+    def test_latest_is_kept_even_when_older_than_seven_days(self):
+        self.hub.tag_data["latest"]["pushed_at"] = OLD
+        plan, _ = self.plan()
+        self.assertNotIn(digest("new-index"), plan["repositories"][REPO]["manifests"])
+
+    def test_exact_cutoff_and_recent_pushes_are_kept(self):
+        for name, pushed in (("boundary", iso(NOW - timedelta(days=7))), ("fresh", NEW)):
+            self.hub.images[digest(name)] = []
+            self.hub.tag_data[name] = tag(name, name, pushed)
+        plan, _ = self.plan()
+        self.assertEqual(
+            {t["name"] for t in plan["repositories"][REPO]["tags"]},
+            {"20260901", "sha-old"},
+        )
+
+    def test_removes_old_alias_without_deleting_recently_tagged_image(self):
+        self.hub.tag_data["recent-alias"] = tag("recent-alias", "old-index", NEW)
+        plan, _ = self.plan()
+        self.assertEqual(plan["repositories"][REPO]["manifests"], [])
+        apply_plan(self.hub, plan, NOW)
+        self.assertIn(digest("old-index"), self.hub.images)
+
+    def test_old_failed_build_is_discoverable_through_retention_tag(self):
+        self.hub.tag_data["build-123-1-linux-amd64"] = tag(
+            "build-123-1-linux-amd64", "failed-build"
+        )
+        self.hub.images[digest("failed-build")] = []
+        plan, _ = self.plan()
+        self.assertIn(digest("failed-build"), plan["repositories"][REPO]["manifests"])
+
+    def test_retention_index_survives_overwritten_release_tags_without_a_journal(self):
+        self.hub.tag_data.pop("20260901")
+        self.hub.tag_data.pop("sha-old")
+        self.hub.tag_data["build-123-1-index"] = tag("build-123-1-index", "old-index")
+        plan, _ = self.plan()
+        self.assertEqual(
+            plan["repositories"][REPO]["manifests"],
+            [digest("old-index"), digest("old-arm")],
+        )
+        apply_plan(self.hub, plan, NOW)
+
+    def test_legacy_orphan_is_recovered_and_recent_orphan_is_kept(self):
+        self.hub.images[digest("legacy")] = [digest("legacy-child")]
+        self.hub.images[digest("legacy-child")] = []
+        self.hub.images[digest("recent-orphan")] = []
+        plan, journal = self.plan(
+            {REPO: {digest("legacy"): OLD, digest("recent-orphan"): NEW}}
+        )
+        candidates = plan["repositories"][REPO]["manifests"]
+        self.assertIn(digest("legacy"), candidates)
+        self.assertIn(digest("legacy-child"), candidates)
+        self.assertNotIn(digest("recent-orphan"), candidates)
+        self.assertIn(digest("legacy-child"), journal["repositories"][REPO])
+
+    def test_retry_recovers_child_after_tags_and_parent_were_deleted(self):
+        plan, journal = self.plan()
+        self.hub.fail_digest = digest("old-arm")
+        with self.assertRaisesRegex(RetentionError, "pending"):
+            apply_plan(self.hub, plan, NOW)
+        self.hub.fail_digest = None
+        next_plan, next_journal = self.plan(journal["repositories"])
+        self.assertNotIn(digest("old-index"), next_journal["repositories"][REPO])
+        self.assertEqual(
+            next_plan["repositories"][REPO]["manifests"], [digest("old-arm")]
+        )
+        apply_plan(self.hub, next_plan, NOW)
+        self.assertNotIn(digest("old-arm"), self.hub.images)
+
+    def test_missing_historical_manifest_is_idempotently_removed_from_inventory(self):
+        _, journal = self.plan({REPO: {digest("already-deleted"): OLD}})
+        self.assertNotIn(digest("already-deleted"), journal["repositories"][REPO])
+
+    def test_orphan_index_with_already_deleted_child_can_be_cleaned(self):
+        self.hub.images[digest("legacy")] = [digest("already-deleted")]
+        plan, journal = self.plan({REPO: {digest("legacy"): OLD}})
+        self.assertIn(digest("legacy"), plan["repositories"][REPO]["manifests"])
+        self.assertNotIn(digest("already-deleted"), journal["repositories"][REPO])
+        apply_plan(self.hub, plan, NOW)
+
+    def test_missing_latest_or_referenced_child_fails_before_mutations(self):
+        for missing in ("latest", "child"):
+            with self.subTest(missing=missing):
+                self.hub = FakeHub()
+                if missing == "latest":
+                    self.hub.tag_data.pop("latest")
+                else:
+                    self.hub.images.pop(digest("shared"))
+                with self.assertRaises(RetentionError):
+                    self.plan()
+                self.assertEqual(self.hub.deleted, [])
+
+    def test_nested_indexes_are_deleted_in_topological_order(self):
+        self.hub.images[digest("nested")] = [digest("old-arm")]
+        self.hub.images[digest("old-index")] = [digest("nested")]
+        plan, _ = self.plan()
+        self.assertEqual(
+            plan["repositories"][REPO]["manifests"],
+            [digest("old-index"), digest("nested"), digest("old-arm")],
+        )
+
+    def test_multiple_expired_parents_are_deleted_before_shared_child(self):
+        self.hub.images[digest("other-index")] = [digest("old-arm")]
+        plan, _ = self.plan({REPO: {digest("other-index"): OLD}})
+        candidates = plan["repositories"][REPO]["manifests"]
+        self.assertLess(
+            candidates.index(digest("other-index")), candidates.index(digest("old-arm"))
+        )
+        self.assertLess(
+            candidates.index(digest("old-index")), candidates.index(digest("old-arm"))
+        )
+        apply_plan(self.hub, plan, NOW)
+
+    def test_cycle_is_rejected(self):
+        self.hub.images[digest("shared")] = [digest("new-index")]
+        with self.assertRaisesRegex(RetentionError, "Cyclic"):
+            self.plan()
+
+    def test_dry_run_does_not_delete_tags_manifests_or_require_credentials(self):
+        self.hub.token = ""
+        plan, _ = self.plan()
+        apply_plan(self.hub, plan, NOW, dry_run=True)
+        self.assertEqual(self.hub.deleted, [])
+        self.assertIn("Would delete tag", self.output.getvalue())
+        self.assertIn("Would delete manifest", self.output.getvalue())
+        with self.assertRaisesRegex(RetentionError, "DOCKERHUB_TOKEN"):
+            apply_plan(self.hub, plan, NOW)
+
+    def test_changed_expired_tag_fails_before_any_deletion(self):
+        plan, _ = self.plan()
+        self.hub.tag_data["20260901"]["pushed_at"] = NEW
+        with self.assertRaisesRegex(RetentionError, "changed after planning"):
+            apply_plan(self.hub, plan, NOW)
+        self.assertEqual(self.hub.deleted, [])
+
+    def test_new_tag_protects_candidate_and_all_its_children(self):
+        plan, _ = self.plan()
+        self.hub.tag_data["new-reference"] = tag("new-reference", "old-index", NEW)
+        apply_plan(self.hub, plan, NOW)
+        self.assertFalse(any(kind == "manifest" for kind, _ in self.hub.deleted))
+
+    def test_stale_plan_invalid_namespace_and_latest_deletion_fail(self):
+        plan, _ = self.plan()
+        invalid = [
+            {**plan, "namespace": "different"},
+            {**plan, "generated_at": iso(NOW - timedelta(hours=7))},
+            {**plan, "generated_at": iso(NOW + timedelta(minutes=1))},
+            {**plan, "cutoff": iso(NOW)},
+        ]
+        bad_latest = copy.deepcopy(plan)
+        bad_latest["repositories"][REPO]["tags"].append(tag("latest", "new-index"))
+        invalid.append(bad_latest)
+        for bad in invalid:
+            with self.subTest(plan=bad), self.assertRaises(RetentionError):
+                apply_plan(self.hub, bad, NOW)
+        self.assertEqual(self.hub.deleted, [])
+
+    def test_inventory_round_trip_and_validation(self):
+        _, journal = self.plan()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "inventory.json"
+            write_json(path, journal)
+            self.assertEqual(read_inventory(path, "jdubois"), journal["repositories"])
+            with self.assertRaises(RetentionError):
+                read_inventory(path, "someone-else")
+            journal["repositories"]["unexpected"] = {}
+            write_json(path, journal)
+            with self.assertRaises(RetentionError):
+                read_inventory(path, "jdubois")
+
+
+class ApiTests(unittest.TestCase):
+    def json_response(self, value):
+        return Response(200, json.dumps(value).encode())
+
+    def test_paginates_all_tags_and_uses_push_not_pull_or_metadata_update(self):
+        responses = []
+        for page in range(3):
+            results = [
+                {
+                    "name": f"build-{i}",
+                    "digest": digest(str(i)),
+                    "tag_last_pushed": OLD,
+                    "tag_last_pulled": NEW,
+                    "last_updated": NEW,
+                }
+                for i in range(page * 100, min((page + 1) * 100, 205))
+            ]
+            next_url = (
+                f"https://hub.docker.com/v2/repositories/jdubois/{REPO}/tags/?page={page + 2}"
+                if page < 2
+                else None
+            )
+            responses.append(self.json_response({"results": results, "next": next_url}))
+        transport = Mock(side_effect=responses)
+        hub = DockerHub("jdubois", transport=transport)
+        tags = hub.tags(REPO)
+        self.assertEqual(len(tags), 205)
+        self.assertEqual(tags["build-204"]["pushed_at"], OLD)
+        self.assertTrue(all(call.args[0] == "GET" for call in transport.call_args_list))
+
+    def test_unsafe_and_cyclic_pagination_fail_closed(self):
+        base = f"https://hub.docker.com/v2/repositories/jdubois/{REPO}/tags/"
+        for next_url in (
+            "https://evil.example/tags",
+            base + "?page_size=100",
+            base.replace("https:", "http:"),
+        ):
+            transport = Mock(
+                return_value=self.json_response({"results": [], "next": next_url})
+            )
+            with self.subTest(next=next_url), self.assertRaisesRegex(
+                RetentionError, "pagination"
+            ):
+                DockerHub("jdubois", transport=transport).tags(REPO)
+            self.assertEqual(transport.call_count, 1)
+
+    def test_unauthorized_inventory_is_not_treated_as_empty(self):
+        for code in (401, 403, 404, 429, 500):
+            transport = Mock(return_value=Response(code, b"error"))
+            with self.subTest(code=code), self.assertRaisesRegex(
+                RetentionError, str(code)
+            ):
+                DockerHub("jdubois", transport=transport).tags(REPO)
+
+    def test_missing_timestamp_and_unsupported_manifest_fail_closed(self):
+        transport = Mock(
+            side_effect=[
+                self.json_response({"token": "test"}),
+                Response(200, media_type="unsupported"),
+            ]
+        )
+        with self.assertRaisesRegex(RetentionError, "Unsupported"):
+            DockerHub("jdubois", transport=transport).manifest(REPO, digest("image"))
+        transport = Mock(
+            return_value=self.json_response(
+                {"results": [{"name": "old", "digest": digest("old")}], "next": None}
+            )
+        )
+        with self.assertRaises(KeyError):
+            DockerHub("jdubois", transport=transport).tags(REPO)
+
+    def test_deletion_requests_delete_scope_and_confirms_absence_without_deleting_blobs(self):
+        transport = Mock(
+            side_effect=[
+                self.json_response({"token": "write"}),
+                Response(202),
+                self.json_response({"token": "read"}),
+                Response(200),
+                Response(404),
+            ]
+        )
+        hub = DockerHub("jdubois", token="test", transport=transport, sleep=Mock())
+        hub.delete_manifest(REPO, digest("old"))
+        self.assertIn("pull%2Cpush%2Cdelete", transport.call_args_list[0].args[1])
+        deletes = [c.args for c in transport.call_args_list if c.args[0] == "DELETE"]
+        self.assertEqual(len(deletes), 1)
+        self.assertIn("/manifests/", deletes[0][1])
+        self.assertNotIn("/blobs/", deletes[0][1])
+        self.assertEqual(transport.call_args_list[-1].args[0], "HEAD")
+
+    def test_queued_500_is_confirmed_without_repeating_delete(self):
+        transport = Mock(
+            side_effect=[
+                self.json_response({"token": "write"}),
+                Response(500),
+                self.json_response({"token": "read"}),
+                Response(404),
+            ]
+        )
+        hub = DockerHub("jdubois", token="test", transport=transport, sleep=Mock())
+        hub.delete_manifest(REPO, digest("old"))
+        self.assertEqual(sum(c.args[0] == "DELETE" for c in transport.call_args_list), 1)
+
+    def test_pending_deletion_or_permission_denial_is_a_failure(self):
+        for code in (401, 403, 405, 429, 202):
+            transport = Mock(
+                side_effect=[
+                    self.json_response({"token": "write"}),
+                    Response(code),
+                    self.json_response({"token": "read"}),
+                    *[Response(200)] * 6,
+                ]
+            )
+            with self.subTest(code=code), self.assertRaises(RetentionError):
+                hub = DockerHub("jdubois", token="test", transport=transport, sleep=Mock())
+                hub.delete_manifest(REPO, digest("old"))
+
+    def test_missing_manifest_delete_is_idempotent(self):
+        transport = Mock(
+            side_effect=[self.json_response({"token": "write"}), Response(404)]
+        )
+        DockerHub("jdubois", token="test", transport=transport).delete_manifest(
+            REPO, digest("old")
+        )
+        self.assertEqual(transport.call_count, 2)
+
+    def test_tag_delete_errors_are_not_ignored(self):
+        transport = Mock(
+            side_effect=[self.json_response({"token": "hub"}), Response(403)]
+        )
+        with self.assertRaisesRegex(RetentionError, "403"):
+            DockerHub("jdubois", token="test", transport=transport).delete_tag(REPO, "old")
+
+    def test_redirects_cannot_forward_authorization(self):
+        self.assertIsNone(
+            NoRedirect().redirect_request(None, None, 302, "", {}, "https://evil.example")
+        )
+
+    def test_namespace_is_validated_before_requests(self):
+        transport = Mock()
+        with self.assertRaisesRegex(RetentionError, "namespace"):
+            DockerHub("../different-owner", transport=transport)
+        transport.assert_not_called()
+
+    def test_leaf_discovery_uses_head_instead_of_consuming_image_pull_quota(self):
+        transport = Mock(
+            side_effect=[
+                self.json_response({"token": "test"}),
+                Response(200, media_type="application/vnd.oci.image.manifest.v1+json"),
+            ]
+        )
+        hub = DockerHub("jdubois", transport=transport)
+        self.assertEqual(hub.manifest(REPO, digest("leaf")), [])
+        self.assertEqual(transport.call_args_list[-1].args[0], "HEAD")
+
+    def test_index_discovery_fetches_children_after_head(self):
+        index_type = "application/vnd.oci.image.index.v1+json"
+        transport = Mock(
+            side_effect=[
+                self.json_response({"token": "test"}),
+                Response(200, media_type=index_type),
+                self.json_response(
+                    {
+                        "schemaVersion": 2,
+                        "mediaType": index_type,
+                        "manifests": [{"digest": digest("child")}],
+                    }
+                ),
+            ]
+        )
+        hub = DockerHub("jdubois", transport=transport)
+        self.assertEqual(hub.manifest(REPO, digest("index")), [digest("child")])
+        self.assertEqual(
+            [c.args[0] for c in transport.call_args_list[-2:]], ["HEAD", "GET"]
+        )
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_cleanup_runs_after_failure_and_journal_upload_precedes_deletion(self):
+        workflow = (
+            Path(__file__).resolve().parents[1] / "workflows/docker-publish.yml"
+        ).read_text()
+        prune = workflow.split("\n  prune:\n")[1]
+        self.assertIn("needs: [docker-config, build, merge]", prune)
+        self.assertIn("always()", prune)
+        self.assertIn("actions: read", prune)
+        self.assertIn("group: docker-hub-publish", workflow)
+        self.assertIn("cancel-in-progress: false", workflow)
+        self.assertIn("github.ref == 'refs/heads/main' || inputs.prune_dry_run", prune)
+        self.assertIn(
+            "docker-retention-inventory-${{ github.run_id }}-${{ github.run_attempt }}",
+            prune,
+        )
+        self.assertLess(
+            prune.index("uses: actions/upload-artifact@"),
+            prune.index("name: Apply retention"),
+        )
+        self.assertNotIn("continue-on-error", prune)
+        self.assertNotIn("DOCKERHUB_UNTAGGED_PRUNE", workflow)
+        self.assertIn(":build-${{ github.run_id }}-${{ github.run_attempt }}-", workflow)
+        self.assertIn(":build-${{ github.run_id }}-${{ github.run_attempt }}-index", workflow)
+        self.assertLess(
+            workflow.index("name: Create the retention-tagged manifest list"),
+            workflow.index("name: Apply release tags to the retained manifest list"),
+        )
+
+
+class HttpIntegrationTests(unittest.TestCase):
+    def test_all_six_repositories_through_real_http_transport(self):
+        repositories = {repo: FakeHub() for repo in REPOSITORIES}
+        calls = []
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *_):
+                pass
+
+            def respond(self, status, value=None, media_type="application/json"):
+                body = b"" if value is None else json.dumps(value).encode()
+                self.send_response(status)
+                self.send_header("Content-Type", media_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                if self.command != "HEAD":
+                    self.wfile.write(body)
+
+            def route(self):
+                path = urlsplit(self.path).path
+                calls.append((self.command, path))
+                if path == "/token" or path == "/v2/users/login":
+                    self.respond(200, {"token": "fixture-token"})
+                    return
+                parts = path.split("/")
+                if "/tags/" in path:
+                    repo = parts[4]
+                    hub = repositories[repo]
+                    if self.command == "GET":
+                        self.respond(
+                            200,
+                            {
+                                "results": [
+                                    {
+                                        "name": tag["name"],
+                                        "digest": tag["digest"],
+                                        "tag_last_pushed": tag["pushed_at"],
+                                    }
+                                    for tag in hub.tag_data.values()
+                                ],
+                                "next": None,
+                            },
+                        )
+                    elif self.headers.get("Authorization") != "JWT fixture-token":
+                        self.respond(401)
+                    else:
+                        hub.delete_tag(repo, parts[6])
+                        self.respond(204)
+                    return
+                if "/manifests/" in path:
+                    repo, image = parts[3], parts[5]
+                    hub = repositories[repo]
+                    if image not in hub.images:
+                        self.respond(404)
+                        return
+                    if self.command == "DELETE":
+                        if self.headers.get("Authorization") != "Bearer fixture-token":
+                            self.respond(401)
+                            return
+                        hub.delete_manifest(repo, image)
+                        self.respond(202)
+                        return
+                    children = hub.images[image]
+                    media_type = (
+                        "application/vnd.oci.image.index.v1+json"
+                        if children
+                        else "application/vnd.oci.image.manifest.v1+json"
+                    )
+                    self.respond(
+                        200,
+                        {
+                            "schemaVersion": 2,
+                            "mediaType": media_type,
+                            "manifests": [{"digest": child} for child in children],
+                        },
+                        media_type,
+                    )
+                    return
+                self.respond(404)
+
+            do_GET = route
+            do_HEAD = route
+            do_POST = route
+            do_DELETE = route
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join, 5)
+        self.addCleanup(server.shutdown)
+
+        def transport(method, url, headers, body):
+            parsed = urlsplit(url)
+            local_url = (
+                f"http://127.0.0.1:{server.server_port}{parsed.path}?{parsed.query}"
+            )
+            return request(method, local_url, headers, body)
+
+        client = DockerHub("jdubois", token="fixture-only", transport=transport)
+        with redirect_stdout(io.StringIO()), tempfile.TemporaryDirectory() as directory:
+            plan, inventory = plan_retention(client, {}, NOW)
+            journal = Path(directory) / "inventory.json"
+            write_json(journal, inventory)
+            self.assertEqual(set(read_inventory(journal, "jdubois")), set(REPOSITORIES))
+            apply_plan(client, plan, NOW, dry_run=True)
+            self.assertFalse(any(method == "DELETE" for method, _ in calls))
+            apply_plan(client, plan, NOW)
+        for hub in repositories.values():
+            self.assertEqual(set(hub.tag_data), {"latest"})
+            self.assertEqual(
+                set(hub.images),
+                {digest("new-index"), digest("new-arm"), digest("shared")},
+            )
+        self.assertEqual(sum(method == "DELETE" for method, _ in calls), 24)
+        self.assertFalse(any("/blobs/" in path for _, path in calls))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_docker_retention_history.py
+++ b/.github/scripts/test_docker_retention_history.py
@@ -1,0 +1,645 @@
+import copy
+import io
+import json
+import unittest
+import zipfile
+from contextlib import redirect_stderr
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, urlsplit
+
+import docker_retention_history as history
+
+NOW = datetime(2026, 9, 9, 12, tzinfo=timezone.utc)
+REPO = "bootui-sample-app-quarkus"
+IMAGE = "docker.io/***/" + REPO
+D1, D2, D3, CONFIG, BASE = ("sha256:" + char * 64 for char in "abcde")
+OLD = "2026-09-01T08:04:00Z"
+NEW = "2026-09-08T08:04:00Z"
+
+
+def inventory(namespace="jdubois"):
+    return {
+        "version": 1,
+        "namespace": namespace,
+        "repositories": {
+            repo: ({D1: OLD} if repo == REPO else {})
+            for repo in history.REPOSITORIES
+        },
+    }
+
+
+def archive(value, plan=None):
+    content = io.BytesIO()
+    with zipfile.ZipFile(content, "w") as zipped:
+        zipped.writestr("inventory.json", json.dumps(value))
+        if plan is not None:
+            zipped.writestr("plan.json", json.dumps(plan))
+    return content.getvalue()
+
+
+def artifact(identity=1, run_id=10, **overrides):
+    return {
+        "id": identity,
+        "name": history.ARTIFACT,
+        "created_at": NEW,
+        "expires_at": "2026-12-01T00:00:00Z",
+        "expired": False,
+        "workflow_run": {"id": run_id, "head_branch": "main"},
+        **overrides,
+    }
+
+
+def run(identity=10, **overrides):
+    return {
+        "id": identity,
+        "workflow_id": 42,
+        "head_branch": "main",
+        "created_at": OLD,
+        "updated_at": NEW,
+        "status": "completed",
+        "conclusion": "success",
+        **overrides,
+    }
+
+
+def merge_job(identity=20, repository=REPO, **overrides):
+    return {
+        "id": identity,
+        "name": f"Merge {repository} manifests",
+        "conclusion": "success",
+        "steps": [],
+        **overrides,
+    }
+
+
+def build_job(identity=21, repository=REPO, **overrides):
+    return {
+        "id": identity,
+        "name": f"Build, smoke-test and publish {repository} (linux/amd64)",
+        "conclusion": "failure",
+        "steps": [{
+            "name": "Push the smoke-tested image by digest",
+            "conclusion": "success",
+            "started_at": "2026-09-01T08:03:00Z",
+            "completed_at": "2026-09-01T08:03:10Z",
+        }],
+        **overrides,
+    }
+
+
+def log(*lines, at="2026-09-01T08:03:05.1234567Z"):
+    return "".join(f"{at} {line}\n" for line in lines).encode()
+
+
+def merge_log(repository=REPO):
+    image = "docker.io/***/" + repository
+    return log(
+        f"#1 0.000 copying {D1} from {image}@{D1} to {image}",
+        f"#1 0.000 copying {D2} from {image}@{D2} to {image}",
+        f"#1 0.603 pushing {D3} to {image}:20260901",
+        f"#1 2.093 pushing {D3} to {image}:latest",
+    )
+
+
+def build_log():
+    return log(
+        f"#8 FROM docker.io/library/eclipse-temurin:21@{BASE}",
+        f"#17 exporting manifest {D1} done",
+        f"#17 exporting config {CONFIG} done",
+        "#17 pushing layers 14.3s done",
+        f"#17 pushing manifest for {IMAGE}",
+        f"#17 pushing manifest for {IMAGE} 0.5s done",
+        "##[group]ImageID",
+        CONFIG,
+        "##[group]Digest",
+        D1,
+    )
+
+
+class FakeGitHub:
+    def __init__(self, artifacts=None, runs=None, jobs=None, downloads=None):
+        self.artifacts = artifacts or []
+        self.history = runs or []
+        self.jobs = jobs or {}
+        self.downloads = downloads or {}
+        self.requested = []
+        self.run_reads = []
+        self.bounds = None
+
+    def json(self, path):
+        if path == "/actions/workflows/docker-publish.yml":
+            return {"id": 42, "path": history.WORKFLOW}
+        identity = int(path.rsplit("/", 1)[1])
+        self.run_reads.append(identity)
+        return next(item for item in self.history if item["id"] == identity)
+
+    def pages(self, path, key, params=None):
+        if key == "artifacts":
+            return iter(self.artifacts)
+        identity = int(path.split("/")[-2])
+        return iter(self.jobs.get(identity, []))
+
+    def runs(self, since, until):
+        self.bounds = since, until
+        return iter(self.history)
+
+    def download(self, path):
+        self.requested.append(path)
+        value = self.downloads[path]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+class HistoryTests(unittest.TestCase):
+    def setUp(self):
+        self.stderr = io.StringIO()
+        redirect = redirect_stderr(self.stderr)
+        redirect.__enter__()
+        self.addCleanup(redirect.__exit__, None, None, None)
+
+    def recover(self, client):
+        return history.recover(client, "jdubois", "999", NOW)
+
+    def test_restores_failed_run_artifact_without_reading_job_logs(self):
+        client = FakeGitHub(
+            [artifact()], [run(conclusion="failure")],
+            downloads={"/actions/artifacts/1/zip": archive(inventory())},
+        )
+        self.assertEqual(inventory(), self.recover(client))
+        self.assertEqual(["/actions/artifacts/1/zip"], client.requested)
+        self.assertIsNone(client.bounds)
+
+    def test_selects_freshest_by_creation_and_id_not_run_status(self):
+        client = FakeGitHub(
+            [artifact(9, created_at=OLD), artifact(1), artifact(2)],
+            [run(conclusion="cancelled")],
+            downloads={"/actions/artifacts/2/zip": archive(inventory())},
+        )
+        self.recover(client)
+        self.assertEqual(["/actions/artifacts/2/zip"], client.requested)
+
+    def test_accepts_workflow_run_attempt_suffix_without_unrelated_artifacts(self):
+        client = FakeGitHub(
+            [
+                artifact(5, name=f"{history.ARTIFACT}-11-1"),
+                artifact(4, name=f"{history.ARTIFACT}-10-0"),
+                artifact(3, name=f"{history.ARTIFACT}-10-unrelated"),
+                artifact(2, name=f"{history.ARTIFACT}-10-2"),
+                artifact(1),
+            ],
+            [run(conclusion="failure")],
+            downloads={"/actions/artifacts/2/zip": archive(inventory())},
+        )
+        self.assertEqual(inventory(), self.recover(client))
+        self.assertEqual(["/actions/artifacts/2/zip"], client.requested)
+
+    def test_restores_current_run_earlier_attempt_with_optional_plan(self):
+        for status, conclusion in (("completed", "failure"), ("in_progress", None)):
+            with self.subTest(status=status):
+                client = FakeGitHub(
+                    [
+                        artifact(1),
+                        artifact(3, 999, name=f"{history.ARTIFACT}-999-2"),
+                        artifact(2, 999, name=f"{history.ARTIFACT}-999-1"),
+                    ],
+                    [run(), run(999, status=status, conclusion=conclusion, run_attempt=3)],
+                    downloads={
+                        "/actions/artifacts/3/zip": archive(inventory(), {"operations": []})
+                    },
+                )
+                self.assertEqual(inventory(), self.recover(client))
+                self.assertEqual(["/actions/artifacts/3/zip"], client.requested)
+                self.assertIsNone(client.bounds)
+
+    def test_restores_exact_legacy_name_from_current_run(self):
+        client = FakeGitHub(
+            [artifact(run_id=999)], [run(999, conclusion="failure")],
+            downloads={"/actions/artifacts/1/zip": archive(inventory())},
+        )
+        self.assertEqual(inventory(), self.recover(client))
+        self.assertIsNone(client.bounds)
+
+    def test_ignores_other_workflows_branches_and_expired_artifacts(self):
+        client = FakeGitHub(
+            [
+                artifact(10, 15),
+                artifact(9, 14, workflow_run={"id": 14, "head_branch": "feature"}),
+                artifact(7, expired=True),
+                artifact(6, expires_at=OLD),
+                artifact(5, name="unrelated-inventory"),
+                artifact(4),
+            ],
+            [run(15, workflow_id=100), run()],
+            downloads={"/actions/artifacts/4/zip": archive(inventory())},
+        )
+        self.assertEqual(inventory(), self.recover(client))
+        self.assertEqual([15, 10], client.run_reads)
+        self.assertEqual(["/actions/artifacts/4/zip"], client.requested)
+
+    def test_verifies_actual_run_branch_not_only_artifact_branch(self):
+        client = FakeGitHub([artifact()], [run(head_branch="feature")])
+        result = self.recover(client)
+        self.assertEqual({}, result["repositories"][REPO])
+        self.assertFalse(client.requested)
+
+    def test_wrong_namespace_is_fatal_without_bootstrap_or_stale_fallback(self):
+        client = FakeGitHub(
+            [artifact(), artifact(2, created_at=OLD)], [run()],
+            downloads={"/actions/artifacts/1/zip": archive(inventory("other"))},
+        )
+        with self.assertRaisesRegex(history.HistoryError, "namespace"):
+            self.recover(client)
+        self.assertIsNone(client.bounds)
+
+    def test_unavailable_artifact_is_fatal_instead_of_losing_journal(self):
+        for status in (401, 403, 404, 410, 500):
+            with self.subTest(status=status):
+                client = FakeGitHub(
+                    [artifact()], [run()],
+                    downloads={"/actions/artifacts/1/zip": history.APIError(status)},
+                )
+                with self.assertRaises(history.APIError):
+                    self.recover(client)
+                self.assertIsNone(client.bounds)
+
+    def test_invalid_zip_and_inventory_are_fatal(self):
+        bad_digest = inventory()
+        bad_digest["repositories"][REPO] = {"sha256:short": OLD}
+        bad_repo = inventory()
+        bad_repo["repositories"]["unrelated-image"] = {}
+        bad_timestamp = inventory()
+        bad_timestamp["repositories"][REPO] = {D1: "2026-09-01"}
+        for data in (b"not a zip", archive(bad_digest), archive(bad_repo), archive(bad_timestamp)):
+            with self.subTest(data=data[:10]):
+                client = FakeGitHub(
+                    [artifact()], [run()],
+                    downloads={"/actions/artifacts/1/zip": data},
+                )
+                with self.assertRaises(history.HistoryError):
+                    self.recover(client)
+
+    def test_zip_entries_never_extracted_or_path_traversed(self):
+        content = io.BytesIO()
+        with zipfile.ZipFile(content, "w") as zipped:
+            zipped.writestr("../inventory.json", json.dumps(inventory()))
+        client = FakeGitHub(
+            [artifact()], [run()],
+            downloads={"/actions/artifacts/1/zip": content.getvalue()},
+        )
+        with self.assertRaisesRegex(history.HistoryError, "contain inventory.json"):
+            self.recover(client)
+
+    def test_bootstrap_reads_only_six_merge_logs_for_a_successful_run(self):
+        jobs = [merge_job(i + 20, repo) for i, repo in enumerate(history.REPOSITORIES)]
+        jobs.extend(build_job(i + 30, repo) for i, repo in enumerate(history.REPOSITORIES))
+        client = FakeGitHub(
+            runs=[run()], jobs={10: jobs},
+            downloads={
+                f"/actions/jobs/{i + 20}/logs": merge_log(repo)
+                for i, repo in enumerate(history.REPOSITORIES)
+            },
+        )
+        result = self.recover(client)
+        self.assertEqual(set(history.REPOSITORIES), set(result["repositories"]))
+        for records in result["repositories"].values():
+            self.assertEqual({D1: NEW, D2: NEW, D3: NEW}, records)
+        self.assertEqual(6, len(client.requested))
+        self.assertEqual((NOW - timedelta(days=90), NOW), client.bounds)
+        self.assertIn("90-day", self.stderr.getvalue())
+        self.assertIn("::warning::", self.stderr.getvalue())
+        self.assertIn("not proof", self.stderr.getvalue())
+
+    def test_build_fallback_after_failed_merge_and_partial_run(self):
+        for merge_conclusion in ("failure", "cancelled", "skipped"):
+            with self.subTest(conclusion=merge_conclusion):
+                client = FakeGitHub(
+                    runs=[run(conclusion="failure")],
+                    jobs={10: [merge_job(conclusion=merge_conclusion), build_job()]},
+                    downloads={
+                        "/actions/jobs/20/logs": log("##[error]merge failed"),
+                        "/actions/jobs/21/logs": build_log(),
+                    },
+                )
+                result = self.recover(client)
+                self.assertEqual({D1: NEW}, result["repositories"][REPO])
+
+    def test_failed_merge_can_recover_partially_pushed_index_too(self):
+        client = FakeGitHub(
+            runs=[run(conclusion="failure")],
+            jobs={10: [merge_job(conclusion="failure"), build_job()]},
+            downloads={
+                "/actions/jobs/20/logs": log(f"#1 0.1 pushing {D3} to {IMAGE}:20260901"),
+                "/actions/jobs/21/logs": build_log(),
+            },
+        )
+        self.assertEqual({D1: NEW, D3: NEW}, self.recover(client)["repositories"][REPO])
+
+    def test_successful_merge_does_not_hide_orphan_pushes_from_another_attempt(self):
+        client = FakeGitHub(
+            runs=[run(conclusion="failure")],
+            jobs={10: [
+                merge_job(run_attempt=1),
+                build_job(run_attempt=2),
+            ]},
+            downloads={
+                "/actions/jobs/20/logs": merge_log(),
+                "/actions/jobs/21/logs": build_log().replace(D1.encode(), BASE.encode()),
+            },
+        )
+        self.assertEqual(
+            {D1: NEW, D2: NEW, D3: NEW, BASE: NEW},
+            self.recover(client)["repositories"][REPO],
+        )
+
+    def test_expired_logs_are_reported_and_successful_builds_still_recovered(self):
+        for status in (404, 410):
+            client = FakeGitHub(
+                runs=[run()], jobs={10: [merge_job(), build_job()]},
+                downloads={
+                    "/actions/jobs/20/logs": history.APIError(status),
+                    "/actions/jobs/21/logs": build_log(),
+                },
+            )
+            self.assertEqual({D1: NEW}, self.recover(client)["repositories"][REPO])
+            self.assertIn(f"HTTP {status}", self.stderr.getvalue())
+            self.assertIn("1 job logs unavailable", self.stderr.getvalue())
+
+    def test_log_auth_rate_limit_and_server_errors_are_not_swallowed(self):
+        for status in (401, 403, 429, 500):
+            client = FakeGitHub(
+                runs=[run()], jobs={10: [merge_job()]},
+                downloads={"/actions/jobs/20/logs": history.APIError(status)},
+            )
+            with self.assertRaises(history.APIError):
+                self.recover(client)
+
+    def test_bootstrap_filters_run_identity_status_and_temporal_window(self):
+        excluded = [
+            run(11, head_branch="feature"),
+            run(12, workflow_id=43),
+            run(13, status="in_progress"),
+            run(999),
+            run(14, created_at=history.iso(NOW - timedelta(days=91))),
+            run(15, created_at=history.iso(NOW + timedelta(hours=1))),
+        ]
+        client = FakeGitHub(
+            runs=excluded + [run()], jobs={10: [merge_job()]},
+            downloads={"/actions/jobs/20/logs": merge_log()},
+        )
+        self.assertEqual({D1: NEW, D2: NEW, D3: NEW}, self.recover(client)["repositories"][REPO])
+        self.assertEqual(["/actions/jobs/20/logs"], client.requested)
+
+    def test_uses_maximum_run_updated_timestamp_across_repushes(self):
+        client = FakeGitHub(
+            runs=[run(), run(11, updated_at=OLD)],
+            jobs={10: [merge_job()], 11: [merge_job(21)]},
+            downloads={
+                "/actions/jobs/20/logs": merge_log(),
+                "/actions/jobs/21/logs": merge_log(),
+            },
+        )
+        self.assertEqual({D1: NEW, D2: NEW, D3: NEW}, self.recover(client)["repositories"][REPO])
+
+    def test_wrong_job_identity_is_not_parsed(self):
+        client = FakeGitHub(
+            runs=[run()], jobs={10: [
+                merge_job(name=f"Post Merge {REPO} manifests"),
+                build_job(name=f"Build, smoke-test and publish {REPO}-evil (linux/amd64)"),
+            ]},
+        )
+        self.assertEqual({}, self.recover(client)["repositories"][REPO])
+        self.assertFalse(client.requested)
+
+    def test_workflow_endpoint_identity_is_checked(self):
+        client = Mock()
+        client.json.return_value = {"id": 42, "path": ".github/workflows/other.yml"}
+        with self.assertRaisesRegex(history.HistoryError, "identity"):
+            self.recover(client)
+        client.pages.assert_not_called()
+
+
+class ParserTests(unittest.TestCase):
+    def test_merge_accepts_masked_and_real_namespace_and_only_actual_manifest_records(self):
+        content = merge_log() + log(
+            f"Run actions/checkout@{BASE}",
+            f"#1 FROM docker.io/library/ubuntu@{CONFIG}",
+            f"#1 0.0 copying {BASE} from {IMAGE}@{CONFIG} to {IMAGE}",
+            f"#1 0.0 pushing {CONFIG} to {IMAGE}-evil:latest",
+            f"#1 0.0 pushing {CONFIG} to docker.io/other/{REPO}:latest",
+            f"#1 0.0 pushing {CONFIG} to ghcr.io/jdubois/{REPO}:latest",
+        )
+        self.assertEqual({D1, D2, D3}, history.merge_digests(content, "jdubois", REPO))
+        self.assertEqual(
+            {D1, D2, D3},
+            history.merge_digests(content.replace(b"***", b"jdubois"), "jdubois", REPO),
+        )
+
+    def test_build_requires_export_and_successful_push_within_exact_step(self):
+        content = build_log() + log(
+            f"#18 exporting manifest {D2} done",
+            f"#18 pushing manifest for {IMAGE}-evil 0.5s done",
+            f"#19 exporting manifest {D3} done",
+            f"#19 pushing manifest for {IMAGE}",
+        ) + log(
+            f"#17 exporting manifest {BASE} done",
+            f"#17 pushing manifest for {IMAGE} 0.5s done",
+            at="2026-09-01T08:02:00Z",
+        )
+        self.assertEqual(
+            {D1}, history.build_digests(content, "jdubois", REPO, build_job()["steps"])
+        )
+        wrong_step = copy.deepcopy(build_job()["steps"])
+        wrong_step[0]["name"] = "Build the image for smoke testing"
+        self.assertEqual(set(), history.build_digests(content, "jdubois", REPO, wrong_step))
+
+    def test_push_step_end_timestamp_includes_fractional_log_records(self):
+        content = build_log().replace(b"08:03:05.1234567", b"08:03:10.9999999")
+        self.assertEqual(
+            {D1}, history.build_digests(content, "jdubois", REPO, build_job()["steps"])
+        )
+
+    def test_failed_push_step_can_still_have_a_completed_push(self):
+        steps = build_job()["steps"]
+        steps[0]["conclusion"] = "failure"
+        self.assertEqual(
+            {D1}, history.build_digests(build_log(), "jdubois", REPO, steps)
+        )
+
+    def test_ansi_color_codes_are_removed(self):
+        content = merge_log().replace(b"#1", b"\x1b[32m#1").replace(b"\n", b"\x1b[0m\n")
+        self.assertEqual({D1, D2, D3}, history.merge_digests(content, "jdubois", REPO))
+
+
+class GitHubTests(unittest.TestCase):
+    def setUp(self):
+        self.client = history.GitHub("jdubois/boot-ui", "test-secret")
+
+    def test_pagination_uses_local_page_numbers_not_untrusted_links(self):
+        self.client.json = Mock(side_effect=[
+            {"total_count": 101, "artifacts": [{"id": number} for number in range(100)]},
+            {"total_count": 101, "artifacts": [{"id": 100}]},
+        ])
+        result = list(self.client.pages(
+            "/actions/artifacts", "artifacts", {"name": history.ARTIFACT}
+        ))
+        self.assertEqual(101, len(result))
+        self.assertEqual(
+            [
+                f"/actions/artifacts?name={history.ARTIFACT}&per_page=100&page=1",
+                f"/actions/artifacts?name={history.ARTIFACT}&per_page=100&page=2",
+            ],
+            [call.args[0] for call in self.client.json.call_args_list],
+        )
+
+    def test_repeated_or_truncated_pagination_fails_closed(self):
+        for final in ([{"id": 0}], []):
+            self.client.json = Mock(side_effect=[
+                {"total_count": 201, "jobs": [{"id": number} for number in range(100)]},
+                {"total_count": 201, "jobs": final},
+            ])
+            with self.assertRaises(history.HistoryError):
+                list(self.client.pages("/actions/runs/10/jobs", "jobs"))
+
+    def test_run_history_splits_queries_above_github_thousand_run_limit(self):
+        self.client.json = Mock(side_effect=[
+            {"total_count": 1001},
+            {"total_count": 1, "workflow_runs": [run()]},
+            {"total_count": 2, "workflow_runs": [run(), run(11)]},
+        ])
+        result = list(self.client.runs(NOW - timedelta(days=90), NOW))
+        self.assertEqual([10, 11], [item["id"] for item in result])
+        self.assertEqual(3, self.client.json.call_count)
+        for call in self.client.json.call_args_list:
+            params = parse_qs(urlsplit(call.args[0]).query)
+            self.assertEqual(["main"], params["branch"])
+            self.assertIn("..", params["created"][0])
+
+    def test_workflow_runs_and_jobs_are_paginated(self):
+        for key, path in (
+            ("workflow_runs", "/actions/workflows/docker-publish.yml/runs"),
+            ("jobs", "/actions/runs/10/jobs"),
+        ):
+            with self.subTest(key=key):
+                self.client.json = Mock(side_effect=[
+                    {"total_count": 101, key: [{"id": n} for n in range(100)]},
+                    {"total_count": 101, key: [{"id": 100}]},
+                ])
+                self.assertEqual(101, len(list(self.client.pages(path, key))))
+                self.assertEqual(2, self.client.json.call_count)
+
+    def test_signed_storage_redirect_drops_authorization_and_keeps_timeout(self):
+        signed = "https://productionresultssa7.blob.core.windows.net/logs/job?sig=signed-secret"
+        response = Mock()
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=False)
+        response.read.return_value = b"job logs"
+        self.client.opener.open = Mock(side_effect=[
+            HTTPError(
+                "https://api.github.com", 302, "redirect",
+                {"Location": signed}, io.BytesIO(),
+            ),
+            response,
+        ])
+        self.assertEqual(b"job logs", self.client.download("/actions/jobs/20/logs"))
+        calls = self.client.opener.open.call_args_list
+        self.assertEqual("Bearer test-secret", calls[0].args[0].get_header("Authorization"))
+        self.assertIsNone(calls[1].args[0].get_header("Authorization"))
+        self.assertEqual(signed, calls[1].args[0].full_url)
+        self.assertTrue(all(call.kwargs["timeout"] == 45 for call in calls))
+
+    def test_redirect_to_unapproved_host_never_receives_request(self):
+        for location in (
+            "http://productionresultssa7.blob.core.windows.net/logs",
+            "https://api.github.com.attacker.example/logs",
+            "https://attacker.example/logs",
+            "https://productionresultssa7.blob.core.windows.net@attacker.example/logs",
+            "https://productionresultssa7.blob.core.windows.net:444/logs",
+            "https://productionresultssa7.blob.core.windows.net:invalid/logs",
+            "https://[malformed/logs",
+        ):
+            with self.subTest(location=location):
+                self.client.opener.open = Mock(side_effect=HTTPError(
+                    history.API, 302, "redirect", {"Location": location}, io.BytesIO()
+                ))
+                with self.assertRaisesRegex(history.HistoryError, "Unapproved"):
+                    self.client.download("/actions/jobs/20/logs")
+                self.assertEqual(1, self.client.opener.open.call_count)
+
+    def test_api_json_requests_do_not_follow_redirects(self):
+        self.client.opener.open = Mock(side_effect=HTTPError(
+            history.API, 302, "redirect",
+            {"Location": "https://productionresultssa7.blob.core.windows.net/logs"},
+            io.BytesIO(),
+        ))
+        with self.assertRaises(history.APIError):
+            self.client.json("/actions/workflows/docker-publish.yml")
+        self.assertEqual(1, self.client.opener.open.call_count)
+
+    def test_http_error_streams_close_on_failure_and_rejected_redirect(self):
+        for status in (302, 403, 404):
+            with self.subTest(status=status):
+                stream = io.BytesIO(b"response")
+                self.client.opener.open = Mock(side_effect=HTTPError(
+                    history.API, status, "error",
+                    {"Location": "https://unapproved.example/logs"}, stream,
+                ))
+                with self.assertRaises(history.HistoryError):
+                    self.client.download("/actions/jobs/20/logs")
+                self.assertTrue(stream.closed)
+
+    def test_transport_errors_never_expose_tokens_signed_urls_or_response_bodies(self):
+        for error in (
+            URLError("test-secret signed-secret"),
+            HTTPError(history.API, 403, "test-secret", {}, io.BytesIO(b"signed-secret")),
+        ):
+            self.client.opener.open = Mock(side_effect=error)
+            with self.assertRaises(history.HistoryError) as caught:
+                self.client.download("/actions/jobs/20/logs")
+            self.assertNotIn("test-secret", str(caught.exception))
+            self.assertNotIn("signed-secret", str(caught.exception))
+
+    def test_auth_and_repository_inputs_are_required(self):
+        with self.assertRaises(history.HistoryError):
+            history.GitHub("jdubois/boot-ui", "")
+        with self.assertRaises(history.HistoryError):
+            history.GitHub("jdubois/boot-ui?token=bad", "token")
+        with self.assertRaises(history.HistoryError):
+            self.client.get("https://attacker.example")
+        with self.assertRaises(history.HistoryError):
+            history.GitHub("jdubois/boot-ui", "token\nmalformed")
+
+
+class CommandTests(unittest.TestCase):
+    def test_cli_writes_exact_inventory_schema(self):
+        environment = {
+            "GH_TOKEN": "test-secret", "GITHUB_REPOSITORY": "jdubois/boot-ui",
+            "GITHUB_RUN_ID": "999",
+        }
+        with patch.dict(history.os.environ, environment, clear=True), \
+                patch.object(history, "GitHub") as client, \
+                patch.object(history, "recover", return_value=inventory()) as recover, \
+                patch.object(history, "Path") as path:
+            self.assertEqual(
+                0, history.main(["--output", "inventory.json", "--namespace", "jdubois"])
+            )
+            client.assert_called_once_with("jdubois/boot-ui", "test-secret")
+            recover.assert_called_once_with(client.return_value, "jdubois", "999")
+            written = path.return_value.write_text.call_args.args[0]
+            self.assertEqual(inventory(), json.loads(written))
+
+    def test_failure_is_nonzero_and_never_overwrites_inventory(self):
+        with patch.dict(history.os.environ, {}, clear=True), \
+                patch.object(history, "Path") as path, \
+                redirect_stderr(io.StringIO()) as stderr:
+            self.assertEqual(
+                1, history.main(["--output", "inventory.json", "--namespace", "jdubois"])
+            )
+            path.assert_not_called()
+            self.assertIn("ERROR:", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check release workflow integrity
         run: bash .github/scripts/check-release-integrity.sh
 
+      - name: Test Docker image retention
+        run: python3 -B -m unittest discover -s .github/scripts -p 'test_docker_retention*.py'
+
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v6
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,11 +18,12 @@ name: Publish Docker images
 # The images are published once a day from the main branch (scheduled events run
 # against the default branch) and can also be built on demand from the Actions tab.
 #
-# The workflow runs in strictly ordered phases, and tagging is all-or-nothing: no
-# usable (tagged) image reaches Docker Hub unless every image on every platform builds
-# and passes its smoke test. Each verified image is pushed by digest only (untagged, and
-# therefore invisible until tagged); the rolling, dated and short-SHA tags are applied
-# later, in a single merge phase that runs only if every build succeeded.
+# Release tagging starts only after every image/platform passes its smoke test.
+# Each verified platform image first receives a unique build-* retention tag so it
+# remains discoverable even if another build fails or the workflow is interrupted.
+# These internal, single-platform tags are not releases. The rolling, dated and
+# short-SHA release tags are applied later by the merge phase, after the combined
+# index also receives its own unique build-<run>-<attempt>-index retention tag.
 #
 #   1. docker-config - validate the sample app's full Docker stack (the "docker"
 #      Spring profile: PostgreSQL, Redis and Ollama from
@@ -43,26 +44,24 @@ name: Publish Docker images
 #      container and starts it again from the persisted checkpoint, verifying that the
 #      restore serves BootUI and comes up at least twice as fast as the initial
 #      boot-and-checkpoint start. Only once the smoke test passes does the job push that
-#      exact image to Docker Hub by digest (no tags): the push reuses the layers just
+#      exact image to Docker Hub with a build-* retention tag: the push reuses the layers just
 #      built in this job's local Buildx cache (backed by a per-image, per-platform GitHub
 #      Actions layer cache), so it is a cache hit that only assembles and pushes - the
 #      tested image is published, never a rebuild of it, and the expensive native-image
 #      compilation is never repeated. A failed build or smoke test on any image/platform
-#      fails its job, so the merge phase below never runs and no tag is ever applied.
+#      fails its job, so the merge phase below never runs and no release tag is applied.
 #
 #   3. merge - assemble the tagged multi-arch manifest list for each image (a matrix
 #      of 6 images) from the per-platform digests pushed in phase 2, applying the
 #      rolling `latest`, dated and short-SHA tags. Runs only if every build job
 #      succeeded.
 #
-#   4. prune - delete dated/SHA tags older than one week from each repository (the
-#      rolling `latest` tag is always kept) so old daily images do not accumulate,
-#      since Docker Hub has no built-in retention policy. Deleting a tag only removes the
-#      tag pointer, so this phase then also sweeps the now-orphaned, untagged per-platform
-#      child manifests that every build pushes by digest (the merge phase stitches those
-#      digests into the tagged manifest list, but Docker Hub never garbage-collects them and
-#      the tags API does not even list them). Runs only after a successful merge, so old
-#      images are pruned only once fresh ones have actually replaced them.
+#   4. prune - always run, including after failed/skipped builds. Delete tags older
+#      than seven days by last push (not pull), preserving latest and its entire
+#      manifest graph. Upload a digest inventory BEFORE removing tags, then delete
+#      unreferenced indexes before their children via the supported registry API.
+#      Docker Hub reclaims unreferenced layers asynchronously; shared layers remain.
+#      The inventory also recovers known legacy orphans from available Actions logs.
 #
 # Multi-arch is produced by building each image once per platform on a *native* runner
 # (amd64 on ubuntu-latest, arm64 on ubuntu-24.04-arm) rather than under QEMU emulation:
@@ -77,7 +76,7 @@ name: Publish Docker images
 #   DOCKERHUB_USERNAME  Docker Hub account/namespace the images are pushed to.
 #   DOCKERHUB_TOKEN     Docker Hub access token (Account Settings > Personal access
 #                       tokens). It must have "Read, Write, Delete" scope: Write to
-#                       push images and Delete to prune old tags. Do not use the
+#                       push images and Delete to prune tags and manifests. Do not use the
 #                       account password.
 
 on:
@@ -89,13 +88,19 @@ on:
   workflow_dispatch:
     inputs:
       prune_dry_run:
-        description: 'Preview untagged-manifest pruning without deleting (dry run)'
+        description: 'Preview retention without deleting any tags or manifests'
+        type: boolean
+        default: false
+      cleanup_only:
+        description: 'Run retention without rebuilding the images'
         type: boolean
         default: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # All refs publish to the same repositories. Never interrupt a cleanup between
+  # tag and manifest deletion, or let a second publisher race its retained graph.
+  group: docker-hub-publish
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -103,6 +108,7 @@ permissions:
 jobs:
   docker-config:
     name: Validate the Docker-based configuration
+    if: ${{ !inputs.cleanup_only }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -480,7 +486,7 @@ jobs:
           fi
           echo "OK: CRaC restore (${second_start_seconds}s) is at least 2x faster than the initial start (${FIRST_START_SECONDS}s)."
 
-      - name: Push the smoke-tested image by digest
+      - name: Push the smoke-tested image with a retention tag
         id: build
         uses: docker/build-push-action@v7
         with:
@@ -493,9 +499,10 @@ jobs:
           # already in this job's local Buildx cache - and in the GitHub Actions cache
           # written by the build-and-load step above (same image/platform scope) - so
           # this is a cache hit that only assembles and pushes: the (expensive, native)
-          # build is never repeated. Push the per-platform image by digest only (no
-          # tags); the merge job builds the tagged manifest list from these digests.
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # build is never repeated. Unique retention tags also cover partial or
+          # cancelled builds; merge still consumes the exact per-platform digests.
+          tags: ${{ env.REGISTRY_IMAGE }}:build-${{ github.run_id }}-${{ github.run_attempt }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ env.PLATFORM_PAIR }}
           # Do not attach SLSA provenance / SBOM attestations. They would be pushed as
           # extra "unknown/unknown" manifests alongside each platform image, and once
@@ -535,8 +542,7 @@ jobs:
   merge:
     name: Merge ${{ matrix.image }} manifests
     runs-on: ubuntu-latest
-    # Tag and publish only once every per-platform image has been pushed by digest, so
-    # the rolling tags are applied atomically across all images (all-or-nothing).
+    # Apply release tags only after every smoke-tested platform image was pushed.
     needs: build
     if: github.repository == 'jdubois/boot-ui'
     environment: docker-hub
@@ -586,165 +592,77 @@ jobs:
             type=schedule,pattern={{date 'YYYYMMDD'}}
             type=sha,format=short
 
-      - name: Create and push the tagged manifest list
+      - name: Create the retention-tagged manifest list
         working-directory: ${{ runner.temp }}/digests
         run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+          docker buildx imagetools create \
+            -t "${REGISTRY_IMAGE}:build-${{ github.run_id }}-${{ github.run_attempt }}-index" \
             $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+      # Anchor the index before moving any release tag. Otherwise two interrupted
+      # publishes of the same commit/day can orphan an undiscoverable index even
+      # though its platform images still have retention tags.
+      - name: Apply release tags to the retained manifest list
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            "${REGISTRY_IMAGE}:build-${{ github.run_id }}-${{ github.run_attempt }}-index"
 
       - name: Inspect the published manifest list
         run: docker buildx imagetools inspect "${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}"
 
   prune:
-    name: Prune Docker Hub tags (and untagged manifests when enabled)
+    name: Prune expired Docker Hub images
     runs-on: ubuntu-latest
-    # Prune only after a successful merge, so old daily images are removed only once
-    # fresh ones have replaced them - never pruning a repository down to a stale
-    # `latest` because today's build failed.
-    needs: merge
-    if: github.repository == 'jdubois/boot-ui'
+    needs: [docker-config, build, merge]
+    # Cleanup also runs after failed/skipped builds. Other refs may only preview.
+    if: ${{ always() && github.repository == 'jdubois/boot-ui' && (github.ref == 'refs/heads/main' || inputs.prune_dry_run) }}
     environment: docker-hub
-    timeout-minutes: 10
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      actions: read
     env:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      # Tags whose last push is older than this many days are deleted.
-      MAX_AGE_DAYS: '7'
+      GH_TOKEN: ${{ github.token }}
+      RETENTION_DIR: ${{ runner.temp }}/docker-retention
+      PRUNE_DRY_RUN: ${{ inputs.prune_dry_run || false }}
     steps:
-      - name: Delete tags older than ${{ env.MAX_AGE_DAYS }} days
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Restore inventory or recover legacy manifest digests
+        run: >
+          python3 .github/scripts/docker_retention_history.py
+          --namespace "$DOCKERHUB_USERNAME"
+          --output "$RETENTION_DIR/previous.json"
+
+      - name: Plan seven-day retention
+        run: >
+          python3 .github/scripts/docker_retention.py
+          --namespace "$DOCKERHUB_USERNAME" plan
+          --inventory "$RETENTION_DIR/previous.json"
+          --inventory-out "$RETENTION_DIR/inventory.json"
+          --output "$RETENTION_DIR/plan.json"
+
+      # This is a write-ahead journal, not just a report. Do not move deletion
+      # before the upload: otherwise a failure can orphan digests permanently.
+      - name: Preserve inventory before deleting tags
+        uses: actions/upload-artifact@v7
+        with:
+          name: docker-retention-inventory-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.RETENTION_DIR }}/inventory.json
+            ${{ env.RETENTION_DIR }}/plan.json
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Apply retention and confirm manifest deletion
         run: |
-          set -euo pipefail
-
-          # Exchange the access token for a short-lived Docker Hub API JWT.
-          token=$(curl -fsS -H 'Content-Type: application/json' \
-            -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
-            https://hub.docker.com/v2/users/login | jq -r '.token')
-          if [ -z "$token" ] || [ "$token" = 'null' ]; then
-            echo 'Failed to authenticate to the Docker Hub API.' >&2
-            exit 1
+          args=()
+          if [ "$PRUNE_DRY_RUN" = 'true' ]; then
+            args+=(--dry-run)
           fi
-
-          cutoff=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
-
-          for repo in bootui-sample-app bootui-sample-app-aot bootui-sample-app-crac bootui-sample-app-native bootui-sample-app-webflux bootui-sample-app-quarkus; do
-            echo "::group::Pruning ${DOCKERHUB_USERNAME}/${repo}"
-            url="https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/${repo}/tags/?page_size=100"
-            while [ -n "$url" ] && [ "$url" != 'null' ]; do
-              resp=$(curl -fsS -H "Authorization: JWT ${token}" "$url")
-              while read -r name updated; do
-                # Always keep the rolling 'latest' tag.
-                [ "$name" = 'latest' ] && { echo "Keeping  ${repo}:${name} (latest)"; continue; }
-                updated_epoch=$(date -u -d "$updated" +%s)
-                if [ "$updated_epoch" -lt "$cutoff" ]; then
-                  echo "Deleting ${repo}:${name} (last updated ${updated})"
-                  curl -fsS -X DELETE -H "Authorization: JWT ${token}" \
-                    "https://hub.docker.com/v2/repositories/${DOCKERHUB_USERNAME}/${repo}/tags/${name}/"
-                else
-                  echo "Keeping  ${repo}:${name} (last updated ${updated})"
-                fi
-              done < <(echo "$resp" | jq -r '.results[] | "\(.name) \(.last_updated)"')
-              url=$(echo "$resp" | jq -r '.next')
-            done
-            echo "::endgroup::"
-          done
-
-      - name: Delete untagged manifests older than ${{ env.MAX_AGE_DAYS }} days
-        # The build phase pushes each per-platform image by digest (untagged); the merge
-        # phase stitches those digests into the tagged multi-arch manifest list. Deleting a
-        # tag above only removes the tag pointer - Docker Hub never garbage-collects the
-        # untagged per-platform child manifests, and the tags API does not even list them,
-        # so they accumulate. This step sweeps them via the images API (currently_tagged=false
-        # returns only untagged manifests) and the bulk delete-images endpoint. active_from is
-        # the same cutoff and is passed to delete-images as a server-side safety net, so nothing
-        # pushed or pulled within the window can be removed even by mistake.
-        #
-        # IMPORTANT - this is OPT-IN and disabled by default. The images / delete-images API it
-        # uses is only available to Docker Pro and Team plans (it returns 403/404 on Free) and
-        # uses Bearer auth, not the JWT scheme the older /v2/repositories tags API accepts. On
-        # the Free plan there is no safe automated way to reclaim untagged-manifest storage:
-        # deleting a tag does not free the underlying manifest, and the only Free operation that
-        # does - deleting the whole repository - would also reset these public images' stars and
-        # pull counts and make them unavailable during each rebuild. So the step runs only when
-        # the repository variable DOCKERHUB_UNTAGGED_PRUNE is set to 'true' (do that after
-        # upgrading to a Pro/Team plan). If it is enabled on a plan that lacks the API it still
-        # degrades gracefully - it warns and skips rather than failing the publish pipeline.
-        if: vars.DOCKERHUB_UNTAGGED_PRUNE == 'true'
-        env:
-          DRY_RUN: ${{ github.event.inputs.prune_dry_run || 'false' }}
-        run: |
-          set -euo pipefail
-
-          # Exchange the access token for a short-lived Docker Hub API JWT.
-          token=$(curl -fsS -H 'Content-Type: application/json' \
-            -d "{\"username\": \"${DOCKERHUB_USERNAME}\", \"password\": \"${DOCKERHUB_TOKEN}\"}" \
-            https://hub.docker.com/v2/users/login | jq -r '.token')
-          if [ -z "$token" ] || [ "$token" = 'null' ]; then
-            echo 'Failed to authenticate to the Docker Hub API.' >&2
-            exit 1
-          fi
-
-          # Untagged manifests last active (pushed or pulled) before this moment are pruned.
-          active_from=$(date -u -d "${MAX_AGE_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
-
-          for repo in bootui-sample-app bootui-sample-app-aot bootui-sample-app-crac bootui-sample-app-native bootui-sample-app-webflux bootui-sample-app-quarkus; do
-            echo "::group::Sweeping untagged manifests in ${DOCKERHUB_USERNAME}/${repo}"
-
-            # Collect the digests of untagged, inactive manifests older than the cutoff.
-            # The status / currently_tagged filters are applied again client-side so the
-            # sweep stays correct even if a paginated 'next' URL drops a query parameter.
-            digests=()
-            url="https://hub.docker.com/v2/namespaces/${DOCKERHUB_USERNAME}/repositories/${repo}/images?status=inactive&currently_tagged=false&active_from=${active_from}&ordering=last_activity&page_size=100"
-            while [ -n "$url" ] && [ "$url" != 'null' ]; do
-              # Capture the HTTP status (no -f) so a plan-gated 403/404 can be skipped gracefully.
-              body=$(mktemp)
-              status=$(curl -sS -o "$body" -w '%{http_code}' -H "Authorization: Bearer ${token}" "$url")
-              resp=$(cat "$body")
-              rm -f "$body"
-              if [ "$status" = '403' ] || [ "$status" = '404' ]; then
-                echo "::warning::Docker Hub returned HTTP ${status} for the image-management API. Untagged-manifest pruning requires a Docker Pro or Team plan; skipping. Untagged per-platform manifests must be removed manually from the Docker Hub UI."
-                echo "::endgroup::"
-                # Plan entitlement is account-wide, so the remaining repositories would fail too.
-                exit 0
-              fi
-              if [ "$status" != '200' ]; then
-                echo "Unexpected HTTP ${status} from the Docker Hub images API:" >&2
-                echo "$resp" >&2
-                exit 1
-              fi
-              while read -r digest; do
-                [ -n "$digest" ] && digests+=("$digest")
-              done < <(echo "$resp" | jq -r '
-                .results[]
-                | select(.status == "inactive")
-                | select([.tags[]? | select(.is_current)] | length == 0)
-                | .digest')
-              url=$(echo "$resp" | jq -r '.next')
-            done
-
-            if [ "${#digests[@]}" -eq 0 ]; then
-              echo "No untagged manifests older than ${MAX_AGE_DAYS} days."
-              echo "::endgroup::"
-              continue
-            fi
-
-            echo "Found ${#digests[@]} untagged manifest(s) to delete (dry_run=${DRY_RUN})."
-
-            # Docker Hub caps each delete-images request at 25 manifests, so batch them.
-            for ((i = 0; i < ${#digests[@]}; i += 25)); do
-              batch=("${digests[@]:i:25}")
-              manifests=$(printf '%s\n' "${batch[@]}" \
-                | jq -R --arg repo "$repo" 'select(length > 0) | {repository: $repo, digest: .}' \
-                | jq -s '.')
-              payload=$(jq -n \
-                --argjson dry_run "$DRY_RUN" \
-                --arg active_from "$active_from" \
-                --argjson manifests "$manifests" \
-                '{dry_run: $dry_run, active_from: $active_from, manifests: $manifests}')
-              echo "Deleting batch of ${#batch[@]} manifest(s)..."
-              curl -fsS -X POST -H "Authorization: Bearer ${token}" -H 'Content-Type: application/json' \
-                -d "$payload" \
-                "https://hub.docker.com/v2/namespaces/${DOCKERHUB_USERNAME}/delete-images" \
-                | jq '.'
-            done
-            echo "::endgroup::"
-          done
+          python3 .github/scripts/docker_retention.py \
+            --namespace "$DOCKERHUB_USERNAME" apply \
+            --plan "$RETENTION_DIR/plan.json" "${args[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,47 @@ use the secret rather than copying registry credentials into the project.
 Without `--secret`, npm keeps its default registry configuration. There is no
 new requirement for normal developers or CI, and no secret is needed at runtime.
 
+### Docker Hub image retention
+
+The **Publish Docker images** workflow retains seven days of sample images, measured
+from their last push, not their last pull. `latest` and every manifest it references
+are always preserved, even if builds have failed for more than a week. Each
+smoke-tested platform image also receives a unique `build-<run>-<attempt>-<platform>`
+tag. The combined image index receives a `build-<run>-<attempt>-index` tag before
+release tags move. These internal retention tags make images and indexes from
+failed or interrupted publishes discoverable, including repeated builds of the
+same commit or day.
+
+Cleanup runs after the build jobs regardless of their outcome. It inventories all
+tags before deleting any, resolves image indexes recursively, and preserves every
+manifest reachable from retained tags. It then deletes expired tags, unreferenced
+indexes, and their unreferenced platform manifests, in that order. Layers are never
+deleted directly: Docker Hub reclaims unreferenced layers asynchronously and keeps
+layers shared with retained images. Registry permission failures and unconfirmed
+deletions fail the job rather than silently skipping cleanup.
+
+The `docker-retention-inventory-*` Actions artifact is a write-ahead journal, uploaded
+**before** any tags are removed. The next run restores it, including from a failed
+cleanup, so a partially deleted image remains discoverable. Do not manually remove
+these artifacts. Each run attempt creates a new journal with 90-day retention
+without overwriting the previous one. On first use, the workflow recovers legacy
+digests from available Docker publish logs; expired or
+missing logs limit that recovery and are reported explicitly. Content that predates
+available history may still need manual inventory through Docker Hub Image Management.
+
+Use **Run workflow** with `cleanup_only=true` to run retention without rebuilding.
+Set `prune_dry_run=true` to preview **both tag and manifest deletion** without deleting
+anything. A dry run still preserves an inventory artifact. Destructive cleanup runs
+only on `main`; other branches may preview. All publish runs are serialized across
+branches to prevent concurrent registry changes. `DOCKERHUB_TOKEN` must have
+**Read, Write, Delete** permissions; `DOCKERHUB_UNTAGGED_PRUNE` is no longer used.
+
+The scripts use Python's standard library. Run their offline regression suite with:
+
+```bash
+python3 -B -m unittest discover -s .github/scripts -p 'test_docker_retention*.py'
+```
+
 ### Software Bill of Materials (SBOM)
 
 Generate a CycloneDX SBOM covering every dependency across the whole reactor after an install:


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Replaces tag-only cleanup with manifest-aware Docker Hub retention so expired sample images can actually release storage.

- Keep all images pushed within the last seven days, plus `latest` and every manifest it references. Recent pulls do not extend retention.
- Give platform images and their combined index unique retention tags before moving release tags, keeping interrupted and repeated publishes discoverable.
- Save a write-ahead inventory artifact before removing tags, then delete unreferenced indexes before their children and confirm deletion. Never delete layer blobs directly; Docker Hub reclaims unreferenced layers asynchronously.
- Restore inventories across failed runs and reruns. Bootstrap legacy digests from available Docker publish logs, with explicit warnings about missing history and the 90-day recovery limit.
- Run cleanup after failed or skipped builds, serialize publishers across branches, and add `cleanup_only` plus a dry run covering both tags and manifests. Permission failures and unconfirmed deletions fail visibly.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

The existing workflow deleted expired tags but skipped its opt-in manifest cleanup. During the audit, Quarkus's September 1 tag was absent while its index, both platform manifests, and their large layers remained accessible. Docker Hub reported about 58 GB for the Quarkus repository.

The correction uses Docker Hub's documented registry deletion API rather than the optional image-management API. `DOCKERHUB_UNTAGGED_PRUNE` is no longer required. Quarkus's larger development-mode image is unchanged; reducing its individual image size is separate from fixing retention.

N/A - no linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally - N/A, no Java or application changes.
- [ ] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests - N/A, no HTTP application contract changes.
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082 - N/A, no application changes.
- [ ] Ran the affected Playwright suite(s) for browser-facing changes - N/A, no browser-facing changes.
- [x] Added or updated tests where applicable.

`python3 -B -W error::ResourceWarning -m unittest discover -s .github/scripts -p 'test_docker_retention*.py'` passes all **72 tests**, including local HTTP plan/dry-run/deletion flows across all six repositories, shared references, retention boundaries, interrupted cleanup recovery, pagination, authorization failures, asynchronous deletion, and legacy inventory restoration. The suite is wired into the baseline build workflow.

Action-reference and release-integrity guards, workflow YAML parsing, shell syntax checks, cleanup shellcheck, and `git diff --check` pass.

A live read-only Quarkus preview selected the three known expired manifests while protecting 21 retained manifests. Broader live planning succeeded, but the subsequent preview hit Docker Hub's anonymous rate limit. Discovery now uses HEAD for platform manifests to avoid unnecessary image pulls. **No live deletions were performed**, and authenticated deletion still needs validation with the workflow's Docker Hub credentials.

After merge, dispatch with `cleanup_only=true` and `prune_dry_run=true` for an authenticated preview, then disable dry run to apply retention. Manifests older than available historical logs may still require manual inventory.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

N/A.

## Checklist

- [ ] Documentation in `docs/` or `README.md` updated when behaviour changes - N/A for application documentation; workflow operation and recovery are documented in `CONTRIBUTING.md`.
- [x] Public API kept backward compatible, or a migration note added to the PR description.
- [x] No secrets, tokens, or local paths committed.