### PR TITLE
Fix HIB-QUERY-008 timestamp and parameter version false positives

### DIFF
--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateQueryShape.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateQueryShape.java
@@ -128,6 +128,8 @@ final class HibernateQueryShape {
     private static final Pattern UPDATE_HEAD = Pattern.compile("(?is)^\\s*update\\s+(.+?)\\s+set\\b");
     private static final Pattern UPDATE_VERSIONED = Pattern.compile("(?is)^\\s*update\\s+versioned\\b");
     private static final Pattern UPDATE_SET_CLAUSE = Pattern.compile("(?is)\\bset\\s+(.*?)(?:\\bwhere\\b|$)");
+    private static final Pattern QUERY_PARAMETER = Pattern.compile("(?::[A-Za-z_]\\w*|\\?[1-9]\\d*)");
+    private static final Pattern CURRENT_TIMESTAMP = Pattern.compile("(?i)current_timestamp(?:\\s*\\(\\s*\\))?");
 
     static boolean isUpdate(String query) {
         String text = lexical(query);
@@ -277,6 +279,10 @@ final class HibernateQueryShape {
                 if (rhsSelf.matcher(rhs).matches()) {
                     continue;
                 }
+                if (CURRENT_TIMESTAMP.matcher(rhs).matches()
+                        || QUERY_PARAMETER.matcher(rhs).matches()) {
+                    return true;
+                }
                 List<String> parts = splitTopLevel(rhs, '+');
                 if (parts.size() == 2) {
                     String op1 = unwrapBalancedParens(parts.get(0).trim());
@@ -287,8 +293,12 @@ final class HibernateQueryShape {
                     boolean op2Target = Pattern.compile("(?is)^" + targetPatternStr + "$")
                             .matcher(op2)
                             .matches();
-                    if ((op1Target && literalNumber.matcher(op2).matches())
-                            || (op2Target && literalNumber.matcher(op1).matches())) {
+                    if ((op1Target
+                                    && (literalNumber.matcher(op2).matches()
+                                            || QUERY_PARAMETER.matcher(op2).matches()))
+                            || (op2Target
+                                    && (literalNumber.matcher(op1).matches()
+                                            || QUERY_PARAMETER.matcher(op1).matches()))) {
                         return true;
                     }
                 }

--- a/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
+++ b/bootui-engine/src/main/java/io/github/jdubois/bootui/engine/hibernate/HibernateRules.java
@@ -2321,10 +2321,13 @@ final class BulkUpdateVersionRule extends AbstractHibernateRule {
                         HibernateCategory.QUERY,
                         "MEDIUM",
                         "Detects JPQL/HQL bulk UPDATE queries targeting versioned entities that neither use UPDATE VERSIONED"
-                                + " nor explicitly maintain the version attribute, leaving the database version unchanged.",
+                                + " nor use a recognized explicit version assignment. Bulk updates leave the database version"
+                                + " unchanged by default.",
                         "Review whether this operation should invalidate previously loaded entity versions. Where appropriate,"
-                                + " use ordinary managed-entity updates, Hibernate's update versioned syntax, or explicit numeric"
-                                + " version incrementation.",
+                                + " use ordinary managed-entity updates, Hibernate's update versioned syntax, or explicitly maintain"
+                                + " the version with a numeric increment, a type-compatible CURRENT_TIMESTAMP assignment, or a"
+                                + " fresh version parameter. Parameter values, type compatibility, and actual version changes"
+                                + " are not verified.",
                         "https://docs.jboss.org/hibernate/orm/current/userguide/html_single/Hibernate_User_Guide.html#batch-bulk-hql-update-delete"));
     }
 

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateQueryShapeTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateQueryShapeTests.java
@@ -1,0 +1,128 @@
+package io.github.jdubois.bootui.engine.hibernate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HibernateQueryShapeTests {
+
+    @Test
+    void recognizesTimestampAssignments() {
+        for (String expression : List.of(
+                "CURRENT_TIMESTAMP",
+                "current_timestamp()",
+                "CuRrEnT_TiMeStAmP ( )",
+                "((current_timestamp()))",
+                "current_timestamp /* database time */ ()")) {
+            assertThat(maintainsVersion("update Order o set o.lastModified = " + expression, "o", "lastModified"))
+                    .as("timestamp assignment: %s", expression)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void recognizesDirectParameterAssignments() {
+        for (String expression : List.of(":now", ":nextVersion", ":next_version2", "?1", "?12", "((:now))", "(?2)")) {
+            assertThat(maintainsVersion("update Order o set o.lastModified = " + expression, "o", "lastModified"))
+                    .as("parameter assignment: %s", expression)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void recognizesParameterizedIncrements() {
+        for (String expression : List.of(
+                "o.version + :delta",
+                ":delta + o.version",
+                "o.version + ?1",
+                "?2 + o.version",
+                "((o.version) + (:delta))",
+                "((?1) + (version))")) {
+            assertThat(maintainsVersion("update Order o set o.version = " + expression, "o", "version"))
+                    .as("parameterized increment: %s", expression)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void preservesLiteralIncrements() {
+        for (String expression : List.of("o.version + 1", "1L + o.version", "((version) + (2l))")) {
+            assertThat(maintainsVersion("update Order o set o.version = " + expression, "o", "version"))
+                    .as("literal increment: %s", expression)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    void matchesTheVersionAssignmentInTheSetClause() {
+        for (String query : List.of(
+                "update Order o set lastModified = :now where o.id = :id",
+                "update Order o set o . lastModified = (:now) where o.id = :id",
+                "update Order o set o.status = coalesce(:status, o.status), o.lastModified = :now",
+                "update Order o set o.lastModified = :now, o.status = coalesce(:status, o.status)")) {
+            assertThat(maintainsVersion(query, "o", "lastModified")).as(query).isTrue();
+        }
+        assertThat(maintainsVersion("update Order set lastModified = current_timestamp", null, "lastModified"))
+                .isTrue();
+    }
+
+    @Test
+    void rejectsSelfAssignmentsAndUnsupportedExpressions() {
+        for (String expression : List.of(
+                "o.version",
+                "((o.version))",
+                "version",
+                "1",
+                "null",
+                "coalesce(o.version, :next)",
+                "some_function()",
+                "current_timestamp(1)",
+                "current_timestamp + 1",
+                "",
+                ":",
+                ":next trailing",
+                "?",
+                "?0",
+                "?1suffix",
+                "(current_timestamp()",
+                "current_timestamp())",
+                "o.version +",
+                "o.version + :",
+                "o.version + ?0",
+                "o.version + :delta + 1")) {
+            assertThat(maintainsVersion("update Order o set o.version = " + expression, "o", "version"))
+                    .as("unsupported assignment: %s", expression)
+                    .isFalse();
+        }
+    }
+
+    @Test
+    void ignoresOtherAttributesAliasesPredicatesAndQuotedText() {
+        for (String query : List.of(
+                "update Order o set o.status = :now",
+                "update Order o set o.lastModifiedCopy = :now",
+                "update Order o set other.lastModified = :now",
+                "update Order o set o.status = :status where o.lastModified = :now",
+                "update Order o set o.status = 'o.lastModified = CURRENT_TIMESTAMP'",
+                "update Order o set o.status = :status /* o.lastModified = :now */",
+                "update Order o set o.status = :status -- o.lastModified = :now\n",
+                "update Order o set o.lastModified = 'CURRENT_TIMESTAMP'",
+                "update Order o set o.lastModified = ':now'")) {
+            assertThat(maintainsVersion(query, "o", "lastModified")).as(query).isFalse();
+        }
+    }
+
+    @Test
+    void requiresQueryAndVersionAttribute() {
+        assertThat(maintainsVersion(null, "o", "version")).isFalse();
+        assertThat(maintainsVersion("update Order o set o.version = :next", "o", null))
+                .isFalse();
+        assertThat(maintainsVersion("update Order o set o.version = :next", "o", " "))
+                .isFalse();
+    }
+
+    private static boolean maintainsVersion(String query, String alias, String attribute) {
+        return HibernateQueryShape.maintainsVersion(HibernateQueryShape.lexical(query), alias, attribute);
+    }
+}

--- a/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
+++ b/bootui-engine/src/test/java/io/github/jdubois/bootui/engine/hibernate/HibernateRulesTests.java
@@ -36,6 +36,9 @@ import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Version;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -320,6 +323,100 @@ class HibernateRulesTests {
 
             assertThat(result.status()).isEqualTo(HibernateRuleSupport.PASS);
         }
+    }
+
+    @Test
+    void bulkUpdateVersionRulePassesForTimestampFunctions() {
+        for (String expression : List.of("CURRENT_TIMESTAMP", "current_timestamp()", "((current_timestamp ( )))")) {
+            HibernateRuleResultDto result = evaluateObservedBulkUpdate(
+                    TimestampVersionEntity.class,
+                    "update TimestampVersionEntity e set e.id = :id, e.lastModified = " + expression);
+
+            assertThat(result.status()).as(expression).isEqualTo(HibernateRuleSupport.PASS);
+            assertThat(result.violationCount()).isZero();
+        }
+    }
+
+    @Test
+    void bulkUpdateVersionRulePassesForTemporalParametersIncludingInheritedAndPropertyAccessVersions() {
+        for (Class<?> entityType : List.of(
+                TimestampVersionEntity.class,
+                InheritedInstantVersionEntity.class,
+                PropertyDateTimeVersionEntity.class)) {
+            for (String expression : List.of(":now", "?1", "((:now))")) {
+                HibernateRuleResultDto result = evaluateObservedBulkUpdate(
+                        entityType, "update " + entityType.getSimpleName() + " e set e.lastModified = " + expression);
+
+                assertThat(result.status())
+                        .as("%s: %s", entityType.getSimpleName(), expression)
+                        .isEqualTo(HibernateRuleSupport.PASS);
+                assertThat(result.violationCount()).isZero();
+            }
+        }
+    }
+
+    @Test
+    void bulkUpdateVersionRulePassesForNumericParameters() {
+        for (String expression : List.of(
+                ":nextVersion", "?1", "e.version + :delta", ":delta + e.version", "e.version + ?1", "?1 + e.version")) {
+            HibernateRuleResultDto result = evaluateObservedBulkUpdate(
+                    PrimitiveVersionEntity.class, "update PrimitiveVersionEntity e set e.version = " + expression);
+
+            assertThat(result.status()).as(expression).isEqualTo(HibernateRuleSupport.PASS);
+            assertThat(result.violationCount()).isZero();
+        }
+    }
+
+    @Test
+    void bulkUpdateVersionRuleStillFlagsUnmaintainedTemporalVersions() {
+        for (Class<?> entityType : List.of(
+                TimestampVersionEntity.class,
+                InheritedInstantVersionEntity.class,
+                PropertyDateTimeVersionEntity.class)) {
+            for (String clause : List.of(
+                    "e.id = :id",
+                    "e.lastModified = e.lastModified",
+                    "e.lastModified = ((lastModified))",
+                    "e.id = :id where e.lastModified = :now",
+                    "e.id = :id /* e.lastModified = current_timestamp */")) {
+                HibernateRuleResultDto result = evaluateObservedBulkUpdate(
+                        entityType, "update " + entityType.getSimpleName() + " e set " + clause);
+
+                assertThat(result.status())
+                        .as("%s: %s", entityType.getSimpleName(), clause)
+                        .isEqualTo(HibernateRuleSupport.VIOLATION);
+                assertThat(result.severity()).isEqualTo(HibernateRuleSupport.MEDIUM);
+                assertThat(result.violationCount()).isEqualTo(1);
+            }
+        }
+    }
+
+    private static HibernateRuleResultDto evaluateObservedBulkUpdate(Class<?> entityType, String query) {
+        HibernateRepositoryMethodModel method = new HibernateRepositoryMethodModel(
+                "com.example.Repo",
+                "updateVersion",
+                entityType,
+                int.class,
+                query,
+                false,
+                null,
+                false,
+                true,
+                false,
+                false,
+                List.of(),
+                new HibernateQueryEvidence(true, true, false, false, false, null, false, null, null, List.of()));
+        HibernateContext observed = new HibernateContext(
+                List.of(HibernateEntityModel.fromClass(entityType)),
+                List.of(new HibernateRepositoryModel("com.example.Repo", entityType, List.of(method), true)),
+                key -> null,
+                List.of(),
+                HibernateRuntimeVersion.parse("7.3.9.Final"),
+                HibernateFactorySettings.unknown(),
+                null,
+                null,
+                new HibernateEvaluationEvidence());
+        return new BulkUpdateVersionRule().evaluate(observed);
     }
 
     @Test
@@ -2319,6 +2416,51 @@ class HibernateRulesTests {
 
         public void setVersion(Long version) {
             this.version = version;
+        }
+    }
+
+    @Entity
+    static class TimestampVersionEntity {
+        @Id
+        Long id;
+
+        @Version
+        Timestamp lastModified;
+    }
+
+    @jakarta.persistence.MappedSuperclass
+    abstract static class InstantVersionBase {
+        @Version
+        Instant lastModified;
+    }
+
+    @Entity
+    static class InheritedInstantVersionEntity extends InstantVersionBase {
+        @Id
+        Long id;
+    }
+
+    @Entity
+    static class PropertyDateTimeVersionEntity {
+        private Long id;
+        private LocalDateTime lastModified;
+
+        @Id
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        @Version
+        public LocalDateTime getLastModified() {
+            return lastModified;
+        }
+
+        public void setLastModified(LocalDateTime lastModified) {
+            this.lastModified = lastModified;
         }
     }
 }

--- a/docs/HIBERNATE-CHECKS.md
+++ b/docs/HIBERNATE-CHECKS.md
@@ -709,15 +709,21 @@ Named and dynamic queries outside the observed metadata remain outside coverage.
 - **Severity**: MEDIUM
 - **Inspects**: Spring Data repository `@Modifying` queries targeting entities with a `@Version` attribute.
 - **Fires when**: a JPQL/HQL bulk `UPDATE` query targets an entity that declares an optimistic-locking `@Version`
-  attribute (including via inheritance or property access) and neither uses `UPDATE VERSIONED` nor explicitly maintains
-  the version attribute in its `SET` clause.
+  attribute (including via inheritance or property access) and neither uses `UPDATE VERSIONED` nor a recognized explicit
+  version assignment in its `SET` clause. Recognized forms are numeric increments such as `e.version = e.version + 1`,
+  parameterized increments such as `e.version = e.version + :delta` (both also accept reversed operands), direct named
+  or numbered positional parameters such as `e.version = :nextVersion` or `e.lastModified = ?1`, and timestamp assignments
+  such as `e.lastModified = CURRENT_TIMESTAMP` or `e.lastModified = current_timestamp()`. A version predicate only in
+  `WHERE`, self-assignment, constant resets, and arbitrary expressions do not establish recognized maintenance.
 - **Why it matters**: bulk updates bypass entity state tracking and direct SQL updates leave `@Version` unchanged by
   default. Concurrent transactions holding previously loaded instances will not encounter optimistic locking failures
   on subsequent flushes, leading to lost updates. `clearAutomatically=true` only clears the calling persistence context
   and does not advance the database version.
 - **Recommendation**: review whether concurrent transactions require version invalidation. Where appropriate, use
-  managed-entity updates, Hibernate's `update versioned` syntax, or explicit numeric version incrementation
-  (e.g., `set e.version = e.version + 1`).
+  managed-entity updates, Hibernate's `update versioned` syntax, or explicitly maintain the version with a numeric
+  increment, a type-compatible current timestamp, or a fresh version parameter (e.g., `set e.lastModified = :now`).
+  Recognition is a query-shape heuristic, not proof of runtime advancement: the check does not evaluate parameter
+  values, validate expression type compatibility, or guarantee that timestamp precision yields a different value.
 
 ## Configuration
 


### PR DESCRIPTION
## What does this PR do?

<!-- One-sentence summary of the change. -->

Recognizes `CURRENT_TIMESTAMP` assignments, direct named/positional version parameters, and parameterized increments in HIB-QUERY-008, with regression coverage and updated remediation guidance.

Recognition remains deliberately narrow: self-assignment, constant resets, and arbitrary expressions are not newly accepted. Existing query exclusions, rule identity, severity, and API contracts remain unchanged. The guidance distinguishes explicit maintenance from guaranteed runtime version advancement.

## Why is this change needed?

<!-- Link to an issue, describe the problem, or both. -->

The rule previously recognized only literal numeric increments, so bulk updates maintaining timestamp versions or supplying new versions through parameters were incorrectly reported as leaving `@Version` unchanged.

Fixes: #1022

## How was it tested?

- [x] `./mvnw clean install` passes locally
- [x] Ran the affected Spring MVC, Spring WebFlux, and/or Quarkus conformance tests
- [ ] Started the affected sample app(s) and verified `/bootui` loads on port 8080, 8081, and/or 8082 - N/A: no manual browser smoke test for this engine-only fix
- [ ] Ran the affected Playwright suite(s) for browser-facing changes - N/A: no UI, endpoint, or response-shape changes
- [x] Added or updated tests where applicable

The new regressions reproduced seven failures before the fix. All 175 focused Hibernate tests pass afterward, including timestamp, inherited/property-access, parameter, negative-case, scanner, and evidence coverage. Spotless apply/check and whitespace checks pass.

The full build used `./mvnw -B -ntp -Dmaven.repo.local=.m2 clean install` on JDK 26. MVC and WebFlux conformance each passed 31 tests; base Quarkus conformance passed 27 with 4 skips. Existing JDK gates exclude the Quarkus Hibernate integration module and sample ORM augmentation on JDK 26.

`npm run docs:build` completed but logged pre-existing `RuleIndex` null-severity rendering errors. The Hibernate rule catalog, including the affected null-severity entries, is identical to HEAD; this PR does not change the renderer or catalog metadata.

## Screenshots (UI changes)

<!-- Drop before/after screenshots here if you touched the Vue UI. -->

N/A: no Vue UI changes.

## Checklist

- [x] Documentation in `docs/` or `README.md` updated when behaviour changes
- [x] Public API kept backward compatible, or a migration note added to the PR description
- [x] No secrets, tokens, or local paths committed