### PR TITLE
Fix native Security scans and compact unscored overview cards

### DIFF
--- a/.github/scripts/check-sample-security.py
+++ b/.github/scripts/check-sample-security.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Exercise the servlet sample's passive Security advisor, including native-image field metadata."""
+
+import http.cookiejar
+import json
+import sys
+import urllib.parse
+import urllib.request
+
+
+def check(base_url):
+    cookies = http.cookiejar.CookieJar()
+    client = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookies))
+    endpoint = base_url.rstrip("/") + "/bootui/api/security"
+
+    def read(request):
+        with client.open(request, timeout=60) as response:
+            return json.load(response)
+
+    read(endpoint)
+    token = next((cookie.value for cookie in cookies if cookie.name == "XSRF-TOKEN"), None)
+    assert token, "The servlet sample must issue its CSRF cookie"
+    report = read(
+        urllib.request.Request(
+            endpoint + "/scan",
+            data=b"{}",
+            headers={
+                "Content-Type": "application/json",
+                "Origin": base_url.rstrip("/"),
+                "X-XSRF-TOKEN": urllib.parse.unquote(token),
+            },
+        )
+    )
+    assert report["filterChainsAnalyzed"] == 3, "Application filter-chain inventory was not read"
+    assert report["evidence"]["usable"] is True, "No usable security evidence was observed"
+    assert report["analysisErrors"] == [], "Security rule evaluation failed"
+    assert report["scan"]["status"] == "PARTIAL", "Custom sample security remains partly unobserved"
+    assert report["evidence"]["coverageComplete"] is False, "Do not invent complete sample coverage"
+    assert report["evidence"]["limitations"], "The sample must retain its real observation limits"
+    assert not any(
+        reason.startswith("Filter chains:") for reason in report["evidence"]["limitations"]
+    ), "Framework chain metadata could not be read"
+    assert read(endpoint) == report, "Passive reads must retain the completed assessment"
+    print("OK: Security observed all 3 sample chains and retained usable, honestly partial evidence.")
+
+
+if __name__ == "__main__":
+    check(sys.argv[1])

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -414,6 +414,14 @@ jobs:
           curl -fsS -o /dev/null "${base_url}/bootui/"
           echo "OK: BootUI front end is served (/bootui/ -> 200)."
 
+          # The servlet variants share the real three-chain sample. A GET-only smoke test
+          # cannot detect lost private-field metadata in GraalVM's closed world.
+          case "$IMAGE_NAME" in
+            bootui-sample-app|bootui-sample-app-aot|bootui-sample-app-crac|bootui-sample-app-native)
+              python3 .github/scripts/check-sample-security.py "$base_url"
+              ;;
+          esac
+
           echo "Smoke test passed for ${IMAGE_REF}."
 
       - name: Verify the CRaC image restarts at least 2x faster from its checkpoint

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHints.java
@@ -1,5 +1,6 @@
 package io.github.jdubois.bootui.autoconfigure;
 
+import io.github.jdubois.bootui.autoconfigure.security.SecurityRuntimeHints;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -16,15 +17,15 @@ import org.springframework.util.ClassUtils;
  *
  * <p>This registrar is imported from {@link BootUiAutoConfiguration} via {@code @ImportRuntimeHints}
  * so the hints are only contributed when BootUI auto-configuration is on the classpath. It covers
- * two kinds of metadata that Spring's generic AOT processing cannot infer on its own:
+ * metadata that Spring's generic AOT processing cannot infer on its own:
  *
  * <ul>
  *   <li><b>Classpath resources</b> that BootUI reads at runtime through {@link ClassLoader} or
  *       {@code PathMatchingResourcePatternResolver} scanning. These are excluded from a native image
  *       unless registered, which would otherwise leave the Vulnerabilities and Config panels empty and
  *       the BootUI version reported as {@code unknown}.
- *   <li><b>Reflective method invocations</b> on well-known JDK and Spring Security types that BootUI
- *       discovers at runtime and calls reflectively.
+ *   <li><b>Reflective access</b> on well-known JDK and Spring types: public method invocations and
+ *       the security advisors' passive inspection of supported private framework fields.
  *   <li><b>DTO binding types</b> under {@code io.github.jdubois.bootui.core.dto} that Jackson can
  *       synthesize while serializing BootUI records, including array types derived from
  *       {@code List<...>} record components.
@@ -93,6 +94,7 @@ class BootUiRuntimeHints implements RuntimeHintsRegistrar {
         }
 
         registerDtoBindingHints(hints, classLoader);
+        new SecurityRuntimeHints().registerHints(hints, classLoader);
 
         // Heap Dump panel: HeapDumpService reflectively calls HotSpotDiagnosticMXBean#dumpHeap.
         hints.reflection()

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuntimeHints.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityRuntimeHints.java
@@ -1,0 +1,161 @@
+package io.github.jdubois.bootui.autoconfigure.security;
+
+import java.util.Set;
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+
+/**
+ * Field metadata for the security advisors' passive readers, not permission to invoke application
+ * callbacks. Public-method hints do not retain private chain inventories in a native image.
+ */
+public final class SecurityRuntimeHints implements RuntimeHintsRegistrar {
+
+    static final Set<String> FRAMEWORK_TYPES = Set.of(
+            "org.springframework.security.web.access.intercept.AuthorizationFilter",
+            "org.springframework.security.web.access.intercept.FilterSecurityInterceptor",
+            "org.springframework.security.web.context.SecurityContextHolderFilter",
+            "org.springframework.security.web.context.SecurityContextPersistenceFilter",
+            "org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter",
+            "org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter",
+            "org.springframework.security.web.authentication.www.BasicAuthenticationFilter",
+            "org.springframework.security.web.authentication.AnonymousAuthenticationFilter",
+            "org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter",
+            "org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter",
+            "org.springframework.security.web.authentication.ui.DefaultLogoutPageGeneratingFilter",
+            "org.springframework.security.web.authentication.ui.DefaultResourcesFilter",
+            "org.springframework.security.web.authentication.logout.LogoutFilter",
+            "org.springframework.security.web.authentication.AuthenticationFilter",
+            "org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter",
+            "org.springframework.security.web.csrf.CsrfFilter",
+            "org.springframework.security.web.session.SessionManagementFilter",
+            "org.springframework.security.web.session.ConcurrentSessionFilter",
+            "org.springframework.security.web.session.DisableEncodeUrlFilter",
+            "org.springframework.security.web.access.ExceptionTranslationFilter",
+            "org.springframework.security.web.savedrequest.RequestCacheAwareFilter",
+            "org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter",
+            "org.springframework.security.web.header.HeaderWriterFilter",
+            "org.springframework.security.web.transport.HttpsRedirectFilter",
+            "org.springframework.security.web.access.channel.ChannelProcessingFilter",
+            "org.springframework.security.web.debug.DebugFilter",
+            "org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy",
+            "org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy",
+            "org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy",
+            "org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy",
+            "org.springframework.security.web.authentication.session.ConcurrentSessionControlAuthenticationStrategy",
+            "org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy",
+            "org.springframework.security.web.csrf.CsrfAuthenticationStrategy",
+            "org.springframework.security.web.header.writers.HstsHeaderWriter",
+            "org.springframework.security.web.header.writers.ContentSecurityPolicyHeaderWriter",
+            "org.springframework.security.web.header.writers.XContentTypeOptionsHeaderWriter",
+            "org.springframework.security.web.header.writers.XXssProtectionHeaderWriter",
+            "org.springframework.security.web.header.writers.CacheControlHeadersWriter",
+            "org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter",
+            "org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter",
+            "org.springframework.security.web.header.writers.PermissionsPolicyHeaderWriter",
+            "org.springframework.security.web.header.writers.CrossOriginOpenerPolicyHeaderWriter",
+            "org.springframework.security.web.header.writers.CrossOriginEmbedderPolicyHeaderWriter",
+            "org.springframework.security.web.header.writers.CrossOriginResourcePolicyHeaderWriter",
+            "org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter",
+            "org.springframework.security.oauth2.server.resource.web.OAuth2ProtectedResourceMetadataFilter",
+            "org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter",
+            "org.springframework.security.oauth2.client.web.OAuth2AuthorizationCodeGrantFilter",
+            "org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter");
+
+    private static final String[] SHARED_TYPES = {
+        "org.springframework.core.env.AbstractEnvironment",
+        "org.springframework.core.env.MutablePropertySources",
+        "org.springframework.core.env.PropertySource",
+        "org.springframework.core.env.CommandLinePropertySource",
+        "org.springframework.core.env.CommandLineArgs",
+        "org.springframework.boot.origin.OriginTrackedValue",
+        "org.springframework.boot.support.SystemEnvironmentPropertySourceEnvironmentPostProcessor$OriginAwareSystemEnvironmentPropertySource",
+        "java.util.Collections$UnmodifiableMap"
+    };
+
+    private static final String[] SERVLET_TYPES = {
+        "org.springframework.security.web.FilterChainProxy",
+        "org.springframework.security.web.DefaultSecurityFilterChain",
+        "org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration$CompositeFilterChainProxy",
+        "org.springframework.security.config.annotation.web.configuration.WebMvcSecurityConfiguration$CompositeFilterChainProxy",
+        "org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter",
+        "org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter",
+        "org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices",
+        "org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices",
+        "org.springframework.security.web.context.DelegatingSecurityContextRepository",
+        "org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager",
+        "org.springframework.security.authorization.ObservationAuthorizationManager",
+        "org.springframework.security.authorization.SingleResultAuthorizationManager",
+        "org.springframework.security.authorization.AuthorizationDecision",
+        "org.springframework.security.authentication.ProviderManager",
+        "org.springframework.security.authentication.ObservationAuthenticationManager",
+        "org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider",
+        "org.springframework.security.authentication.dao.DaoAuthenticationProvider",
+        "org.springframework.security.crypto.password.DelegatingPasswordEncoder",
+        "org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder",
+        "org.springframework.util.function.SingletonSupplier",
+        "org.springframework.security.web.firewall.StrictHttpFirewall",
+        "org.springframework.security.web.PortMapperImpl",
+        "org.springframework.security.web.DefaultRedirectStrategy",
+        "org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher",
+        "org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher$HttpMethodRequestMatcher",
+        "org.springframework.security.web.util.matcher.OrRequestMatcher",
+        "org.springframework.security.web.util.matcher.AndRequestMatcher",
+        "org.springframework.security.web.util.matcher.NegatedRequestMatcher",
+        "org.springframework.web.util.pattern.PathPattern",
+        "org.springframework.web.filter.CorsFilter",
+        "org.springframework.web.cors.UrlBasedCorsConfigurationSource",
+        "org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider",
+        "org.springframework.security.oauth2.server.resource.authentication.OpaqueTokenAuthenticationProvider",
+        "org.springframework.security.authorization.method.AuthorizationManagerBeforeMethodInterceptor",
+        "org.springframework.security.authorization.method.AuthorizationManagerAfterMethodInterceptor",
+        "org.springframework.boot.webmvc.actuate.endpoint.web.AbstractWebMvcEndpointHandlerMapping",
+        "org.springframework.boot.webmvc.actuate.endpoint.web.WebMvcEndpointHandlerMapping",
+        "org.springframework.boot.actuate.endpoint.web.EndpointMapping",
+        "org.springframework.boot.actuate.endpoint.AbstractExposableEndpoint",
+        "org.springframework.boot.actuate.endpoint.annotation.AbstractDiscoveredEndpoint",
+        "org.springframework.boot.actuate.endpoint.web.annotation.DiscoveredWebEndpoint",
+        "org.springframework.boot.actuate.endpoint.web.annotation.DiscoveredWebOperation",
+        "org.springframework.boot.actuate.endpoint.EndpointId",
+        "org.springframework.boot.actuate.endpoint.web.WebOperationRequestPredicate",
+        "org.apache.catalina.core.ApplicationContextFacade",
+        "org.apache.catalina.core.ApplicationContext"
+    };
+
+    private static final String[] REACTIVE_TYPES = {
+        "org.springframework.security.web.server.MatcherSecurityWebFilterChain",
+        "org.springframework.security.web.server.authentication.AuthenticationWebFilter",
+        "org.springframework.security.oauth2.client.web.server.authentication.OAuth2LoginAuthenticationWebFilter",
+        "org.springframework.security.config.web.server.ServerHttpSecurity$OAuth2LoginSpec$OidcSessionRegistryAuthenticationWebFilter",
+        "org.springframework.security.web.server.transport.HttpsRedirectWebFilter",
+        "org.springframework.security.web.server.util.matcher.PathPatternParserServerWebExchangeMatcher",
+        "org.springframework.security.web.server.header.HttpHeaderWriterWebFilter",
+        "org.springframework.security.web.server.header.CompositeServerHttpHeadersWriter",
+        "org.springframework.security.web.server.header.StrictTransportSecurityServerHttpHeadersWriter",
+        "org.springframework.security.web.server.header.ContentSecurityPolicyServerHttpHeadersWriter",
+        "org.springframework.security.web.server.header.StaticServerHttpHeadersWriter",
+        "org.springframework.web.cors.reactive.CorsWebFilter",
+        "org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource"
+    };
+
+    @Override
+    public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+        // Spring 7 type hints include declared-method query metadata. The AOT ownership check
+        // only queries the factory method; adding invocation categories would be unnecessary.
+        hints.reflection()
+                .registerTypeIfPresent(
+                        classLoader, "io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration");
+        register(hints, classLoader, SHARED_TYPES);
+        register(hints, classLoader, SERVLET_TYPES);
+        register(hints, classLoader, REACTIVE_TYPES);
+        // Include concrete filters as well as their declaring superclasses: the reader walks
+        // getDeclaredField up the hierarchy, including negative lookups on a concrete filter.
+        register(hints, classLoader, FRAMEWORK_TYPES.toArray(String[]::new));
+    }
+
+    private static void register(RuntimeHints hints, ClassLoader classLoader, String[] types) {
+        for (String type : types) {
+            hints.reflection().registerTypeIfPresent(classLoader, type, MemberCategory.ACCESS_DECLARED_FIELDS);
+        }
+    }
+}

--- a/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
+++ b/bootui-spring-autoconfigure/src/main/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScanner.java
@@ -1,5 +1,7 @@
 package io.github.jdubois.bootui.autoconfigure.security;
 
+import static io.github.jdubois.bootui.autoconfigure.security.SecurityRuntimeHints.FRAMEWORK_TYPES;
+
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.AuthorizationMapping;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.ChainDetails;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.CorsConfigModel;
@@ -27,8 +29,10 @@ import java.util.Set;
 import java.util.function.Supplier;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.aot.BeanInstanceSupplier;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authorization.AuthorizationManager;
@@ -957,9 +961,20 @@ final class SecurityScanner {
                 || !configurable.containsBeanDefinition(name)
                 || configurable.getSingleton(name) != chain) return false;
         var definition = configurable.getBeanDefinition(name);
-        return "io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration"
-                        .equals(definition.getFactoryBeanName())
-                && name.equals(definition.getFactoryMethodName());
+        String configuration = "io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration";
+        if (!configuration.equals(definition.getFactoryBeanName())) return false;
+        if (name.equals(definition.getFactoryMethodName())) return true;
+        // AOT keeps the factory method in its native BeanInstanceSupplier rather than the
+        // definition's factoryMethodName. Inspect only that final framework implementation;
+        // getResolvedFactoryMethod() could dispatch to a custom InstanceSupplier callback.
+        if (definition instanceof RootBeanDefinition root
+                && root.getInstanceSupplier() instanceof BeanInstanceSupplier<?> supplier) {
+            Method method = supplier.getFactoryMethod();
+            return method != null
+                    && configuration.equals(method.getDeclaringClass().getName())
+                    && name.equals(method.getName());
+        }
+        return false;
     }
 
     private static FilterChainModel unknownChain(int index) {
@@ -989,57 +1004,6 @@ final class SecurityScanner {
                 ? value.getClass().getSimpleName()
                 : "Unknown";
     }
-
-    private static final Set<String> FRAMEWORK_TYPES = Set.of(
-            "org.springframework.security.web.access.intercept.AuthorizationFilter",
-            "org.springframework.security.web.access.intercept.FilterSecurityInterceptor",
-            "org.springframework.security.web.context.SecurityContextHolderFilter",
-            "org.springframework.security.web.context.SecurityContextPersistenceFilter",
-            "org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter",
-            "org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter",
-            "org.springframework.security.web.authentication.www.BasicAuthenticationFilter",
-            "org.springframework.security.web.authentication.AnonymousAuthenticationFilter",
-            "org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationFilter",
-            "org.springframework.security.web.authentication.ui.DefaultLoginPageGeneratingFilter",
-            "org.springframework.security.web.authentication.ui.DefaultLogoutPageGeneratingFilter",
-            "org.springframework.security.web.authentication.ui.DefaultResourcesFilter",
-            "org.springframework.security.web.authentication.logout.LogoutFilter",
-            "org.springframework.security.web.authentication.AuthenticationFilter",
-            "org.springframework.security.web.authentication.preauth.x509.X509AuthenticationFilter",
-            "org.springframework.security.web.csrf.CsrfFilter",
-            "org.springframework.security.web.session.SessionManagementFilter",
-            "org.springframework.security.web.session.ConcurrentSessionFilter",
-            "org.springframework.security.web.session.DisableEncodeUrlFilter",
-            "org.springframework.security.web.access.ExceptionTranslationFilter",
-            "org.springframework.security.web.savedrequest.RequestCacheAwareFilter",
-            "org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter",
-            "org.springframework.security.web.header.HeaderWriterFilter",
-            "org.springframework.security.web.transport.HttpsRedirectFilter",
-            "org.springframework.security.web.access.channel.ChannelProcessingFilter",
-            "org.springframework.security.web.debug.DebugFilter",
-            "org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy",
-            "org.springframework.security.web.authentication.session.SessionFixationProtectionStrategy",
-            "org.springframework.security.web.authentication.session.NullAuthenticatedSessionStrategy",
-            "org.springframework.security.web.authentication.session.CompositeSessionAuthenticationStrategy",
-            "org.springframework.security.web.authentication.session.ConcurrentSessionControlAuthenticationStrategy",
-            "org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy",
-            "org.springframework.security.web.csrf.CsrfAuthenticationStrategy",
-            "org.springframework.security.web.header.writers.HstsHeaderWriter",
-            "org.springframework.security.web.header.writers.ContentSecurityPolicyHeaderWriter",
-            "org.springframework.security.web.header.writers.XContentTypeOptionsHeaderWriter",
-            "org.springframework.security.web.header.writers.XXssProtectionHeaderWriter",
-            "org.springframework.security.web.header.writers.CacheControlHeadersWriter",
-            "org.springframework.security.web.header.writers.frameoptions.XFrameOptionsHeaderWriter",
-            "org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter",
-            "org.springframework.security.web.header.writers.PermissionsPolicyHeaderWriter",
-            "org.springframework.security.web.header.writers.CrossOriginOpenerPolicyHeaderWriter",
-            "org.springframework.security.web.header.writers.CrossOriginEmbedderPolicyHeaderWriter",
-            "org.springframework.security.web.header.writers.CrossOriginResourcePolicyHeaderWriter",
-            "org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter",
-            "org.springframework.security.oauth2.server.resource.web.OAuth2ProtectedResourceMetadataFilter",
-            "org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter",
-            "org.springframework.security.oauth2.client.web.OAuth2AuthorizationCodeGrantFilter",
-            "org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter");
 
     private static MatcherFacts unknownMatcher() {
         return new MatcherFacts("unknown", null, null, List.of());

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/BootUiRuntimeHintsTests.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.jdubois.bootui.core.dto.PanelDto;
 import io.github.jdubois.bootui.core.dto.StartupStepDto;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.boot.test.context.FilteredClassLoader;
 
 class BootUiRuntimeHintsTests {
 
@@ -56,6 +59,90 @@ class BootUiRuntimeHintsTests {
                         .onType(TypeReference.of("org.springframework.security.core.authority.SimpleGrantedAuthority"))
                         .withMemberCategory(MemberCategory.INVOKE_PUBLIC_METHODS))
                 .accepts(hints);
+    }
+
+    @Test
+    @SuppressWarnings("removal")
+    void permitsQueryingTheExactAotSecurityFactoryMethodWithoutPermittingInvocation() throws Exception {
+        var factoryMethod = BootUiSpringSecurityAutoConfiguration.class.getDeclaredMethod(
+                "bootUiSecurityFilterChain",
+                Class.forName("org.springframework.security.config.annotation.web.builders.HttpSecurity"),
+                BootUiProperties.class);
+
+        assertThat(RuntimeHintsPredicates.reflection().onMethod(factoryMethod).introspect())
+                .accepts(hints);
+        assertThat(RuntimeHintsPredicates.reflection().onMethodInvocation(factoryMethod))
+                .rejects(hints);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "org.springframework.security.web.FilterChainProxy, filterChains",
+        "org.springframework.security.web.FilterChainProxy, firewall",
+        "org.springframework.security.web.DefaultSecurityFilterChain, filters",
+        "org.springframework.security.web.DefaultSecurityFilterChain, requestMatcher",
+        "org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration$CompositeFilterChainProxy, springSecurityFilterChain",
+        "org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter, sessionStrategy",
+        "org.springframework.security.web.authentication.www.BasicAuthenticationFilter, authenticationManager",
+        "org.springframework.security.web.access.intercept.AuthorizationFilter, authorizationManager",
+        "org.springframework.security.web.access.intercept.RequestMatcherDelegatingAuthorizationManager, mappings",
+        "org.springframework.security.authorization.ObservationAuthorizationManager, delegate",
+        "org.springframework.security.authorization.SingleResultAuthorizationManager, result",
+        "org.springframework.security.authorization.AuthorizationDecision, granted",
+        "org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher, pattern",
+        "org.springframework.web.util.pattern.PathPattern, caseSensitive",
+        "org.springframework.security.web.header.HeaderWriterFilter, headerWriters",
+        "org.springframework.security.web.header.writers.HstsHeaderWriter, maxAgeInSeconds",
+        "org.springframework.security.web.csrf.CsrfFilter, requireCsrfProtectionMatcher",
+        "org.springframework.security.authentication.ProviderManager, providers",
+        "org.springframework.security.authentication.dao.DaoAuthenticationProvider, passwordEncoder",
+        "org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider, hideUserNotFoundExceptions",
+        "org.springframework.util.function.SingletonSupplier, singletonInstance",
+        "org.springframework.security.crypto.password.DelegatingPasswordEncoder, passwordEncoderForEncode",
+        "org.springframework.security.web.server.MatcherSecurityWebFilterChain, filters",
+        "org.springframework.security.web.server.MatcherSecurityWebFilterChain, matcher",
+        "org.springframework.security.web.server.header.HttpHeaderWriterWebFilter, writer",
+        "org.springframework.security.web.server.header.CompositeServerHttpHeadersWriter, writers",
+        "org.springframework.security.web.server.header.ContentSecurityPolicyServerHttpHeadersWriter, delegate",
+        "org.springframework.core.env.AbstractEnvironment, propertySources",
+        "org.springframework.core.env.AbstractEnvironment, activeProfiles",
+        "org.springframework.core.env.MutablePropertySources, propertySourceList",
+        "org.springframework.core.env.PropertySource, source",
+        "org.springframework.boot.origin.OriginTrackedValue, value",
+        "java.util.Collections$UnmodifiableMap, m",
+        "org.apache.catalina.core.ApplicationContextFacade, context",
+        "org.apache.catalina.core.ApplicationContext, parameters",
+        "org.springframework.boot.webmvc.actuate.endpoint.web.AbstractWebMvcEndpointHandlerMapping, endpoints",
+        "org.springframework.boot.actuate.endpoint.AbstractExposableEndpoint, operations",
+        "org.springframework.boot.actuate.endpoint.web.annotation.DiscoveredWebOperation, requestPredicate"
+    })
+    void registersFieldsReadByPassiveSecurityObservations(String type, String name) throws Exception {
+        var field = Class.forName(type).getDeclaredField(name);
+        assertThat(RuntimeHintsPredicates.reflection().onFieldAccess(field)).accepts(hints);
+        // The previous method-only hints cannot make any of these private observations available.
+        RuntimeHints methodOnly = new RuntimeHints();
+        methodOnly.reflection().registerType(field.getDeclaringClass(), MemberCategory.INVOKE_PUBLIC_METHODS);
+        assertThat(RuntimeHintsPredicates.reflection().onFieldAccess(field)).rejects(methodOnly);
+    }
+
+    @Test
+    void securityFieldHintsRemainSafeWithoutOptionalServletOrSecurityDependencies() {
+        RuntimeHints filteredHints = new RuntimeHints();
+        new BootUiRuntimeHints()
+                .registerHints(
+                        filteredHints,
+                        new FilteredClassLoader(
+                                "org.springframework.security",
+                                "jakarta.servlet",
+                                "org.apache.catalina",
+                                "org.springframework.boot.webmvc"));
+        assertThat(filteredHints.reflection().typeHints())
+                .noneMatch(hint -> hint.getType().getName().startsWith("org.springframework.security.")
+                        || hint.getType().getName().startsWith("org.apache.catalina."));
+        assertThat(RuntimeHintsPredicates.reflection()
+                        .onType(TypeReference.of("org.springframework.core.env.AbstractEnvironment"))
+                        .withMemberCategory(MemberCategory.ACCESS_DECLARED_FIELDS))
+                .accepts(filteredHints);
     }
 
     @Test

--- a/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
+++ b/bootui-spring-autoconfigure/src/test/java/io/github/jdubois/bootui/autoconfigure/security/SecurityScannerTests.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.github.jdubois.bootui.autoconfigure.BootUiProperties;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.CorsConfigModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.FilterChainModel;
 import io.github.jdubois.bootui.autoconfigure.security.SecurityModel.PasswordEncoderModel;
@@ -23,7 +24,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.aot.BeanInstanceSupplier;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.InstanceSupplier;
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
@@ -58,6 +63,53 @@ class SecurityScannerTests {
 
     private static final int RULE_COUNT = 54;
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
+
+    @Test
+    void aotFactoryMetadataExcludesOnlyBootUisChainWithoutInvokingItsGenerator() throws Exception {
+        String configuration = "io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration";
+        var definition = new RootBeanDefinition(SecurityFilterChain.class);
+        definition.setFactoryBeanName(configuration);
+        definition.setInstanceSupplier(BeanInstanceSupplier.forFactoryMethod(
+                        Class.forName(configuration),
+                        "bootUiSecurityFilterChain",
+                        HttpSecurity.class,
+                        BootUiProperties.class)
+                .withGenerator((registeredBean, arguments) -> {
+                    throw new AssertionError("Must not invoke the AOT bean generator");
+                }));
+        assertThat(definition.getFactoryMethodName()).isNull();
+
+        assertThat(scanWithNamedBootUiChain(definition).filterChainsAnalyzed()).isEqualTo(1);
+    }
+
+    @Test
+    void coincidentalBootUiBeanNameAndCustomSupplierDoNotHideAnApplicationChain() {
+        var definition = new RootBeanDefinition(SecurityFilterChain.class);
+        definition.setFactoryBeanName("io.github.jdubois.bootui.autoconfigure.BootUiSpringSecurityAutoConfiguration");
+        definition.setInstanceSupplier(new InstanceSupplier<SecurityFilterChain>() {
+            @Override
+            public SecurityFilterChain get(RegisteredBean registeredBean) {
+                throw new AssertionError("Must not initialize the bean");
+            }
+
+            @Override
+            public java.lang.reflect.Method getFactoryMethod() {
+                throw new AssertionError("Must not invoke custom provenance callbacks");
+            }
+        });
+
+        assertThat(scanWithNamedBootUiChain(definition).filterChainsAnalyzed()).isEqualTo(2);
+    }
+
+    private static SecurityReport scanWithNamedBootUiChain(RootBeanDefinition definition) {
+        var bootUi = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE);
+        var application = new DefaultSecurityFilterChain(AnyRequestMatcher.INSTANCE);
+        var factory = new DefaultListableBeanFactory();
+        factory.registerBeanDefinition("bootUiSecurityFilterChain", definition);
+        factory.registerSingleton("bootUiSecurityFilterChain", bootUi);
+        return scannerFor(new FilterChainProxy(List.of(bootUi, application)), factory)
+                .scan();
+    }
 
     @Test
     void scanReportsSecurityFindingsAcrossCategories() {

--- a/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
+++ b/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
@@ -333,6 +333,90 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
     }
 
     for (const theme of ['light', 'dark']) {
+      test(`keeps unscored advisor cards compact and opens their details in ${theme}`, async ({page}, testInfo) => {
+        await page.addInitScript((value) => localStorage.setItem('bootui.theme', value), theme)
+        await page.setViewportSize({width: theme === 'dark' ? 390 : 1600, height: 900})
+        const ids = scannerIds.filter((id) => id !== 'github')
+        const limitations = Array.from(
+          {length: 20},
+          (_, index) => `Required security observation ${index + 1} could not be inspected in this runtime.`
+        )
+        const report = {
+          ...architectureReport('PARTIAL'),
+          scan: {status: 'PARTIAL', scannedAt: 1700000000000, message: 'Security metadata is unavailable.'},
+          evidence: {usable: false, coverageComplete: false, limitations},
+          severityCounts: [],
+          results: [],
+          violationsFound: 0,
+          rulesEvaluated: 0,
+          filterChainsAnalyzed: 0,
+          filterChains: []
+        }
+        const scans = []
+        await showAdvisors(page, ...ids)
+        for (const id of ids) {
+          await page.route(`**${apiPath}/${id}{,/scan}`, (route) => {
+            if (route.request().method() === 'POST') scans.push(id)
+            return route.fulfill({json: scans.includes(id) ? report : unscannedReport()})
+          })
+        }
+        await page.goto(`${uiPath}/#/overview`)
+        const cards = page.locator('.scanner-card')
+        await expect(cards).toHaveCount(ids.length)
+        expect(scans).toEqual([])
+        await page.getByRole('button', {name: 'Run all scanners', exact: true}).click()
+        await expect(page.locator('.overall-card')).toContainText('9 of 9 advisors assessed')
+        await expect(page.locator('.overall-card').getByRole('img')).toHaveCount(0)
+        await expect(page.locator('.assessment-summary')).toContainText('9 advisors have scan notes')
+        expect([...scans].sort()).toEqual([...ids].sort())
+        for (const card of await cards.all()) {
+          await expect(card.locator('.scanner-status')).toHaveText('Incomplete')
+          await expect(card.locator('.scanner-assessment')).toHaveText('Not scored')
+          await expect(card.locator('.scanner-score')).toHaveCount(0)
+          await expect(card).not.toContainText('No usable assessment evidence')
+          await expect(card).not.toContainText(report.scan.message)
+          for (const reason of limitations) await expect(card).not.toContainText(reason)
+          const geometry = await card.evaluate((element) => {
+            const label = element.querySelector('.scanner-assessment')
+            const style = getComputedStyle(label)
+            return {
+              height: element.getBoundingClientRect().height,
+              labelHeight: label.getBoundingClientRect().height,
+              fontSize: parseFloat(style.fontSize),
+              fontWeight: Number(style.fontWeight),
+              overflow: element.scrollWidth > element.clientWidth
+            }
+          })
+          expect(geometry.height).toBeLessThan(260)
+          expect(geometry.labelHeight).toBeLessThan(30)
+          expect(geometry.fontSize).toBeLessThanOrEqual(18)
+          expect(geometry.fontWeight).toBeGreaterThanOrEqual(600)
+          expect(geometry.overflow).toBe(false)
+        }
+        expect(await page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true)
+        await page.evaluate(() => {
+          window.scrollTo(0, 0)
+          document.querySelector('.bootui-workspace')?.scrollTo(0, 0)
+        })
+        await page.screenshot({path: testInfo.outputPath(`overview-unscored-${theme}.png`), animations: 'disabled'})
+        const security = cards.filter({hasText: 'Security'})
+        await security.screenshot({path: testInfo.outputPath(`security-unscored-${theme}.png`), animations: 'disabled'})
+        const open = security.getByRole('link', {name: 'Open panel: Security', exact: true})
+        await expect(open).toHaveCount(1)
+        await expect(open).toHaveAttribute('href', new RegExp(`#/security$`))
+        await security.getByRole('button', {name: 'Re-run scan', exact: true}).focus()
+        await page.keyboard.press('Tab')
+        await expect(open).toBeFocused()
+        await page.keyboard.press('Enter')
+        await expect(page).toHaveURL(new RegExp(`#/security$`))
+        const assessment = page.locator('.advisor-summary__assessment')
+        await expect(assessment.getByText('Not scored', {exact: true})).toBeVisible()
+        for (const reason of limitations) await expect(assessment).toContainText(reason)
+        await expect(assessment).toContainText(report.scan.message)
+        await expect(assessment).toBeVisible()
+        expect(scans).toHaveLength(ids.length)
+      })
+
       test(`restores individual score colors in ${theme}`, async ({page}, testInfo) => {
         await page.addInitScript((value) => localStorage.setItem('bootui.theme', value), theme)
         await page.setViewportSize({width: theme === 'dark' ? 390 : 1600, height: 900})
@@ -965,7 +1049,8 @@ export function registerAdvisorScoringTests(test, expect, {uiPath = '/bootui', a
       const card = page.locator('.scanner-card').filter({hasText: 'Vulnerabilities'})
       await expect(card).toBeVisible()
       expect(scans).toBe(0)
-      await expect(card).toContainText('No usable assessment evidence')
+      await expect(card.locator('.scanner-assessment')).toHaveText('Not scored')
+      await expect(card).not.toContainText('No usable assessment evidence')
       await expect(page.locator('.assessment-summary')).toContainText('1 advisor has scan notes')
       await expect(card).toContainText('1 unknown')
       await card.getByRole('link', {name: 'Open panel'}).click()

--- a/bootui-ui/src/main/frontend/src/views/Overview.test.js
+++ b/bootui-ui/src/main/frontend/src/views/Overview.test.js
@@ -116,6 +116,40 @@ function scannerCard(wrapper, title) {
 }
 
 describe('Overview', () => {
+  it('keeps every unscored advisor compact after a full scan, with details left to its panel', async () => {
+    const ids = onlyPanels()
+      .panels.filter(({id}) => id !== 'github')
+      .map(({id}) => id)
+    const limitations = Array.from({length: 20}, (_, index) => `Required observation ${index + 1} was unavailable.`)
+    const report = {
+      severityCounts: [{severity: 'INFO', count: 1}],
+      scan: {status: 'PARTIAL', message: 'Some required observations could not be collected.'},
+      evidence: {usable: false, coverageComplete: false, limitations}
+    }
+    stubFetch(Object.fromEntries(ids.map((id) => [`api/${id}/scan`, report])))
+    const wrapper = mountOverview(onlyPanels(...ids))
+    await flushPromises()
+    const runAll = wrapper.findAll('button').find((button) => button.text() === 'Run all scanners')
+    await runAll.trigger('click')
+    await flushPromises()
+
+    const cards = wrapper.findAllComponents(ScannerScoreCard)
+    expect(cards).toHaveLength(ids.length)
+    for (const card of cards) {
+      expect(card.get('.scanner-assessment').text()).toBe('Not scored')
+      expect(card.get('.scanner-status').text()).toBe('Incomplete')
+      expect(card.text()).toContain('1 info')
+      expect(card.find('.scanner-score').exists()).toBe(false)
+      expect(card.get('a').attributes('aria-label')).toBe(`Open panel: ${card.props('title')}`)
+      expect(card.text()).not.toContain(report.scan.message)
+      expect(card.text()).not.toContain('No usable assessment evidence')
+      for (const reason of limitations) expect(card.text()).not.toContain(reason)
+    }
+    expect(wrapper.get('.overall-card').text()).toContain('9 of 9 advisors assessed')
+    expect(wrapper.get('.assessment-summary').text()).toContain('9 advisors have scan notes')
+    expect(wrapper.find('.overall-gauge').exists()).toBe(false)
+  })
+
   it.each([
     [0, 'success'],
     [3, 'warning'],

--- a/bootui-ui/src/main/frontend/src/views/Overview.vue
+++ b/bootui-ui/src/main/frontend/src/views/Overview.vue
@@ -135,7 +135,6 @@ function newScannerState() {
     incomplete: false,
     hasReport: false,
     scoreLabel: '',
-    scoreReason: '',
     severityCounts: [],
     statusLabel: null,
     statusTone: 'secondary',
@@ -166,7 +165,6 @@ function applyReport(def, state, report) {
   state.severityCounts = validSummary ? report.severityCounts : []
   state.score = assessment.score
   state.scoreLabel = assessment.score !== null ? 'Scan complete' : assessment.label
-  state.scoreReason = assessment.reason
   const status = report?.scan?.status
   state.assessed = ['SCANNED', 'PARTIAL'].includes(status) && report.evidence != null
   state.incomplete = assessment.incomplete
@@ -592,7 +590,6 @@ watch(
           :score="scanners[def.id].score"
           :has-report="scanners[def.id].hasReport"
           :score-label="scanners[def.id].scoreLabel"
-          :score-reason="scanners[def.id].scoreReason"
           :incomplete="scanners[def.id].incomplete"
           :severity-counts="scanners[def.id].severityCounts"
           :status-label="scanners[def.id].statusLabel"

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.test.js
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.test.js
@@ -57,8 +57,9 @@ describe('ScannerScoreCard', () => {
         state: 'done',
         hasReport: true,
         score: null,
-        scoreLabel: 'Incomplete',
-        scoreReason: 'No usable assessment evidence.',
+        scoreLabel: 'Not scored',
+        statusLabel: 'Incomplete',
+        to: '/security',
         incomplete: true,
         severityCounts: [
           {severity: 'HIGH', count: 2},
@@ -68,7 +69,10 @@ describe('ScannerScoreCard', () => {
     })
     expect(wrapper.find('.scanner-score').exists()).toBe(false)
     expect(wrapper.text()).toContain('Incomplete')
-    expect(wrapper.get('.scanner-assessment').text()).toContain('No usable assessment evidence.')
+    expect(wrapper.get('.scanner-assessment').text()).toBe('Not scored')
+    expect(wrapper.get('.scanner-body').element.firstElementChild.classList.contains('scanner-assessment')).toBe(true)
+    expect(wrapper.get('router-link-stub').attributes('to')).toBe('/security')
+    expect(wrapper.get('router-link-stub').attributes('aria-label')).toBe('Open panel: Security')
     expect(wrapper.find('details').exists()).toBe(false)
     expect(wrapper.text()).not.toContain('Scan notes available in panel.')
     expect(wrapper.text()).toContain('2 high')
@@ -86,7 +90,6 @@ describe('ScannerScoreCard', () => {
         hasReport: true,
         score: 91,
         scoreLabel: 'Partial assessment',
-        scoreReason: 'Detailed coverage explanation.',
         incomplete
       }
     })
@@ -96,7 +99,17 @@ describe('ScannerScoreCard', () => {
     )
     expect(wrapper.text()).not.toContain('Scan notes available in panel.')
     expect(wrapper.find('.scanner-assessment').exists()).toBe(false)
-    expect(wrapper.text()).not.toContain('Detailed coverage explanation.')
+  })
+
+  it.each(['Not scored', 'Not applicable'])('keeps the unscored label %s distinct from a numeric score', (label) => {
+    const wrapper = mount(ScannerScoreCard, {
+      global: {stubs: {RouterLink: true}},
+      props: {title: 'Architecture', state: 'done', hasReport: true, scoreLabel: label}
+    })
+    expect(wrapper.get('.scanner-assessment').text()).toBe(label)
+    expect(wrapper.get('.scanner-assessment').classes()).not.toContain('scanner-score')
+    expect(wrapper.find('[role="img"]').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('/ 100')
   })
 
   it.each(['running', 'error'])('retains the last report while request state is %s', (state) => {

--- a/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
+++ b/bootui-ui/src/main/frontend/src/views/components/ScannerScoreCard.vue
@@ -14,7 +14,6 @@ const props = defineProps({
   score: {type: Number, default: null},
   hasReport: {type: Boolean, default: false},
   scoreLabel: {type: String, default: ''},
-  scoreReason: {type: String, default: ''},
   incomplete: {type: Boolean, default: false},
   severityCounts: {type: Array, default: () => []},
   statusLabel: {type: String, default: null},
@@ -45,7 +44,7 @@ const topSeverities = computed(() =>
 )
 
 const hasScore = computed(() => Number.isFinite(props.score))
-const coverageLabel = computed(() => props.scoreLabel || 'Coverage unknown')
+const coverageLabel = computed(() => props.scoreLabel || 'Not scored')
 
 function severityTone(severity) {
   return SEVERITY_TONES[String(severity).toUpperCase()] || 'text-bg-light border'
@@ -95,6 +94,7 @@ function onRun() {
             </div>
             <div class="small text-muted mt-1">Known-findings score</div>
           </div>
+          <div v-else-if="hasReport" class="scanner-assessment fw-semibold mb-2">{{ coverageLabel }}</div>
           <template v-if="hasReport || hasScore">
             <div v-if="topSeverities.length" class="d-flex flex-wrap gap-1" aria-label="Retained severity counts">
               <span
@@ -106,10 +106,6 @@ function onRun() {
               </span>
             </div>
             <div v-else-if="hasScore" class="text-muted small">No retained findings in the assessed evidence</div>
-            <div v-if="!hasScore" class="scanner-assessment small mt-2">
-              <div class="fw-semibold">{{ coverageLabel }}</div>
-              <div v-if="scoreReason" class="text-muted">{{ scoreReason }}</div>
-            </div>
           </template>
           <div v-else-if="state === 'idle'" class="text-muted small">{{ idleHint }}</div>
         </slot>
@@ -129,7 +125,12 @@ function onRun() {
           >
             {{ state === 'idle' ? runLabel : rerunLabel }}
           </SpinnerButton>
-          <router-link v-if="to" :to="to" class="btn btn-sm btn-outline-secondary ms-auto">
+          <router-link
+            v-if="to"
+            :to="to"
+            :aria-label="`${openLabel}: ${title}`"
+            class="btn btn-sm btn-outline-secondary ms-auto"
+          >
             {{ openLabel }}<i class="bi bi-arrow-right-short"></i>
           </router-link>
         </slot>

--- a/docs/SECURITY-CHECKS.md
+++ b/docs/SECURITY-CHECKS.md
@@ -42,6 +42,26 @@ provide this access, affected configuration remains unknown rather than being tr
 JDKs may emit deprecation warnings or diagnostic events for the optional internal access.
 Native bootstrap and callback-safety regressions cover Java 17, 21 and 25.
 
+Here, "native" framework objects means the framework's own implementations, not necessarily a GraalVM executable.
+GraalVM additionally requires reflection metadata for the passive readers' private fields. BootUI supplies
+classpath-conditional field hints for supported Spring Security chains, filters, headers, matchers, provider
+metadata, Spring environment sources, Actuator descriptors and the embedded Tomcat context. The hints cover the
+servlet and reactive collectors without making servlet or optional security dependencies mandatory. They do not
+register arbitrary application callbacks or execute them. Without these hints, even a live `FilterChainProxy`
+can lose its readable `filterChains` inventory, yielding zero observed chains and an unusable partial report.
+Public-method hints alone cannot preserve that inventory.
+Spring AOT also moves factory-method provenance into its generated `BeanInstanceSupplier`. BootUI reads that
+framework metadata without invoking its generator, so BootUI's own console chain stays excluded from the application
+assessment in AOT mode. A coincidental bean name or an application-supplied metadata callback is not trusted.
+
+The container publication smoke test explicitly scans the real servlet sample on JVM, AOT, CRaC and GraalVM native
+images and checks that all three chains produce usable evidence while retaining genuine incomplete coverage.
+Runtime-hints tests independently pin private-field access and optional-dependency absence. Custom implementations,
+unregistered application reflection, compiler-generated suppliers, and unsupported observations still remain
+unknown; the hints do not guarantee full security coverage or JVM/native score equality. Quarkus uses its own
+build-time/provider observations and is not affected by this Spring metadata fix; Quarkus native BootUI remains out
+of scope.
+
 For the standard embedded Tomcat servlet context, the passive reader inspects the exact native facade/context
 init-parameter map rather than blocking all lower configuration sources. Custom contexts, subclasses, unsupported
 maps, and callbacks remain opaque. The real Spring sample regression uses embedded Tomcat and the application's

--- a/docs/TRY-SAMPLE-APP.md
+++ b/docs/TRY-SAMPLE-APP.md
@@ -59,6 +59,11 @@ Typical result: **~40–45 % shorter startup** vs the plain JVM image (Spring-re
 
 ### GraalVM native image
 
+The Security advisor needs BootUI's private-field reflection hints in the executable, not just in a replacement
+JAR. Rebuild older native images to pick up those hints. The real sample retains usable results from its three
+chains, but still reports partial coverage for unsupported security observations; it does not claim a complete
+security assessment. See [Security checks](SECURITY-CHECKS.md#availability-and-bounds).
+
 `jdubois/bootui-sample-app-native` is a [GraalVM](https://www.graalvm.org/) native image that starts in well under a
 second:
 

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -41,7 +41,9 @@ Detailed reasons are in a
 collapsed **Scan notes** disclosure in each advisor panel, operable by keyboard and screen reader. Scores with notes
 include **Scan notes available** in their accessible names. Overview summarizes how many advisors have scan notes,
 not how many checks could not run: limitations can be aggregated or capped. Unscored reasons and whole-scan failures
-remain visible, not collapsed. Backend scan statuses and evidence are unchanged.
+remain visible, not collapsed, inside advisor panels. Overview keeps unscored cards compact with **Not scored**
+(or **Not applicable** for confirmed empty scope) and **Open panel** for the full explanation; request failures stay
+visible on the card. Backend scan statuses and evidence are unchanged.
 Penalties are unchanged: CRITICAL 25, HIGH 10, MEDIUM 3, LOW 1,
 and INFO/NONE 0, clamped and rounded to 0–100. A partial 100 means no active penalties in the assessed evidence,
 not that unchecked work passed. Advisor panels use neutral numbers; Overview restores green/amber/red score colors

--- a/docs/features/overview.md
+++ b/docs/features/overview.md
@@ -37,6 +37,8 @@ Each scanner card leads with a large 0–100 **Known-findings score** for an eli
 severity counts. Usable scores have a neutral **Scan complete** status: the scan has finished, not necessarily assessed
 every applicable check. Secondary diagnostics remain inside
 each advisor's **Scan notes**, accessible through **Open panel**, without repeated reminders on the cards.
+Unscored cards show a compact **Not scored** label instead of the detailed assessment explanation; **Open panel**
+opens the advisor with the full reason. Confirmed empty scope keeps its distinct **Not applicable** label.
 The severity-based scanners are Architecture,
 Memory, REST API, Spring, Database, Hibernate, Security, Pentesting, and Vulnerabilities. Each starts at 100 and
 subtracts a fixed weighted penalty per finding — critical 25, high 10, medium 3, low 1 — so a complete clean scan stays
@@ -52,7 +54,8 @@ even if that evidence cannot support a number. Missing legacy evidence does not 
 Unscanned and failed reports do not count as assessed; request failures are shown separately, preserving any last report.
 Unscanned, failed, disabled, and unavailable
 scanners do not inflate the scan-notes count. Full reasons for usable results remain in each panel's keyboard-accessible,
-initially collapsed **Scan notes**. Unscored reasons and failures stay visible. The count is of advisors, never inferred
+initially collapsed **Scan notes**. Unscored reasons stay visible in the advisor panel, while request failures remain
+visible on the Overview card too. The count is of advisors, never inferred
 checks: report limitations may be aggregated or capped.
 Vulnerabilities can score known findings despite inventory/query/detail gaps; UNKNOWN has no penalty but cannot
 establish eligibility even after dismissal. A clean dependency needs completed query and detail evidence and a


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Preserves the Security advisor's passive observations in GraalVM native images and keeps unscored Overview cards compact, with detailed explanations in the advisor panels.

- Registers classpath-conditional private-field metadata for the MVC/WebFlux security readers, without invoking application callbacks or requiring optional dependencies.
- Recognizes Spring AOT factory provenance so BootUI's own console chain is excluded from application evidence.
- Shows a concise **Not scored** label before retained severities across all advisor cards. **Not applicable**, failures, scoring eligibility, and full panel explanations remain distinct and unchanged.
- Adds an explicit Security scan to servlet Docker publication smoke checks and regression coverage for native hints, AOT ownership, and cross-runtime browser behavior.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

The native sample reported **Incomplete / Not scored** while JVM scans worked. Missing reflection metadata made `FilterChainProxy.filterChains` unreadable, leaving zero observed chains and no usable evidence. Overview then displayed the entire concatenated assessment explanation inside a small card.

Existing native executables must be rebuilt to include the metadata. Genuine missing observations still produce partial coverage; this does not promise complete security coverage or identical JVM/native scores.

No linked issue.

## How was it tested?

- [ ] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [x] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082
- [x] Ran the affected Playwright suite(s) for browser-facing changes
- [x] Added or updated tests where applicable

Focused Spring security/hints suites passed on Java 17 and 25; MVC/WebFlux conformance and real sample wiring passed. Generated AOT metadata and a rebuilt AOT JVM sample confirmed three application chains with usable, honestly partial evidence. The factory-method regression also confirms query access without invocation access.

Frontend validation covered 166 focused unit/design tests and 23 shared browser scenarios on each of MVC, WebFlux, and Quarkus using the changed UI with local backends and deterministic advisor fixtures. Light/desktop and dark/mobile cases cover long explanations, compact card geometry, retained state, and keyboard navigation to full Security details. Formatting checks passed.

**Limitation:** a rebuilt GraalVM executable was not confirmed end-to-end. Native compilation exhausted Docker memory; bounded retries were stopped. The existing native failure was reproduced, and the publication smoke check now guards the actual executable. A full reactor `clean install` was not run; validation was targeted.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

Updated Security card with an intentionally unscorable report; full explanations remain accessible through **Open panel**.

| Light / desktop | Dark / mobile |
| --- | --- |
| ![Compact unscored Security card in light theme](https://github.com/user-attachments/assets/d3fffc4d-08fa-43f9-81a9-45e963a71846) | ![Compact unscored Security card in dark theme](https://github.com/user-attachments/assets/b5de6043-f6b0-4c70-87b9-6b99e021380f) |

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed