### PR TITLE
Add HIB-QUERY-008 rule for bulk updates leaving @Version unchanged

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateAttributeModel.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateAttributeModel.java
@@ -164,6 +164,20 @@ public record HibernateAttributeModel(
         return annotation(VERSION) != null;
     }
 
+    String propertyName() {
+        if (name.endsWith("()")) {
+            String base = name.substring(0, name.length() - 2);
+            if (base.startsWith("get") && base.length() > 3) {
+                return Character.toLowerCase(base.charAt(3)) + base.substring(4);
+            }
+            if (base.startsWith("is") && base.length() > 2) {
+                return Character.toLowerCase(base.charAt(2)) + base.substring(3);
+            }
+            return base;
+        }
+        return name;
+    }
+
     boolean isTransient() {
         return annotation(TRANSIENT) != null;
     }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateQueryShape.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateQueryShape.java
@@ -1,5 +1,7 @@
 package io.github.jdubois.bootui.engine.hibernate;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -120,5 +122,223 @@ final class HibernateQueryShape {
     static boolean bulk(String query) {
         String text = lexical(query);
         return text != null && text.stripLeading().toLowerCase(Locale.ROOT).matches("(?s)^(update\\b|delete\\b).*");
+    }
+
+    private static final Pattern UPDATE_PREFIX = Pattern.compile("(?is)^\\s*update\\b");
+    private static final Pattern UPDATE_HEAD = Pattern.compile("(?is)^\\s*update\\s+(.+?)\\s+set\\b");
+    private static final Pattern UPDATE_VERSIONED = Pattern.compile("(?is)^\\s*update\\s+versioned\\b");
+    private static final Pattern UPDATE_SET_CLAUSE = Pattern.compile("(?is)\\bset\\s+(.*?)(?:\\bwhere\\b|$)");
+
+    static boolean isUpdate(String query) {
+        String text = lexical(query);
+        return text != null && UPDATE_PREFIX.matcher(text).find();
+    }
+
+    static boolean isUpdateVersioned(String query) {
+        String text = lexical(query);
+        return text != null && UPDATE_VERSIONED.matcher(text).find();
+    }
+
+    record UpdateTarget(HibernateEntityModel entity, String alias, String query, boolean versioned) {}
+
+    static UpdateTarget resolveUpdateTarget(HibernateContext context, HibernateRepositoryMethodModel method) {
+        if (method.nativeQuery() || !method.hasQuery()) return null;
+        HibernateQueryEvidence evidence = method.evidence();
+        if (context.observed()
+                && (!evidence.verifiedQueryMethod() || evidence.namedQuery() || evidence.queryRewriter())) {
+            context.missingEvidence();
+            return null;
+        }
+        String query = lexical(method.query());
+        if (query == null || !isUpdate(query)) {
+            return null;
+        }
+        // Disallow subqueries or set operations (select, union, intersect, except)
+        if (Pattern.compile("(?i)\\b(select|union|intersect|except)\\b")
+                .matcher(query)
+                .find()) {
+            context.missingEvidence();
+            return null;
+        }
+        Matcher headMatcher = UPDATE_HEAD.matcher(query);
+        if (!headMatcher.find()) {
+            context.missingEvidence();
+            return null;
+        }
+        String head = headMatcher.group(1).trim();
+        if (head.indexOf(',') >= 0) {
+            context.missingEvidence();
+            return null;
+        }
+        String[] tokens = head.split("\\s+");
+        if (tokens.length == 0) {
+            context.missingEvidence();
+            return null;
+        }
+
+        boolean versioned = false;
+        HibernateEntityModel entity = null;
+        String alias = null;
+
+        if (tokens[0].equalsIgnoreCase("versioned")) {
+            if (tokens.length >= 2) {
+                HibernateEntityModel candidate = findEntity(context, tokens[1]);
+                if (candidate != null) {
+                    versioned = true;
+                    entity = candidate;
+                    if (tokens.length == 3) {
+                        alias = tokens[2];
+                    } else if (tokens.length == 4 && tokens[2].equalsIgnoreCase("as")) {
+                        alias = tokens[3];
+                    } else if (tokens.length > 2) {
+                        context.missingEvidence();
+                        return null;
+                    }
+                }
+            }
+            if (entity == null) {
+                entity = findEntity(context, tokens[0]);
+                if (entity != null) {
+                    versioned = false;
+                    if (tokens.length == 2) {
+                        alias = tokens[1];
+                    } else if (tokens.length == 3 && tokens[1].equalsIgnoreCase("as")) {
+                        alias = tokens[2];
+                    } else if (tokens.length > 1) {
+                        context.missingEvidence();
+                        return null;
+                    }
+                }
+            }
+        } else {
+            entity = findEntity(context, tokens[0]);
+            if (entity != null) {
+                if (tokens.length == 2) {
+                    alias = tokens[1];
+                } else if (tokens.length == 3 && tokens[1].equalsIgnoreCase("as")) {
+                    alias = tokens[2];
+                } else if (tokens.length > 1) {
+                    context.missingEvidence();
+                    return null;
+                }
+            }
+        }
+
+        if (entity == null) {
+            context.missingEvidence();
+            return null;
+        }
+        return new UpdateTarget(entity, alias, query, versioned);
+    }
+
+    private static HibernateEntityModel findEntity(HibernateContext context, String name) {
+        HibernateEntityModel found = null;
+        for (HibernateEntityModel entity : context.entities()) {
+            if (entity.javaType() == null) continue;
+            String entityName = entity.annotationStringValue(entity.annotation("jakarta.persistence.Entity"), "name");
+            if (entityName == null || entityName.isBlank()) {
+                entityName = entity.javaType().getSimpleName();
+            }
+            if (name.equals(entityName) || name.equals(entity.javaType().getName())) {
+                if (found != null) {
+                    return null;
+                }
+                found = entity;
+            }
+        }
+        return found;
+    }
+
+    static boolean maintainsVersion(String query, String alias, String versionAttributeName) {
+        if (query == null || versionAttributeName == null || versionAttributeName.isBlank()) {
+            return false;
+        }
+        Matcher setMatcher = UPDATE_SET_CLAUSE.matcher(query);
+        if (!setMatcher.find()) {
+            return false;
+        }
+        String setBody = setMatcher.group(1);
+        List<String> assignments = splitTopLevel(setBody, ',');
+        String quotedVersion = Pattern.quote(versionAttributeName);
+        String targetPatternStr;
+        if (alias != null && !alias.isBlank()) {
+            String quotedAlias = Pattern.quote(alias);
+            targetPatternStr = "(?:(?:" + quotedAlias + "\\s*\\.\\s*)?" + quotedVersion + ")";
+        } else {
+            targetPatternStr = quotedVersion;
+        }
+        Pattern assignPattern = Pattern.compile("(?is)^\\s*" + targetPatternStr + "\\s*=(.*)$");
+        Pattern literalNumber = Pattern.compile("^\\d+[lL]?$");
+        for (String assignment : assignments) {
+            Matcher m = assignPattern.matcher(assignment.trim());
+            if (m.matches()) {
+                String rhs = unwrapBalancedParens(m.group(1).trim());
+                Pattern rhsSelf = Pattern.compile("(?is)^" + targetPatternStr + "$");
+                if (rhsSelf.matcher(rhs).matches()) {
+                    continue;
+                }
+                List<String> parts = splitTopLevel(rhs, '+');
+                if (parts.size() == 2) {
+                    String op1 = unwrapBalancedParens(parts.get(0).trim());
+                    String op2 = unwrapBalancedParens(parts.get(1).trim());
+                    boolean op1Target = Pattern.compile("(?is)^" + targetPatternStr + "$")
+                            .matcher(op1)
+                            .matches();
+                    boolean op2Target = Pattern.compile("(?is)^" + targetPatternStr + "$")
+                            .matcher(op2)
+                            .matches();
+                    if ((op1Target && literalNumber.matcher(op2).matches())
+                            || (op2Target && literalNumber.matcher(op1).matches())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static String unwrapBalancedParens(String expr) {
+        String s = expr.trim();
+        while (s.startsWith("(") && s.endsWith(")") && isBalancedEnclosure(s)) {
+            s = s.substring(1, s.length() - 1).trim();
+        }
+        return s;
+    }
+
+    private static boolean isBalancedEnclosure(String s) {
+        int depth = 0;
+        for (int i = 0; i < s.length() - 1; i++) {
+            char c = s.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth--;
+                if (depth <= 0) {
+                    return false;
+                }
+            }
+        }
+        return depth == 1;
+    }
+
+    private static List<String> splitTopLevel(String expr, char delimiter) {
+        List<String> parts = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < expr.length(); i++) {
+            char c = expr.charAt(i);
+            if (c == '(') {
+                depth++;
+            } else if (c == ')') {
+                depth = Math.max(0, depth - 1);
+            } else if (c == delimiter && depth == 0) {
+                parts.add(expr.substring(start, i));
+                start = i + 1;
+            }
+        }
+        if (start < expr.length()) {
+            parts.add(expr.substring(start));
+        }
+        return parts;
     }
 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRuleRegistry.java
@@ -59,6 +59,7 @@ final class HibernateRuleRegistry {
             new EagerToOneFetchJoinRule(),
             new EntityProjectionQueryRule(),
             new MultipleCollectionJoinFetchRule(),
+            new BulkUpdateVersionRule(),
             // Configuration
             new OpenInViewRule(),
             new LazyLoadNoTransRule(),

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -2311,6 +2311,70 @@ final class DerivedDeleteByQueryRule extends AbstractHibernateRule {
     }
 }
 
+final class BulkUpdateVersionRule extends AbstractHibernateRule {
+
+    BulkUpdateVersionRule() {
+        super(
+                new HibernateRuleDefinition(
+                        "HIB-QUERY-008",
+                        "Bulk updates leave @Version unchanged",
+                        HibernateCategory.QUERY,
+                        "MEDIUM",
+                        "Detects JPQL/HQL bulk UPDATE queries targeting versioned entities that neither use UPDATE VERSIONED"
+                                + " nor explicitly maintain the version attribute, leaving the database version unchanged.",
+                        "Review whether this operation should invalidate previously loaded entity versions. Where appropriate,"
+                                + " use ordinary managed-entity updates, Hibernate's update versioned syntax, or explicit numeric"
+                                + " version incrementation.",
+                        "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#batch-bulk-hql-update-delete"));
+    }
+
+    @Override
+    HibernateRuleResultDto evaluateRule(HibernateContext context) {
+        if (context.repositories().isEmpty()) {
+            return skipped("No repository metadata was detected.");
+        }
+        List<String> details = new ArrayList<>();
+        for (HibernateRepositoryModel repository : context.repositories()) {
+            for (HibernateRepositoryMethodModel method : repository.methods()) {
+                if (!method.modifying()
+                        || method.nativeQuery()
+                        || !HibernateQueryShape.isUpdate(method.query())
+                        || context.observed()
+                                && (!method.evidence().verifiedQueryMethod()
+                                        || method.evidence().queryRewriter())) {
+                    continue;
+                }
+                HibernateQueryShape.UpdateTarget target = HibernateQueryShape.resolveUpdateTarget(context, method);
+                if (target == null) {
+                    continue;
+                }
+                HibernateEntityModel entity = target.entity();
+                if (!entity.hasVersionAttribute()) {
+                    continue;
+                }
+                context.evidence().markApplicable(true);
+                if (target.versioned()) {
+                    continue;
+                }
+                HibernateAttributeModel versionAttr = entity.attributes().stream()
+                        .filter(HibernateAttributeModel::hasVersion)
+                        .findFirst()
+                        .orElse(null);
+                if (versionAttr != null
+                        && (HibernateQueryShape.maintainsVersion(
+                                        target.query(), target.alias(), versionAttr.propertyName())
+                                || HibernateQueryShape.maintainsVersion(
+                                        target.query(), target.alias(), versionAttr.name()))) {
+                    continue;
+                }
+                details.add(method.description() + " performs a bulk UPDATE on versioned entity " + entity.name()
+                        + " without advancing its version attribute.");
+            }
+        }
+        return violation(details);
+    }
+}
+
 final class SqlLoggingInProductionRule extends AbstractHibernateRule {
 
     @Override

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateAdvisorObservationTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateAdvisorObservationTests.java
@@ -360,7 +360,7 @@ class HibernateAdvisorObservationTests {
 
     @Test
     void fiveRetiredIdsAreNotRegisteredOrReported() {
-        assertThat(HibernateRuleRegistry.activeRules()).hasSize(70);
+        assertThat(HibernateRuleRegistry.activeRules()).hasSize(71);
         assertThat(HibernateRuleRegistry.activeRules())
                 .extracting(rule -> rule.definition().id())
                 .doesNotContain("HIB-FETCH-004", "HIB-MAP-012", "HIB-ENTITY-003", "HIB-ENTITY-004", "HIB-MAP-019");

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -235,6 +235,355 @@ class HibernateRulesTests {
         assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
     }
 
+    // --- HIB-QUERY-008 ------------------------------------------------------
+
+    @Test
+    void bulkUpdateVersionRuleFlagsUpdateWithoutVersionAdvancement() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PrimitiveVersionEntity.class,
+                List.of(repositoryMethod(
+                        "bumpStatus",
+                        int.class,
+                        "update PrimitiveVersionEntity e set e.id = 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(repository), PrimitiveVersionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        assertThat(result.severity()).isEqualTo(HibernateRuleSupport.MEDIUM);
+        assertThat(result.sampleViolations())
+                .anySatisfy(sample -> assertThat(sample)
+                        .contains("bumpStatus", "PrimitiveVersionEntity", "without advancing its version"));
+    }
+
+    @Test
+    void bulkUpdateVersionRulePassesForUnversionedEntity() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                IdentityEntity.class,
+                List.of(repositoryMethod(
+                        "bumpStatus",
+                        int.class,
+                        "update IdentityEntity e set e.id = 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(repository), IdentityEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bulkUpdateVersionRulePassesForUpdateVersioned() {
+        HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PrimitiveVersionEntity.class,
+                List.of(repositoryMethod(
+                        "bumpStatus",
+                        int.class,
+                        "update versioned PrimitiveVersionEntity e set e.id = 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(repository), PrimitiveVersionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bulkUpdateVersionRulePassesForExplicitNumericIncrement() {
+        for (String query : List.of(
+                "update PrimitiveVersionEntity e set e.id = 1, e.version = e.version + 1",
+                "update PrimitiveVersionEntity e set e.id = 1, e.version = (e.version + 1)",
+                "update PrimitiveVersionEntity e set e.id = 1, e.version = 1 + e.version")) {
+            HibernateRepositoryModel repository = new HibernateRepositoryModel(
+                    "com.example.Repo",
+                    PrimitiveVersionEntity.class,
+                    List.of(repositoryMethod("bumpStatus", int.class, query, false, false, true, false, false)));
+
+            HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                    .evaluate(context(new TestEnvironment(), List.of(repository), PrimitiveVersionEntity.class));
+
+            assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+        }
+    }
+
+    @Test
+    void bulkUpdateVersionRuleFlagsSelfAssignmentAndWhereClauseVersionPredicate() {
+        // Self assignment: e.version = e.version or parenthesized e.version = (e.version) does not advance version
+        for (String selfAssignQuery : List.of(
+                "update PrimitiveVersionEntity e set e.id = 1, e.version = e.version",
+                "update PrimitiveVersionEntity e set e.id = 1, e.version = (e.version)")) {
+            HibernateRepositoryModel selfAssignRepo = new HibernateRepositoryModel(
+                    "com.example.Repo",
+                    PrimitiveVersionEntity.class,
+                    List.of(repositoryMethod(
+                            "selfAssign", int.class, selfAssignQuery, false, false, true, false, false)));
+
+            HibernateRuleResultDto selfAssignResult = new BulkUpdateVersionRule()
+                    .evaluate(context(new TestEnvironment(), List.of(selfAssignRepo), PrimitiveVersionEntity.class));
+
+            assertThat(selfAssignResult.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+        }
+
+        // Predicate in WHERE clause only: where e.version = :v does not advance version
+        HibernateRepositoryModel whereOnlyRepo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PrimitiveVersionEntity.class,
+                List.of(repositoryMethod(
+                        "whereOnly",
+                        int.class,
+                        "update PrimitiveVersionEntity e set e.id = 1 where e.version = :expectedVersion",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto whereResult = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(whereOnlyRepo), PrimitiveVersionEntity.class));
+
+        assertThat(whereResult.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void bulkUpdateVersionRuleDetectsInheritedAndPropertyAccessVersions() {
+        // Inherited @Version from @MappedSuperclass
+        HibernateRepositoryModel inheritedRepo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                InheritedVersionEntity.class,
+                List.of(repositoryMethod(
+                        "updateInherited",
+                        int.class,
+                        "update InheritedVersionEntity e set e.name = 'new'",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto inheritedResult = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(inheritedRepo), InheritedVersionEntity.class));
+
+        assertThat(inheritedResult.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+
+        // Property access @Version - flagged when not advancing version
+        HibernateRepositoryModel propertyRepo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PropertyVersionEntity.class,
+                List.of(repositoryMethod(
+                        "updateProperty",
+                        int.class,
+                        "update PropertyVersionEntity e set e.id = 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto propertyResult = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(propertyRepo), PropertyVersionEntity.class));
+
+        assertThat(propertyResult.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+
+        // Property access @Version - passes when advancing version
+        HibernateRepositoryModel propertyWithIncRepo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PropertyVersionEntity.class,
+                List.of(repositoryMethod(
+                        "updatePropertySafe",
+                        int.class,
+                        "update PropertyVersionEntity e set e.id = 1, e.version = e.version + 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto propertyWithIncResult = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(propertyWithIncRepo), PropertyVersionEntity.class));
+
+        assertThat(propertyWithIncResult.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bulkUpdateVersionRuleIgnoresNonModifyingOrNativeOrDeleteQueries() {
+        HibernateRepositoryModel repo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PrimitiveVersionEntity.class,
+                List.of(
+                        // Not modifying
+                        repositoryMethod(
+                                "nonModifying",
+                                int.class,
+                                "update PrimitiveVersionEntity e set e.id = 1",
+                                false,
+                                false,
+                                false,
+                                false,
+                                false),
+                        // Native query
+                        repositoryMethod(
+                                "nativeQuery",
+                                int.class,
+                                "UPDATE primitive_version SET id = 1",
+                                true,
+                                false,
+                                true,
+                                false,
+                                false),
+                        // Delete query
+                        repositoryMethod(
+                                "deleteQuery",
+                                int.class,
+                                "delete from PrimitiveVersionEntity e where e.id = 1",
+                                false,
+                                false,
+                                true,
+                                false,
+                                false)));
+
+        HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(repo), PrimitiveVersionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bulkUpdateVersionRuleHandlesQuotedStringsAndCommentsCorrectly() {
+        // String literal contains 'set version = version + 1' but SET clause does not advance version
+        HibernateRepositoryModel repoWithLiteral = new HibernateRepositoryModel(
+                "com.example.Repo",
+                PrimitiveVersionEntity.class,
+                List.of(repositoryMethod(
+                        "withLiteral",
+                        int.class,
+                        "update PrimitiveVersionEntity e set e.id = 1 /* update versioned */ -- set version = version + 1\n",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(repoWithLiteral), PrimitiveVersionEntity.class));
+
+        assertThat(result.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+    }
+
+    @Test
+    void bulkUpdateVersionRuleEntityNamedVersionedIsNotConfusedWithUpdateVersioned() {
+        // Entity is named "Versioned" - without "update versioned", this is an unversioned update
+        HibernateRepositoryModel unversionedRepo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                VersionedNamedEntity.class,
+                List.of(repositoryMethod(
+                        "updateUnversioned",
+                        int.class,
+                        "update Versioned e set e.id = 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto unversionedResult = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(unversionedRepo), VersionedNamedEntity.class));
+
+        assertThat(unversionedResult.status()).isEqualTo(HibernateRuleSupport.VIOLATION);
+
+        // With "update versioned", it is recognized as versioned
+        HibernateRepositoryModel versionedRepo = new HibernateRepositoryModel(
+                "com.example.Repo",
+                VersionedNamedEntity.class,
+                List.of(repositoryMethod(
+                        "updateVersioned",
+                        int.class,
+                        "update versioned Versioned e set e.id = 1",
+                        false,
+                        false,
+                        true,
+                        false,
+                        false)));
+
+        HibernateRuleResultDto versionedResult = new BulkUpdateVersionRule()
+                .evaluate(context(new TestEnvironment(), List.of(versionedRepo), VersionedNamedEntity.class));
+
+        assertThat(versionedResult.status()).isEqualTo(HibernateRuleSupport.PASS);
+    }
+
+    @Test
+    void bulkUpdateVersionRuleHandlesComplexExpressionsAndLongLiterals() {
+        for (String query : List.of(
+                "update PrimitiveVersionEntity e set e.id = coalesce(e.id, 0), e.version = e.version + 1L",
+                "update PrimitiveVersionEntity e set e.id = coalesce(e.id, 0), e.version = 1L + e.version",
+                "update PrimitiveVersionEntity e set e.id = coalesce(e.id, 0), e.version = (e.version) + (1)",
+                "update PrimitiveVersionEntity e set e.id = coalesce(e.id, 0), e.version = (e.version) + (1L)")) {
+            HibernateRepositoryModel repo = new HibernateRepositoryModel(
+                    "com.example.Repo",
+                    PrimitiveVersionEntity.class,
+                    List.of(repositoryMethod(
+                            "updateWithComplexExpr", int.class, query, false, false, true, false, false)));
+
+            HibernateRuleResultDto result = new BulkUpdateVersionRule()
+                    .evaluate(context(new TestEnvironment(), List.of(repo), PrimitiveVersionEntity.class));
+
+            assertThat(result.status())
+                    .as("Expected query to pass version maintenance check: %s", query)
+                    .isEqualTo(HibernateRuleSupport.PASS);
+        }
+    }
+
+    @Test
+    void bulkUpdateVersionRuleSkipsWhenMissingEvidenceOrSubquery() {
+        // Query with subquery in observed context causes missing evidence -> SKIPPED
+        HibernateRepositoryMethodModel subqueryMethod = new HibernateRepositoryMethodModel(
+                "com.example.Repo",
+                "updateWithSubquery",
+                Object.class,
+                int.class,
+                "update PrimitiveVersionEntity e set e.id = 1 where e.id in (select x.id from Other x)",
+                false,
+                null,
+                false,
+                true,
+                false,
+                false,
+                List.of(),
+                new HibernateQueryEvidence(true, true, true, false, false, null, false, null, null, List.of()));
+
+        HibernateRepositoryModel subqueryRepo =
+                new HibernateRepositoryModel("com.example.Repo", PrimitiveVersionEntity.class, List.of(subqueryMethod));
+
+        HibernateContext observed = new HibernateContext(
+                List.of(HibernateEntityModel.fromClass(PrimitiveVersionEntity.class)),
+                List.of(subqueryRepo),
+                key -> null,
+                List.of(),
+                HibernateRuntimeVersion.parse("7.3.9.Final"),
+                HibernateFactorySettings.unknown(),
+                null,
+                null,
+                new HibernateEvaluationEvidence());
+
+        HibernateRuleResultDto subqueryResult = new BulkUpdateVersionRule().evaluate(observed);
+        assertThat(subqueryResult.status()).isEqualTo(HibernateRuleSupport.SKIPPED);
+    }
+
     // --- HIB-CONFIG-002 -----------------------------------------------------
 
     @Test
@@ -1686,6 +2035,15 @@ class HibernateRulesTests {
         int version;
     }
 
+    @Entity(name = "Versioned")
+    static class VersionedNamedEntity {
+        @Id
+        Long id;
+
+        @Version
+        int version;
+    }
+
     @Entity
     static class AssignedIdEntity {
         @Id
@@ -1924,5 +2282,43 @@ class HibernateRulesTests {
         @OneToMany
         @Fetch(FetchMode.SUBSELECT)
         List<SequenceEntity> children;
+    }
+
+    @jakarta.persistence.MappedSuperclass
+    abstract static class SuperclassVersionBase {
+        @Version
+        Long version;
+    }
+
+    @Entity
+    static class InheritedVersionEntity extends SuperclassVersionBase {
+        @Id
+        Long id;
+
+        String name;
+    }
+
+    @Entity
+    static class PropertyVersionEntity {
+        private Long id;
+        private Long version;
+
+        @Id
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        @Version
+        public Long getVersion() {
+            return version;
+        }
+
+        public void setVersion(Long version) {
+            this.version = version;
+        }
     }
 }

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateScannerTests.java
@@ -57,7 +57,7 @@ import org.springframework.data.domain.Page;
 
 class HibernateScannerTests {
 
-    private static final int RULE_COUNT = 70;
+    private static final int RULE_COUNT = 71;
     private static final String AFFECTED_HIBERNATE_VERSION = "7.3.9.Final";
     private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-06-04T10:00:00Z"), ZoneOffset.UTC);
 

--- a/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHibernateAdvisorTest.java
+++ b/bootui-quarkus-integration-tests/hibernate/src/test/java/io/github/jdubois/bootui/quarkus/it/BootUiQuarkusHibernateAdvisorTest.java
@@ -99,7 +99,7 @@ class BootUiQuarkusHibernateAdvisorTest {
                 .isGreaterThanOrEqualTo(3);
         assertThat(scanned.path("rulesEvaluated").asInt())
                 .as("the shared curated rule registry must have run")
-                .isEqualTo(70);
+                .isEqualTo(71);
 
         List<String> violationIds = ruleIds(scanned.path("results"));
         assertThat(violationIds)

--- a/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-quarkus-sample-app/e2e/tests/hibernate.spec.js
@@ -21,7 +21,7 @@ test.describe('Hibernate advisor (Quarkus)', () => {
     const response = await scanResponse
     expect(response.ok()).toBeTruthy()
     const report = await response.json()
-    expect(report.rulesEvaluated).toBe(70)
+    expect(report.rulesEvaluated).toBe(71)
     expect(report.scan.status).toBe('PARTIAL')
     expect(report.scan.message).toBeTruthy()
     expect(report.entitiesAnalyzed).toBeGreaterThan(0)

--- a/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
+++ b/bootui-spring-sample-app/e2e/scenarios/advisor-scoring.js
@@ -78,7 +78,7 @@ function hibernateReport() {
     ...architectureReport('PARTIAL'),
     entityPackages: ['example.app'],
     entitiesAnalyzed: 12,
-    rulesEvaluated: 70,
+    rulesEvaluated: 71,
     results: [
       {
         ...architectureReport('PARTIAL').results[0],

--- a/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
+++ b/bootui-spring-sample-app/e2e/tests/hibernate.spec.js
@@ -15,7 +15,7 @@ test.describe('Hibernate Advisor view', () => {
     const response = await scanResponse
     expect(response.ok()).toBeTruthy()
     const report = await response.json()
-    expect(report.rulesEvaluated).toBe(70)
+    expect(report.rulesEvaluated).toBe(71)
     expect(report.scan.status).toBe('PARTIAL')
     expect(report.scan.message).toBeTruthy()
     expect(report.entitiesAnalyzed).toBeGreaterThan(0)

--- a/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/HibernateScanWiringTest.java
+++ b/bootui-spring-sample-app/src/test/java/io/github/jdubois/bootui/sample/HibernateScanWiringTest.java
@@ -47,7 +47,7 @@ class HibernateScanWiringTest {
 
         assertThat(report.scan().status()).isEqualTo("PARTIAL");
         assertThat(report.entitiesAnalyzed()).isPositive();
-        assertThat(report.rulesEvaluated()).isEqualTo(70);
+        assertThat(report.rulesEvaluated()).isEqualTo(71);
         assertThat(report.results()).allSatisfy(result -> {
             assertThat(result.status()).isEqualTo("VIOLATION");
             assertThat(result.sampleViolations()).allMatch(sample -> sample.startsWith("["));

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -15,7 +15,7 @@ the metamodel cannot be read, BootUI returns a stable empty report with an expla
 The scan is bounded to mapped entities reported by the application's own JPA metamodel. This also covers entities added
 through `@EntityScan` or custom persistence-unit configuration without scanning the entire classpath.
 
-The active catalog contains **70 rules**. Five retired identifiers remain documented below so old links and persisted
+The active catalog contains **71 rules**. Five retired identifiers remain documented below so old links and persisted
 dismissals retain their meaning; retired identifiers are never reused.
 
 ### Evidence and incomplete scans
@@ -703,6 +703,21 @@ Named and dynamic queries outside the observed metadata remain outside coverage.
 - **Recommendation**: fetch at most one collection per query. Initialize the remaining collections with separate queries,
   or suitably bounded batch fetching. An entity graph requesting the same parallel collections is not a universal fix,
   and Set does not eliminate row multiplication.
+
+### HIB-QUERY-008 - Bulk updates leave @Version unchanged
+
+- **Severity**: MEDIUM
+- **Inspects**: Spring Data repository `@Modifying` queries targeting entities with a `@Version` attribute.
+- **Fires when**: a JPQL/HQL bulk `UPDATE` query targets an entity that declares an optimistic-locking `@Version`
+  attribute (including via inheritance or property access) and neither uses `UPDATE VERSIONED` nor explicitly maintains
+  the version attribute in its `SET` clause.
+- **Why it matters**: bulk updates bypass entity state tracking and direct SQL updates leave `@Version` unchanged by
+  default. Concurrent transactions holding previously loaded instances will not encounter optimistic locking failures
+  on subsequent flushes, leading to lost updates. `clearAutomatically=true` only clears the calling persistence context
+  and does not advance the database version.
+- **Recommendation**: review whether concurrent transactions require version invalidation. Where appropriate, use
+  managed-entity updates, Hibernate's `update versioned` syntax, or explicit numeric version incrementation
+  (e.g., `set e.version = e.version + 1`).
 
 ## Configuration
 

--- a/docs/QUARKUS-SUPPORT.md
+++ b/docs/QUARKUS-SUPPORT.md
@@ -184,7 +184,7 @@ Logic lives entirely in `bootui-core` + `bootui-engine`; the Quarkus adapter add
 | ----------------------------------------------------- | --------------------------------------------------------------------------------- |
 | `Memory`, `Live Memory`, `JVM Tuning`, `Heap Dump`, `Threads` | Pure JVM MXBeans                                                           |
 | `Metrics`                                             | Micrometer — same API                                                             |
-| `Hibernate` advisor                                   | Same 70-rule registry/report contract; unit-specific native observations and explicit incomplete scans; Spring Data query rules are inapplicable without verified JPA repository metadata |
+| `Hibernate` advisor                                   | Same 71-rule registry/report contract; unit-specific native observations and explicit incomplete scans; Spring Data query rules are inapplicable without verified JPA repository metadata |
 | `Hibernate Statistics`                                | Standalone Database-section panel over `org.hibernate.stat.Statistics`, gated on the same Hibernate ORM capability as the advisor; its runtime-enable action has the same read-only and cross-site-write protection as Spring |
 | `Vulnerabilities`                                     | Classpath SBOM/Maven metadata + OSV                                               |
 | `HTTP Probe`                                          | Local HTTP probing                                                                |

--- a/docs/features/advisors.md
+++ b/docs/features/advisors.md
@@ -439,7 +439,7 @@ fetch pagination, unsafe cascades, cache misconfiguration, and risky `ddl-auto` 
 not a verdict: it never intercepts queries, invokes repositories, executes SQL, or modifies mappings. See
 [HIBERNATE-CHECKS.md](../HIBERNATE-CHECKS.md) for the full catalogue and remediation links.
 
-The catalog has 70 active rules; five declaration-only or structurally duplicated checks are retired without reusing
+The catalog has 71 active rules; five declaration-only or structurally duplicated checks are retired without reusing
 their identifiers. Unavailable required observations and rule failures yield `PARTIAL` while retaining valid findings.
 The scan message distinguishes attempted-rule coverage from successful evaluation; an empty findings list is not proof
 that every mapping or query was verified. XML overrides, auto-apply converters, custom generators and runtime query
@@ -447,7 +447,7 @@ plans are not fully reconstructed.
 
 ::: details On Quarkus
 
-The panel runs the same 70-rule registry and report contract when `quarkus-hibernate-orm` is present. Entities are
+The panel runs the same 71-rule registry and report contract when `quarkus-hibernate-orm` is present. Entities are
 discovered from the live JPA `EntityManagerFactory` metamodel (across all persistence units, de-duplicated by identity),
 and most mapping/identifier/fetch rules apply unchanged. Spring Data query rules skip when repository metadata is
 unavailable instead of reporting a clean result. Four platform differences are worth noting:


### PR DESCRIPTION
## What does this PR do?

Implements Hibernate advisor rule `HIB-QUERY-008` ("Bulk updates leave @Version unchanged"), detecting JPQL/HQL bulk UPDATE queries targeting versioned entities that neither use `UPDATE VERSIONED` nor explicitly maintain the version attribute.

## Why is this change needed?

JPQL/HQL bulk UPDATE queries bypass the entity lifecycle and do not automatically advance an entity's `@Version` property unless Hibernate's `UPDATE VERSIONED` syntax is used or the version column is explicitly incremented in the SET clause. This can cause lost updates and silent optimistic locking failures against cached or detached entities.

Fixes: #1016
Closes #1016

## How was it tested?

- [x] Added unit tests in `HibernateRulesTests` covering unversioned bulk updates, `UPDATE VERSIONED`, numeric increments, self-assignments, WHERE-clause-only version checks, property-access getters, complex expressions with functions, long literal suffixes (`1L`), subqueries, and entity naming edge cases
- [x] Verified `bootui-engine` test suite passes (`./mvnw test -pl bootui-engine`)
- [x] Spotless code formatting checked across the reactor (`./mvnw spotless:check`)
- [x] Updated rule count assertions from 70 to 71 across test suites, sample apps, and documentation

## Screenshots (UI changes)

N/A

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed